### PR TITLE
Fix doxygen warnings

### DIFF
--- a/ble_controller/include/nrf_errno.h
+++ b/ble_controller/include/nrf_errno.h
@@ -9,7 +9,7 @@
 
 /**
  * @file
- * @defgroup nrf_errno Integer values for errno
+ * @defgroup nrf_errno_ble Integer values for errno
  * @ingroup ble_controller
  *
  * Used by system calls to indicates the latest error.
@@ -57,6 +57,6 @@ extern "C" {
 }
 #endif
 
-/** @} end of nrf_errno */
+/** @} end of nrf_errno_ble */
 
 #endif // NRF_ERRNO_H__

--- a/bsdlib/include/bsd.h
+++ b/bsdlib/include/bsd.h
@@ -22,7 +22,7 @@ extern "C" {
 #endif
 
 /**
- * @defgroup bsd_modem_dfu
+ * @defgroup bsd_modem_dfu BSD Modem DFU
  *           @c bsd_init() return values when executing Modem firmware updates.
  *
  * @ingroup bsd_library

--- a/bsdlib/include/bsd_os.h
+++ b/bsdlib/include/bsd_os.h
@@ -8,7 +8,7 @@
  * @file bsd_os.h
  * @brief OS specific definitions.
  *
- * @defgroup bsd_os
+ * @defgroup bsd_os BSD OS Library
  * @{
  */
 #ifndef BSD_OS_H__

--- a/bsdlib/include/bsd_platform.h
+++ b/bsdlib/include/bsd_platform.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
-/**@file ipc/bsd_platform.h
- *
+/**
+ * @file bsd_platform.h
  * @defgroup bsd_platform_ipc BSD Platform
  * @ingroup bsd_platform
  * @{

--- a/bsdlib/include/nrf_errno.h
+++ b/bsdlib/include/nrf_errno.h
@@ -11,7 +11,7 @@
  * @brief Defines integer values for errno.
  *        Used by system calls to indicates the latest error.
  *
- * @defgroup nrf_errno
+ * @defgroup nrf_errno Integer values for errno
  */
 #ifdef __cplusplus
 extern "C" {

--- a/bsdlib/include/nrf_errno.h
+++ b/bsdlib/include/nrf_errno.h
@@ -7,7 +7,7 @@
 #ifndef NRF_ERRNO_H__
 #define NRF_ERRNO_H__
 /**
- * @file nrf_errno.h
+ * @file bsdlib/include/nrf_errno.h
  * @brief Defines integer values for errno.
  *        Used by system calls to indicates the latest error.
  *

--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -132,7 +132,7 @@ typedef uint32_t nrf_fd_set;
 
 /**@brief
  * Socket option to set role for the connection.
- * Accepts a @ref nrf_sec_role_t with values:
+ * Accepts an nrf_sec_role_t with values:
  *  - 0 - Client role.
  *  - 1 - Server role.
  */
@@ -146,7 +146,7 @@ typedef uint32_t nrf_fd_set;
 
 /**@brief
  * Socket option to control TLS session caching.
- * Accepts a @ref nrf_sec_session_cache_t with values:
+ * Accepts an nrf_sec_session_cache_t with values:
  *  - 0 - Disabled.
  *  - 1 - Enabled.
  * @sa nrf_sec_session_cache_t.
@@ -155,7 +155,7 @@ typedef uint32_t nrf_fd_set;
 
 /**@brief
  * Socket option to set peer verification level.
- * This option accepts a @ref nrf_sec_peer_verify_t with values:
+ * This option accepts an nrf_sec_peer_verify_t with values:
  *  - 0 - None
  *  - 1 - Optional
  *  - 2 - Required
@@ -229,7 +229,7 @@ typedef uint32_t nrf_fd_set;
 
 /**@brief
  * Socket option to schedule a modem firmware update at next boot.
- * The result of the update is returned by @ref bsd_init, at next boot.
+ * The result of the update is returned by bsd_init, at next boot.
  * The modem needs to be reset once more to run the updated firmware.
  */
 #define NRF_SO_DFU_APPLY 4
@@ -251,7 +251,7 @@ typedef uint32_t nrf_fd_set;
  * in the modem's scratch area. This option is used to determine whether
  * a firmware image exists in the modem's scratch area and its size.
  * A value of 2.5 megabytes (2621440 bytes) is returned if the scratch area
- * is dirty, and needs erasing (via @ref NRF_SO_DFU_BACKUP_DELETE).
+ * is dirty, and needs erasing (via NRF_SO_DFU_BACKUP_DELETE).
  * If non-zero and different from 2.5 megabytes, the value indicates the size
  * of the firmware image received so far.
  */
@@ -298,12 +298,12 @@ typedef uint32_t nrf_fd_set;
  */
 #define NRF_SO_GNSS_FIX_RETRY           2
 
-#define NRF_SO_GNSS_SYSTEM              3    /**< Identifies the option used to set and/or get the GNSS system used. See @ref nrf_gnss_system_t for details. */
+#define NRF_SO_GNSS_SYSTEM              3    /**< Identifies the option used to set and/or get the GNSS system used. See nrf_gnss_system_t for details. */
 #define NRF_SO_GNSS_NMEA_MASK           4    /**< Identifies the option used to select the data format of the received data. */
 #define NRF_SO_GNSS_ELEVATION_MASK      5    /**< Indicates at which elevation the GPS should stop tracking a satellite. */
 #define NRF_SO_GNSS_USE_CASE            6    /**< Indicates the targeted start performance: 0 = single cold start performance targeted, 1 = multiple hot start performance targeted. */
-#define NRF_SO_GNSS_START               7    /**< Identifies the option to start the GPS. @ref nrf_gnss_delete_mask_t given as payload. */
-#define NRF_SO_GNSS_STOP                8    /**< Identifies the option to stop the GPS. @ref nrf_gnss_delete_mask_t given as payload. */
+#define NRF_SO_GNSS_START               7    /**< Identifies the option to start the GPS. nrf_gnss_delete_mask_t given as payload. */
+#define NRF_SO_GNSS_STOP                8    /**< Identifies the option to stop the GPS. nrf_gnss_delete_mask_t given as payload. */
 #define NRF_SO_GNSS_POWER_SAVE_MODE     9    /**< Identifies the option to set power save mode. */
 #define NRF_SO_GNSS_ENABLE_PRIORITY     10   /**< Identifies the option to enable priority time window (with no payload). */
 #define NRF_SO_GNSS_DISABLE_PRIORITY    11   /**< Identifies the option to disable priority time window (with no payload). */
@@ -367,7 +367,7 @@ typedef uint32_t nrf_fd_set;
 #define NRF_GNSS_SV_FLAG_UNHEALTHY    8 /**< Indicate that the satellite is unhealthy. */
 /**@} */
 
-/**@defgroup nrf_socket_gnss_data_agps AGPS data enumerator.
+/**@addtogroup nrf_socket_gnss_data_agps
  * @brief Use these values in the address field when using sendto to write AGPS models to the GNSS module.
  * @{
  */
@@ -443,7 +443,7 @@ struct nrf_timeval
 /**
  * @brief Socket families.
  *
- * @details For a list of valid values, refer to @ref nrf_socket_families.
+ * @details For a list of valid values, refer to nrf_socket_families.
  */
 typedef int nrf_socket_family_t;
 typedef nrf_socket_family_t nrf_sa_family_t;
@@ -619,7 +619,7 @@ struct nrf_ifreq
 };
 /**@} */
 
-/**@addtogroup nrf_socket_pdn PDN socket option types
+/**@addtogroup nrf_socket_pdn
  * @brief Data types defined to set and get socket options on a PDN socket.
  * @{
  */
@@ -1073,7 +1073,7 @@ int nrf_close(int sock);
  *
  * @details Set or get file descriptor options or flags. For a list of supported commands, refer
  *          to @ref nrf_fcnt_commands.
- *          For a list of supported flags, refer to @ref nrf_fcnt_flags.
+ *          For a list of supported flags, refer to nrf_fcnt_flags.
  *
  * @param[in] fd    The descriptor to set options on.
  * @param[in] cmd   The command class for options.
@@ -1264,10 +1264,10 @@ int nrf_select(int                        nfds,
  * @brief Method to poll for events on one or more sockets.
  *
  * @param[in,out] p_fds    An array of sockets, and respective for each socket that the caller polls for.
- *                         The occurred events per socket is returned in the revents field of @ref struct nrf_pollfd structure.
+ *                         The occurred events per socket is returned in the revents field of nrf_pollfd structure.
  *                         Shall not be NULL.
  * @param[in]     nfds     Positive number of sockets being polled for events.
- *                         Shall not be more than @ref BSD_MAX_SOCKET_COUNT.
+ *                         Shall not be more than BSD_MAX_SOCKET_COUNT.
  *
  * @param[in]     timeout  Timeout in milliseconds.
  *                         The methods waits for this time period for the events to occur on the sockets.
@@ -1416,8 +1416,8 @@ const char * nrf_inet_ntop(int             family,
 /**@brief Function to resolve the host name into IPv4 and/or IPv6 addresses.
  *
  * @note The memory pointed to by @p pp_res must be freed using
- *       @ref nrf_freeaddrinfo when the address is no longer needed
- *       or before calling @ref nrf_getaddrinfo again.
+ *       nrf_freeaddrinfo when the address is no longer needed
+ *       or before calling nrf_getaddrinfo again.
  *
  * @param[in]  p_node     Host name to resolve.
  * @param[in]  p_service  Service to resolve.
@@ -1433,9 +1433,9 @@ int nrf_getaddrinfo(const char                *  p_node,
                     struct nrf_addrinfo       ** pp_res);
 
 
-/**@brief Function for freeing the memory allocated for the result of @ref nrf_getaddrinfo.
+/**@brief Function for freeing the memory allocated for the result of nrf_getaddrinfo.
  *
- * @details When the linked list of resolved addresses created by @ref getaddrinfo
+ * @details When the linked list of resolved addresses created by nrf_getaddrinfo
  *          is no longer needed, call this function to free the allocated memory.
  *
  * @param[in] p_res  Pointer to the memory to be freed.
@@ -1450,8 +1450,8 @@ void nrf_freeaddrinfo(struct nrf_addrinfo * p_res);
  *          The secondary DNS address does not override the primary DNS address.
  *
  * @param[in] family    Address family.
- * @param[in] in_addr   An IPv4 or IPv6 address encoded in a @ref nrf_in_addr
- *                      or @ref nrf_in6_addr structure, respectively.
+ * @param[in] in_addr   An IPv4 or IPv6 address encoded in a nrf_in_addr or
+ *                      nrf_in6_addr structure, respectively.
  *                      Pass @c NULL to unset the secondary DNS address.
  *
  * @return int Zero on success, or an  error from @file bsdlib/include/nrf_errno.h

--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -961,7 +961,7 @@ typedef struct
  */
 
 /**@brief Defines the interval between each fix in seconds.
- * @defails Allowed values are 0, 1, 10..1800, value 0 denotes single fix.
+ * @details Allowed values are 0, 1, 10..1800, value 0 denotes single fix.
  *          Default interval is 1 second (continous mode), 0 denotes a single fix.
  */
 typedef uint16_t nrf_gnss_fix_interval_t;

--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -1454,7 +1454,8 @@ void nrf_freeaddrinfo(struct nrf_addrinfo * p_res);
  *                      or @ref nrf_in6_addr structure, respectively.
  *                      Pass @c NULL to unset the secondary DNS address.
  *
- * @return int Zero on success, or an  error from @file nrf_errno.h otherwise.
+ * @return int Zero on success, or an  error from @file bsdlib/include/nrf_errno.h
+ *             otherwise.
  */
 int nrf_setdnsaddr(int family, const void *in_addr);
 

--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -601,13 +601,13 @@ typedef uint32_t nrf_sec_cipher_t;
 /**@brief Data type to combine all security configuration parameters. */
 typedef struct
 {
-    nrf_sec_role_t          role;                    /**< Local role to be played. See @nrf_sec_role_t for details. */
-    nrf_sec_peer_verify_t   peer_verify;             /**< Indicates the preference for peer verification. See @nrf_sec_peer_verify_t for details. */
-    nrf_sec_session_cache_t session_cache;           /**< Indicates the preference for session caching. See @nrf_sec_session_cache_t for details. */
+    nrf_sec_role_t          role;                    /**< Local role to be played. See nrf_sec_role_t for details. */
+    nrf_sec_peer_verify_t   peer_verify;             /**< Indicates the preference for peer verification. See nrf_sec_peer_verify_t for details. */
+    nrf_sec_session_cache_t session_cache;           /**< Indicates the preference for session caching. See nrf_sec_session_cache_t for details. */
     uint32_t                cipher_count;            /**< Indicates the number of entries in the cipher list. */
-    nrf_sec_cipher_t        *p_cipher_list;          /**< Indicates the list of ciphers to be used for the session. See @nrf_sec_cipher_t for details. */
+    nrf_sec_cipher_t        *p_cipher_list;          /**< Indicates the list of ciphers to be used for the session. See nrf_sec_cipher_t for details. */
     uint32_t                 sec_tag_count;          /**< Indicates the number of entries in the sec tag list. */
-    nrf_sec_tag_t           *p_sec_tag_list;         /**< Indicates the list of security tags to be used for the session. See @nrf_sec_tag_t for details. */
+    nrf_sec_tag_t           *p_sec_tag_list;         /**< Indicates the list of security tags to be used for the session. See nrf_sec_tag_t for details. */
 } nrf_sec_config_t;
 
 #define NRF_IFNAMSIZ 64

--- a/crypto/nrf_cc310_bl/include/nrf_cc310_bl_hash_sha256.h
+++ b/crypto/nrf_cc310_bl/include/nrf_cc310_bl_hash_sha256.h
@@ -82,6 +82,8 @@ CRYSError_t nrf_cc310_bl_hash_sha256_init(
  *
  * @param[in,out]   p_hash_context  Structure holding context information
  *                                  for the SHA-256 operation.
+ * @param[in]       p_src           Input data to be added to the digest.
+ * @param[in]       len             Amount of data passed in p_src.
  *
  * @retval CRYS_OK If call was successful.
  * @retval CRYS_HASH_INVALID_USER_CONTEXT_POINTER_ERROR    p_hash_context was NULL.
@@ -96,11 +98,11 @@ CRYSError_t nrf_cc310_bl_hash_sha256_update(
 
 /** @brief Function for finalizing the hash calculation.
  *
- *  @note Memory pointed to in hash digest must be allocated prior to this call.
+ * @note Memory pointed to in hash digest must be allocated prior to this call.
  *
  * @param[in,out]   p_hash_context  Structure holding context information for
  *                                  the SHA-256 operation.
- * @param[in,out]   p_hash_digest   Pointer to the structure holding SHA-256
+ * @param[in,out]   p_digest        Pointer to the structure holding SHA-256
  *                                  hash digest. Data pointed to must be 32 bytes long.
  *
  * @retval  CRYS_HASH_INVALID_USER_CONTEXT_POINTER_ERROR    p_hash_context was NULL.

--- a/crypto/nrf_cc310_platform/include/nrf_cc310_platform.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc310_platform.h
@@ -70,7 +70,6 @@ bool nrf_cc310_platform_is_initialized(void);
  */
 bool nrf_cc310_platform_rng_is_initialized(void);
 
-
 /** @brief ISR Function for processing of CC310 Interrupts.
  *         This CC310 interrupt service routine function should be called for
  *         interrupt processing.
@@ -84,3 +83,5 @@ void CRYPTOCELL_IRQHandler(void);
 #endif
 
 #endif /* NRF_CC310_PLATFORM_H__ */
+
+/** @} */

--- a/crypto/nrf_cc310_platform/include/nrf_cc310_platform_mutex.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc310_platform_mutex.h
@@ -143,7 +143,7 @@ void nrf_cc310_platform_set_mutexes(
  * and platform mutexes.
  *
  * @note This function must be called once before calling
- * @ref nrf_cc310_platform_init or @ref nrf_cc310_platform_init_no_rng.
+ * nrf_cc310_platform_init() or nrf_cc310_platform_init_no_rng().
  *
  * @note This function is not expected to be thread-safe.
  */
@@ -154,3 +154,5 @@ void nrf_cc310_platform_mutex_init(void);
 #endif
 
 #endif /* NRF_CC310_PLATFORM_MUTEX_H__ */
+
+/** @} */

--- a/nfc/include/nfc_t2t_lib.h
+++ b/nfc/include/nfc_t2t_lib.h
@@ -203,7 +203,6 @@ int nfc_t2t_payload_raw_set(const u8_t *payload,
  *
  * @note When modifying the internal bytes, remember that they must be
  *	 consistent with the NFC hardware register settings
- *	 (see @ref nfc_t2t_format_internal).
  *
  * @param data Pointer to the memory area containing the data.
  * @param data_length Size of the data in bytes.

--- a/nfc/include/nfc_t4t_lib.h
+++ b/nfc/include/nfc_t4t_lib.h
@@ -42,8 +42,7 @@
  *
  * @note If you are using nRF52832 chip (in IC rev. Engineering B or
  * Engineering C) or if You are using nRF52840 chip (in IC rev. Engineering A,
- * B or C) library will use TIMER 4 to apply workarounds for the anomalies
- * listed in @ref nfc_fixes.h
+ * B or C) library will use TIMER 4 to apply workarounds for the anomalies.
  */
 
 #include <zephyr/types.h>


### PR DESCRIPTION
This fixes warnings generated by Doxygen, apart from those generated under the `zboss` and `nrf_802154_sl` directories.