### PR TITLE
nrf_802154_sl: Increase 802.15.4 RTC IRQ priority

### DIFF
--- a/nrf_802154_sl/include/nrf_802154_sl_config.h
+++ b/nrf_802154_sl/include/nrf_802154_sl_config.h
@@ -55,7 +55,7 @@
  *
  */
 #ifndef NRF_802154_SL_RTC_IRQ_PRIORITY
-#define NRF_802154_SL_RTC_IRQ_PRIORITY 6
+#define NRF_802154_SL_RTC_IRQ_PRIORITY 5
 #endif
 
 /**


### PR DESCRIPTION
802.15.4 RTC priority was set to 6 what is out of allowed range for
Zephyr in selected configurations. Incrase to priority 5.

Signed-off-by: Hubert Miś <hubert.mis@nordicsemi.no>