### PR TITLE
doc: fix api doc for bsdlib_init return values

### DIFF
--- a/bsdlib/doc/api.rst
+++ b/bsdlib/doc/api.rst
@@ -11,6 +11,12 @@ BSD Library Management
    :project: nrfxlib
    :members:
 
+bsd_init() return values for modem firmware updates
+===================================================
+
+.. doxygengroup:: bsd_modem_dfu
+   :project: nrfxlib
+   :members:
 
 Limits of the BSD library
 *************************


### PR DESCRIPTION
Added doxygen group name to api.rst.

Screenshot of output -> 
![return_values](https://user-images.githubusercontent.com/29537761/82713009-d2d74f80-9c89-11ea-97a5-942510adad93.png)

The problem is that a new doxygen group was added for these values. With our current doxygen-RST integration, all doxygen groups must be explicitly included in RST, even if they are a subgroup.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>