### PR TITLE
doc: add missing referenced link

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -24,6 +24,8 @@
 
 .. ### Other links
 
+.. _`Beej's Guide to Network Programming`: https://beej.us/guide/bgnet/
+
 .. _`Socket API`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
 
 .. _`ZBOSS API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss_api_doc/index.html


### PR DESCRIPTION
Build is failing because bsdlib/README.rst is referring to a link which is currently not available in the links.txt file, so add it.