### PR TITLE
Bluetooth: Add nrfxlib ble_controller Kconfig choice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 
-add_subdirectory_ifdef(CONFIG_NRFXLIB_NFC nfc)
-add_subdirectory_ifdef(CONFIG_NRFXLIB_BLE_CONTROLLER ble_controller)
+add_subdirectory_ifdef(CONFIG_NRFXLIB_NFC   nfc)
+add_subdirectory_ifdef(CONFIG_BT_LL_NRFXLIB ble_controller)

--- a/ble_controller/Kconfig
+++ b/ble_controller/Kconfig
@@ -4,11 +4,22 @@
 # SPDX-License-Identifier: BSD-5-Clause-Nordic
 #
 
-config NRFXLIB_BLE_CONTROLLER
-	bool
-	prompt "Enable BLE Controller"
+# BT_LL_CHOICE is declared in Zephyr and also here for a second time,
+# now with additional properties. Note that the dependencies of the
+# original config must be duplicated to not affect it's visibility.
+choice BT_LL_CHOICE
+	   bool
+	   depends on (BT_CTLR && BT_HCI && BT)
 
-if NRFXLIB_BLE_CONTROLLER
+config BT_LL_NRFXLIB
+	bool "Nordic proprietary BLE Link Layer"
+	select ZERO_LATENCY_IRQS
+	help
+	  Use Nordic BLE Link Layer implementation.
+
+endchoice
+
+if BT_LL_NRFXLIB
 
 comment "Common BLE Controller module configuration"
 
@@ -34,4 +45,4 @@ config BLE_CONTROLLER_S140
 
 endchoice
 
-endif # NRFXLIB_BLE_CONTROLLER
+endif # BT_LL_NRFXLIB


### PR DESCRIPTION
Add Nordic ble_controller library as a choice for the link layer. The
choice depends on the nrfxlib repository being present.

Also, rename the config option NRFXLIB_BLE_CONTROLLER as
BT_LL_NRFXLIB, to have it's name be consistent with the other LL
choices.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>