### PR TITLE
doc: nrfxlib: integrate nrfxlib documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,16 @@
+.. _nrfxlib:
 
 nrfxlib
 #######
 
-Overview
-********
-
 nrfxlib is a repository that contains RTOS-independent libraries to be
-used with Nordic SoCs.
+used with Nordic Semiconductor SoCs.
 
 Supported SoCs
 **************
 
 Each library in this repository supports a different set of SoCs from Nordic
-Semiconductor. Please refer to each individual library for more information.
+Semiconductor. Refer to each individual library for more information.
 
 Disclaimer
 **********
@@ -20,3 +18,10 @@ Disclaimer
 This repository is not intended or supported by Nordic Semiconductor for
 product development.
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Libraries:
+
+   ble_controller/README
+   bsdlib/README
+   nfc/README

--- a/ble_controller/CHANGELOG.rst
+++ b/ble_controller/CHANGELOG.rst
@@ -1,15 +1,20 @@
+.. _ble_controller_changelog:
+
 Changelog
 #########
+
 All notable changes to this project are documented in this file.
 
 ble_controller 0.1.0-2.prealpha
 *******************************
 
-No change to library files
+No change to library files.
 
 Added
 =====
-+ Headers necessary to utilize the timeslot api.
+
+* Headers necessary to utilize the timeslot API.
+
 
 ble_controller 0.1.0-1.prealpha
 *******************************
@@ -18,9 +23,10 @@ Initial release.
 
 Added
 =====
-+ Added the following ble_controller_nrf52_0.1.0-1.prealpha library variants,
-  each in soft-float, softfp-float, and hard-float builds.
 
-	+ libble_controller_s112_nrf52_0.1.0-1.prealpha.a
-	+ libble_controller_s132_nrf52_0.1.0-1.prealpha.a
-	+ libble_controller_s140_nrf52_0.1.0-1.prealpha.a
+* Added the following ble_controller_nrf52_0.1.0-1.prealpha library variants,
+  each in soft-float, softfp-float, and hard-float builds:
+
+  * ``libble_controller_s112_nrf52_0.1.0-1.prealpha.a``
+  * ``libble_controller_s132_nrf52_0.1.0-1.prealpha.a``
+  * ``libble_controller_s140_nrf52_0.1.0-1.prealpha.a``

--- a/ble_controller/README.rst
+++ b/ble_controller/README.rst
@@ -1,38 +1,39 @@
-ble_controller
-###############################
+.. _ble_controller:
 
-ble_controller is an RTOS-agnostic Bluetooth Low Energy controller
-binary library, built for Nordic Semiconductor nRF52 Series SoCs.
+Bluetooth LE Controller
+#######################
+
+The ble_controller library is an RTOS-agnostic Bluetooth Low Energy controller binary library, built for Nordic Semiconductor nRF52 Series SoCs.
 
 The following library variants are available:
 
-- libble_controller_s112_nrf52
-	- Intended for nRF52810 and nRF52832.
-	- Supports peripheral role only.
-- libble_controller_s132_nrf52
-	- Intended for nRF52810 and nRF52832.
-	- Supports both peripheral and central roles.
-	- Supports a maximum of one peripheral and two central links.
-- libble_controller_s140_nrf52
-	- Intended for nRF52840.
-	- Supports both peripheral and central roles.
-	- Supports a maximum of one peripheral and two central links.
-	- Supports Coded PHY.
+libble_controller_s112_nrf52
+  * Intended for nRF52810 and nRF52832.
+  * Supports peripheral role only.
+
+libble_controller_s132_nrf52
+  * Intended for nRF52810 and nRF52832.
+  * Supports both peripheral and central roles.
+  * Supports a maximum of one peripheral and two central links.
+
+libble_controller_s140_nrf52
+  * Intended for nRF52840.
+  * Supports both peripheral and central roles.
+  * Supports a maximum of one peripheral and two central links.
+  * Supports Coded PHY.
 
 Each library is distributed in soft-float, softfp-float, and hard-float builds.
 
