### PR TITLE
bsdlib: Use LicenseRef in license headers

### DIFF
--- a/bsdlib/include/bsd.h
+++ b/bsdlib/include/bsd.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 /**@file bsd.h

--- a/bsdlib/include/bsd_limits.h
+++ b/bsdlib/include/bsd_limits.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 /**@file bsd_limits.h

--- a/bsdlib/include/bsd_platform.h
+++ b/bsdlib/include/bsd_platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 /**@file ipc/bsd_platform.h

--- a/bsdlib/include/nrf_errno.h
+++ b/bsdlib/include/nrf_errno.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 #ifndef NRF_ERRNO_H__

--- a/bsdlib/include/nrf_inbuilt_key.h
+++ b/bsdlib/include/nrf_inbuilt_key.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 /**@file nrf_inbuilt_key.h

--- a/bsdlib/include/nrf_key_mgmt.h
+++ b/bsdlib/include/nrf_key_mgmt.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 /**@file nrf_key_mgmt.h

--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 /**@file nrf_socket.h


### PR DESCRIPTION
Add LicenseRef tag required to reference a local license.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>