### PR TITLE
nrf_security: Replace problematic static assert

### DIFF
--- a/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
+++ b/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
@@ -8,13 +8,6 @@
 #include <entropy.h>
 #include <mbedtls/entropy.h>
 
-#if !defined(CONFIG_ENTROPY_GENERATOR)
-#error "CONFIG_ENTROPY_GENERATOR is not enabled."
-#endif
-#if !defined(CONFIG_ENTROPY_HAS_DRIVER)
-#error "CONFIG_ENTROPY_HAS_DRIVER is not set."
-#endif
-
 int mbedtls_hardware_poll(void *data,
                           unsigned char *output,
                           size_t len,

--- a/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
+++ b/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
@@ -8,8 +8,12 @@
 #include <entropy.h>
 #include <mbedtls/entropy.h>
 
-static_assert(defined(CONFIG_ENTROPY_GENERATOR), "CONFIG_ENTROPY_GENERATOR is not enabled.");
-static_assert(defined(CONFIG_ENTROPY_HAS_DRIVER), "CONFIG_ENTROPY_HAS_DRIVER is not set.");
+#if !defined(CONFIG_ENTROPY_GENERATOR)
+#error "CONFIG_ENTROPY_GENERATOR is not enabled."
+#endif
+#if !defined(CONFIG_ENTROPY_HAS_DRIVER)
+#error "CONFIG_ENTROPY_HAS_DRIVER is not set."
+#endif
 
 int mbedtls_hardware_poll(void *data,
                           unsigned char *output,

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -131,11 +131,12 @@ zephyr_library_sources_ifdef(CONFIG_MBEDTLS_ENABLE_HEAP
   ${NRF_SECURITY_ROOT}/src/mbedtls/mbedtls_heap.c
 )
 
-if(CONFIG_SOC_NRF52840 OR CONFIG_SOC_NRF9160)
-  zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/cc310/replacements/entropy.c)
-else()
+if (CONFIG_ENTROPY_NRF5_RNG)
   zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/nrf5x/entropy_nrf5x.c)
+elseif(CONFIG_ENTROPY_CC310)
+  zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/cc310/replacements/entropy.c)
 endif()
+
 zephyr_library_link_libraries(mbedtls_common)
 nrf_security_debug_list_target_files(mbedtls_base_vanilla)
 


### PR DESCRIPTION
Some compile issues were found due to static assert usage.
Replace with #if defined(...) ... #endif blocks.

Signed-off-by: Torstein Grindvik <torstein.grindvik@nordicsemi.no>