### PR TITLE
doc: landing page for zboss api doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,4 @@ Semiconductor. Refer to their respective documentation for more information.
    nrf_802154_sl/README
    nrf_security/README
    nfc/README
+   zboss/README

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -22,6 +22,8 @@
 
 .. _`A-GPS`: https://en.wikipedia.org/wiki/Assisted_GPS
 
+.. _`ZBOSS API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss_api_doc/index.html
+
 .. ### Links to nrf (not a good way to link)
 
 .. _`Modem key management`: ../../../nrf/include/modem/modem_key_mgmt.html

--- a/zboss/README.rst
+++ b/zboss/README.rst
@@ -1,0 +1,8 @@
+.. _zboss:
+
+ZBOSS Zigbee stack
+==================
+
+The Nordic's Zigbee stack uses ZBOSS – a portable, high-performance Zigbee software protocol stack that allows for interoperability, customizing, testing, and optimizing of your Zigbee solution.
+
+For detailed documentation of the ZBOSS API and instructions on how to use it, see `ZBOSS API documentation`_.


### PR DESCRIPTION
Adding a page with some description and a link to the ZBOSS API doc.
The API doc is generated from doxygen and uploaded to developer.nordicsemi.com.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>

Output can be previewed here:
[ZBOSS Zigbee stack — nrfxlib 1.2.99 documentation.pdf](https://github.com/nrfconnect/sdk-nrfxlib/files/4701553/ZBOSS.Zigbee.stack.nrfxlib.1.2.99.documentation.pdf)

The text for the landing page is taken from the old SDK, @wbober @tomchy  please suggest changes, if needed.
