### PR TITLE
jenkins: Point to the new nrfconnect org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline
       // ENVs for check-compliance
       GH_TOKEN = credentials('nordicbuilder-compliance-token') // This token is used to by check_compliance to comment on PRs and use checks
       GH_USERNAME = "NordicBuilder"
-      COMPLIANCE_ARGS = "-r NordicPlayground/nrfxlib"
+      COMPLIANCE_ARGS = "-r nrfconnect/sdk-nrfxlib"
 
       // Build all custom samples that match the ci_build tag
       SANITYCHECK_OPTIONS = "--board-root $WORKSPACE/nrf/boards --testcase-root $WORKSPACE/nrf/samples --testcase-root $WORKSPACE/nrf/applications --build-only --disable-unrecognized-section-test -t ci_build --inline-logs"


### PR DESCRIPTION
Point to nrfconnect instead of NordicPlayground, the new home of the NCS
repos.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>