-Integration notes
-*****************
-The controller library must be the only user of each the following peripherals:
-	- RTC0
-	- TIMER0
-	- RADIO
-	- POWER/CLOCK
-	- SWI5
-	- RNG
+.. important::
+  * The libraries are for evaluation purposes only.
+  * The libraries are not fully functional.
+  * The libraries are not built for performance.
 
-Disclaimer
-**********
-- The libraries are for evaluation purposes only.
-- The libraries are not fully functional.
-- The libraries are not built for performance.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   doc/integration_notes
+   CHANGELOG
+   doc/api

--- a/ble_controller/doc/api.rst
+++ b/ble_controller/doc/api.rst
@@ -1,0 +1,54 @@
+.. ble_controller_api:
+
+API documentation
+#################
+
+
+BLE Controller
+**************
+
+.. doxygengroup:: blectlr
+   :project: nrfxlib
+   :members:
+
+
+BLE Controller HCI
+******************
+
+.. doxygengroup:: blectlr_hci
+   :project: nrfxlib
+   :members:
+
+
+BLE Controller utilities
+************************
+
+.. doxygengroup:: blectlr_util
+   :project: nrfxlib
+   :members:
+
+nRF Errors
+**********
+
+.. doxygengroup:: NRF_ERRORS_BASE
+   :project: nrfxlib
+   :members:
+
+
+.. doxygengroup:: NRF_ERRORS
+   :project: nrfxlib
+   :members:
+
+nRF SoC
+*******
+
+.. doxygengroup:: NRF_SOC_DEFINES
+   :project: nrfxlib
+   :members:
+
+.. doxygengroup:: NRF_SOC_ENUMS
+   :project: nrfxlib
+   :members:
+
+.. doxygengroup:: NRF_SOC_STRUCTURES
+   :project: nrfxlib

--- a/ble_controller/doc/integration_notes.rst
+++ b/ble_controller/doc/integration_notes.rst
@@ -1,0 +1,13 @@
+.. _ble_controller_integration_notes:
+
+Integration notes
+#################
+
+The controller library must be the only user of each the following peripherals:
+
+* RTC0
+* TIMER0
+* RADIO
+* POWER/CLOCK
+* SWI5
+* RNG

--- a/ble_controller/include/blectlr.h
+++ b/ble_controller/include/blectlr.h
@@ -9,6 +9,11 @@
 
 #include <stdint.h>
 
+/** @defgroup blectlr
+ * @{
+ **/
+
+
 /** @brief Host signal handler function pointer type. */
 typedef void (*host_signal_t)(void);
 
@@ -83,5 +88,7 @@ void C_RNG_Handler(void);
  *             The interrupt priority level should be lower than priority 0.
  */
 void C_POWER_CLOCK_Handler(void);
+
+/** @} **/
 
 #endif

--- a/ble_controller/include/blectlr_hci.h
+++ b/ble_controller/include/blectlr_hci.h
@@ -10,6 +10,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/** @defgroup blectlr_hci
+ * @{
+ **/
 
 /** @brief The size of a command packet header. */
 #define HCI_CMD_HEADER_SIZE   (3)
@@ -83,6 +86,5 @@ bool hci_event_packet_get(hci_element_t * buffer);
 #endif // BLECTLR_HCI_H__
 
 /**
-  @}
   @}
 */

--- a/ble_controller/include/blectlr_util.h
+++ b/ble_controller/include/blectlr_util.h
@@ -10,6 +10,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/** @defgroup blectlr_util
+ * @{
+ **/
+
 void blectlr_set_default_evt_length(void);
 
 void cal_init(void);
@@ -22,5 +26,7 @@ void ll_util_block_encrypt(const uint8_t key[16],
                            const uint8_t plaintext[16],
                            bool is_result_le,
                            uint8_t ciphertext[16]);
+
+/** @} **/
 
 #endif

