### PR TITLE
Feature/nrf oberon v3.0.5

### DIFF
--- a/nrf_security/cmake/symbol_strip.cmake
+++ b/nrf_security/cmake/symbol_strip.cmake
@@ -34,6 +34,7 @@ function(symbol_strip_func backend)
   nrf_security_debug("========== Running symbol_strip_function for ${backend} ==========")
   string(TOUPPER "${backend}" BACKEND_NAME_UPPER)
 
+  remove_objects("${BACKEND_NAME_UPPER}_ENABLED"   ${BACKEND_NAME_UPPER} remove_line "empty_file.c.obj")
   remove_objects("MBEDTLS_AES_C"        ${BACKEND_NAME_UPPER} remove_line "aes.c.obj")
   remove_objects("MBEDTLS_AES_C"        ${BACKEND_NAME_UPPER} remove_line "aes_alt.c.obj")
   remove_objects("MBEDTLS_CCM_C"        ${BACKEND_NAME_UPPER} remove_line "ccm.c.obj")

--- a/nrf_security/src/mbedcrypto_glue/oberon/ccm_oberon.c
+++ b/nrf_security/src/mbedcrypto_glue/oberon/ccm_oberon.c
@@ -18,7 +18,7 @@
 #include "backend_ccm.h"
 
 
-BUILD_ASSERT_MSG(OBERON_MBEDTLS_CCM_CONTEXT_WORDS == (sizeof(mbedtls_cipher_context_t) + 3) / 4, "Invalid OBERON_MBEDTLS_CCM_CONTEXT_WORDS value");
+BUILD_ASSERT(OBERON_MBEDTLS_CCM_CONTEXT_WORDS == (sizeof(mbedtls_cipher_context_t) + 3) / 4, "Invalid OBERON_MBEDTLS_CCM_CONTEXT_WORDS value");
 
 
 static int mbedtls_ccm_check(mbedtls_cipher_id_t cipher, unsigned int keybits)


### PR DESCRIPTION
nrf_security: Removing deprecated BUILD_ASSERT_MSG and fixing empty_file.c.obj

-Fixing CI issues on ccm_oberon.c
-Fixing issue with empty_file.c.obj in library recombination

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>
