### PR TITLE
cmake: LD: Ensure that libc symbols are available to the bsd library

### DIFF
--- a/bsdlib/CMakeLists.txt
+++ b/bsdlib/CMakeLists.txt
@@ -16,6 +16,14 @@ endif()
 
 set(BSD_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib/${GCC_M_CPU}/${float_dir})
 
-zephyr_link_libraries(${BSD_LIB_PATH}/libbsd_nrf9160_xxaa.a)
-zephyr_link_libraries(${BSD_LIB_PATH}/liboberon_2.0.5.a)
+# Link in the bsd library, the oberon library, and lib C. Lib C and
+# lib oberon are linked in because they are used by the bsd library
+# and must therefore be placed after the bsd library on the linker's
+# command line.
+zephyr_link_libraries(
+  ${BSD_LIB_PATH}/libbsd_nrf9160_xxaa.a
+  ${BSD_LIB_PATH}/liboberon_2.0.5.a
+  c
+  )
+
 zephyr_include_directories(include)


### PR DESCRIPTION
Ensure that libc symbols are available to the bsd library by
adding lib c to the linker command after the bsd library.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>