--- a/ble_controller/include/nrf_error.h
+++ b/ble_controller/include/nrf_error.h
@@ -12,6 +12,7 @@
 extern "C" {
 #endif
 
+
 /** @defgroup NRF_ERRORS_BASE Error Codes Base number definitions
  * @{ */
 #define NRF_ERROR_BASE_NUM      (0x0)       ///< Global error base
@@ -19,6 +20,9 @@ extern "C" {
 #define NRF_ERROR_SOC_BASE_NUM  (0x2000)    ///< SoC error base
 #define NRF_ERROR_STK_BASE_NUM  (0x3000)    ///< STK error base
 /** @} */
+
+/** @defgroup NRF_ERRORS
+ * @{ */
 
 #define NRF_SUCCESS                           (NRF_ERROR_BASE_NUM + 0)  ///< Successful command
 #define NRF_ERROR_SVC_HANDLER_MISSING         (NRF_ERROR_BASE_NUM + 1)  ///< SVC handler is missing

--- a/ble_controller/include/nrf_soc.h
+++ b/ble_controller/include/nrf_soc.h
@@ -282,5 +282,3 @@ uint32_t sd_radio_request(nrf_radio_request_t const * p_request);
 }
 #endif
 #endif // NRF_SOC_H__
-
-/**@} */

--- a/bsdlib/CHANGELOG.rst
+++ b/bsdlib/CHANGELOG.rst
@@ -1,14 +1,17 @@
+.. _bsdlib_changelog:
+
 Changelog
 #########
+
 All notable changes to this project are documented in this file.
 
 bsdlib 0.2.0
 ************
 
-Updated library and header files.
+Updated library and header files:
 
-- Enabled Nordic Semiconductor proprietary trace log. Increased consumption of the dedicated library RAM, indicated in bsd_platform.h.
-- Resolved include of stdint.h in bsd.h.
+* Enabled Nordic Semiconductor proprietary trace log. Increased consumption of the dedicated library RAM, indicated in bsd_platform.h.
+* Resolved include of ``stdint.h`` in ``bsd.h``.
 
 bsdlib 0.1.0
 ************
@@ -18,6 +21,7 @@ Initial release.
 Added
 =====
 
-- Added the following BSD Socket library variants for nrf9160, for soft-float and hard-float builds
-	- libbsd_nrf9160_xxaa.a
-	- liboberon_2.0.5.a (Dependency of libbsd)
+* Added the following BSD Socket library variants for nrf9160, for soft-float and hard-float builds:
+
+  * ``libbsd_nrf9160_xxaa.a``
+  * ``liboberon_2.0.5.a`` (dependency of libbsd)

--- a/bsdlib/README.rst
+++ b/bsdlib/README.rst
@@ -1,0 +1,11 @@
+.. _bsdlib:
+
+BSD Library
+###########
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   CHANGELOG
+   doc/api

--- a/bsdlib/doc/api.rst
+++ b/bsdlib/doc/api.rst
@@ -1,0 +1,74 @@
+.. bsdlib_api:
+
+API documentation
+#################
+
+
+BSD Library Management
+**********************
+
+.. doxygengroup:: bsd
+   :project: nrfxlib
+   :members:
+
+
+Limits of the BSD library
+*************************
+
+.. doxygengroup:: bsd_limits
+   :project: nrfxlib
+   :members:
+
+BSD Platform
+************
+
+.. doxygengroup:: bsd_platform_ipc
+   :project: nrfxlib
+   :members:
+
+.. doxygengroup:: bsd_version
+   :project: nrfxlib
+   :members:
+
+.. doxygengroup:: bsd_reserved_memory
+   :project: nrfxlib
+   :members:
+
+.. doxygengroup:: BSD_reserved_interrupts
+   :project: nrfxlib
+   :members:
+
+nRF91 Inbuilt Key Management
+****************************
+
+.. doxygengroup:: nrf_inbuilt_key
+   :project: nrfxlib
+   :members:
+
+nRF91 Key Management
+********************
+
+.. doxygengroup:: nrf_key_mgmt
+   :project: nrfxlib
+   :members:
+
+nRF BSD Socket interface
+************************
+
+.. doxygengroup:: nrf_socket
+   :project: nrfxlib
+   :members:
+
+Integer values for errno
+************************
+
+.. doxygengroup:: nrf_errno
+   :project: nrfxlib
+   :members:
+
+OS specific definitions
+***********************
+
+.. doxygengroup:: bsd_os
+   :project: nrfxlib
+   :members:

--- a/bsdlib/include/bsd_os.h
+++ b/bsdlib/include/bsd_os.h
@@ -7,6 +7,9 @@
 /**
  * @file bsd_os.h
  * @brief OS specific definitions.
+ *
+ * @defgroup bsd_os
+ * @{
  */
 #ifndef BSD_OS_H__
 #define BSD_OS_H__

--- a/bsdlib/include/bsd_platform.h
+++ b/bsdlib/include/bsd_platform.h
@@ -15,9 +15,9 @@
  * -# A common entry point for platform specific system initializations.
  * -# Initialization of modules, in right order and with platform specific tuning.
  * -# Any system level configurations. These configurations include:
- *         -1. Interrupts and their priorities.
- *         -2. Any reserved memory.
- *         -3. Any other reserved resources in the system for the purpose.
+ *         1. Interrupts and their priorities.
+ *         2. Any reserved memory.
+ *         3. Any other reserved resources in the system for the purpose.
  */
 #ifndef BSD_PLATFORM_H__
 #define BSD_PLATFORM_H__

--- a/bsdlib/include/nrf_errno.h
+++ b/bsdlib/include/nrf_errno.h
@@ -10,6 +10,9 @@
  * @file nrf_errno.h
  * @brief Defines integer values for errno.
  *        Used by system calls to indicates the latest error.
+ *
+ * @defgroup nrf_errno
+ * @{
  */
 #ifdef __cplusplus
 extern "C" {
@@ -52,5 +55,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+/** @} **/
 
 #endif // NRF_ERRNO_H__

--- a/nfc/CHANGELOG.rst
+++ b/nfc/CHANGELOG.rst
@@ -1,5 +1,8 @@
+.. _nfc_changelog:
+
 Changelog
 #########
+
 All notable changes to this project are documented in this file.
 
 NFC [Unreleased]
@@ -10,15 +13,20 @@ NFCT driver is a part of nrfx repository.
 
 Added
 =====
-+ Added the NFC platform module to abstract runtime environment specific
+
+* Added the NFC platform module to abstract runtime environment specific
   implementation:
-        + nfc_platform_zephyr.c
+
+  * ``nfc_platform_zephyr.c``
 
 Removed
 =======
-+ Removed the NFC HAL modules (replaced by the NFCT driver):
-        + hal_nfc_t2t.c
-        + hal_nfc_t4t.c
+
+* Removed the NFC HAL modules (replaced by the NFCT driver):
+
+  * ``hal_nfc_t2t.c``
+  * ``hal_nfc_t4t.c``
+
 
 NFC 0.1.0
 *********
@@ -27,6 +35,8 @@ Initial release.
 
 Added
 =====
-+ Added the following NFC libraries in both soft-float and hard-float builds.
-	+ libnfct2t_nrf52.a
-	+ libnfct4t_nrf52.a
+
+* Added the following NFC libraries in both soft-float and hard-float builds:
+
+  * ``libnfct2t_nrf52.a``
+  * ``libnfct4t_nrf52.a``

--- a/nfc/README.rst
+++ b/nfc/README.rst
@@ -1,53 +1,31 @@
-NFC
-###
+.. _nfc:
+
+Near-Field Communication (NFC)
+##############################
 
 The following NFC libraries are RTOS-agnostic NFC libraries built for
 Nordic Semiconductor nRF52 Series SoCs.
 
 The following libraries are available:
 
-- libnfct2t_nrf52
-	- Intended for nRF52832 and nRF52840.
-	- Supports NFC-A Type 2 Tag in read-only mode.
-- libnfct4t_nrf52
-	- Intended for nRF52832 and nRF52840.
-	- Supports NFC-A Type 4 Tag.
+libnfct2t_nrf52
+  * Intended for nRF52832 and nRF52840.
+  * Supports NFC-A Type 2 Tag in read-only mode.
+
+libnfct4t_nrf52
+  * Intended for nRF52832 and nRF52840.
+  * Supports NFC-A Type 4 Tag.
 
 Each library is distributed in both soft-float and hard-float builds.
 
-Integration notes
-*****************
-- The libraries require the NFCT driver, which is a part of the nrfx repository.
+.. important::
+   The libraries are for evaluation purposes only.
 
-- The libraries require the NFC Platform software module to operate in different
-  runtime environments. This module must implement the following functions:
-	- nfc_platform_setup(), called by the NFC libraries at initialization.
-          This function sets up clock interface and connects NFCT and TIMER4
-          IRQs with their respective IRQ handler functions from nrfx.
-	- nfc_platform_event_handler(), called by the NFC libraries to forward
-          NFC events received from the NFCT driver. It is necessary to track
-          this event flow in order to determine when HFCLK must be running and
-          when NFCT peripheral must be activated.
 
-- This module is responsible for activating the NFCT driver when the following
-  conditions are fulfilled:
-        - NFC field is present.
-        - HFCLK is running.
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
 
-- Exemplary implementation of the NFC Platform module for the Zephyr environment
-  is provided in the nfc_platform_zephyr.c file, which is located in the nfc/src
-  folder.
-
-- The NFC Platform module for the Zephyr environment starts the HFCLK crystal
-  oscillator during initialization, and does not stop it. You can define a more
-  sophisticated module for clock management, which activates the HFCLK only for
-  the period when NFC field is present.
-
-- Each library must be the only user of each of the following peripherals:
-
-	- NFCT
-	- TIMER4
-
-Disclaimer
-**********
-- The libraries are for evaluation purposes only.
+   doc/integration_notes
+   CHANGELOG
+   doc/api

--- a/nfc/doc/api.rst
+++ b/nfc/doc/api.rst
@@ -1,0 +1,20 @@
+.. nfc_api:
+
+API documentation
+#################
+
+
+NFC tag 2 type emulation library
+********************************
+
+.. doxygengroup:: nfc_t2t_lib
+   :project: nrfxlib
+   :members:
+
+
+NFC tag 4 type emulation library
+********************************
+
+.. doxygengroup:: nfc_t4t_lib
+   :project: nrfxlib
+   :members:

--- a/nfc/doc/integration_notes.rst
+++ b/nfc/doc/integration_notes.rst
@@ -1,0 +1,37 @@
+.. _nfc_integration_notes:
+
+Integration notes
+#################
+
+* The libraries require the NFCT driver, which is a part of the nrfx repository.
+
+* The libraries require the NFC Platform software module to operate in different
+  runtime environments. This module must implement the following functions:
+
+  * nfc_platform_setup(), called by the NFC libraries at initialization.
+    This function sets up clock interface and connects NFCT and TIMER4
+    IRQs with their respective IRQ handler functions from nrfx.
+  * nfc_platform_event_handler(), called by the NFC libraries to forward
+    NFC events received from the NFCT driver. It is necessary to track
+    this event flow in order to determine when HFCLK must be running and
+    when NFCT peripheral must be activated.
+
+* This module is responsible for activating the NFCT driver when the following
+  conditions are fulfilled:
+
+  * NFC field is present.
+  * HFCLK is running.
+
+* Exemplary implementation of the NFC Platform module for the Zephyr environment
+  is provided in the nfc_platform_zephyr.c file, which is located in the nfc/src
+  folder.
+
+* The NFC Platform module for the Zephyr environment starts the HFCLK crystal
+  oscillator during initialization, and does not stop it. You can define a more
+  sophisticated module for clock management, which activates the HFCLK only for
+  the period when NFC field is present.
+
+* Each library must be the only user of each of the following peripherals:
+
+  * NFCT
+  * TIMER4

--- a/nfc/include/nfc_t2t_lib.h
+++ b/nfc/include/nfc_t2t_lib.h
@@ -9,12 +9,6 @@
 
 /** @file
  *
- * @addtogroup nfc_api
- *
- * @defgroup nfc_t2t NFC Type 2 Tag
- * @ingroup nfc_api
- * @brief Implementation of NFC Type 2 Tag.
- *
  * @defgroup nfc_t2t_lib NFC tag 2 type emulation library
  * @{
  * @ingroup nfc_t2t


### PR DESCRIPTION
Basic integration of the nrfxlib documentation into the NCS doc
framework.

Output on \hizz\work\rufu\NCS_doc_with_nrfxlib\index.html

Requires fw-nrfconnect-nrf https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/268.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>