### PR TITLE
nrf_security: Fixing faulty matching platform_cc310

### DIFF
--- a/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
+++ b/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
@@ -9,9 +9,6 @@
 #include <drivers/entropy.h>
 #include <mbedtls/entropy.h>
 
-static_assert(defined(CONFIG_ENTROPY_GENERATOR), "CONFIG_ENTROPY_GENERATOR is not enabled.");
-static_assert(defined(CONFIG_ENTROPY_HAS_DRIVER), "CONFIG_ENTROPY_HAS_DRIVER is not set.");
-
 int mbedtls_hardware_poll(void *data,
                           unsigned char *output,
                           size_t len,

--- a/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
+++ b/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
@@ -5,7 +5,8 @@
  */
 #include <assert.h>
 #include <zephyr.h>
-#include <entropy.h>
+#include <device.h>
+#include <drivers/entropy.h>
 #include <mbedtls/entropy.h>
 
 static_assert(defined(CONFIG_ENTROPY_GENERATOR), "CONFIG_ENTROPY_GENERATOR is not enabled.");
@@ -42,7 +43,8 @@ int mbedtls_hardware_poll(void *data,
         return -1;
     }
 
-    dev = device_get_binding(CONFIG_ENTROPY_NAME);
+    dev = device_get_binding(DT_CHOSEN_ZEPHYR_ENTROPY_LABEL);
+
     if (!dev)
     {
         return MBEDTLS_ERR_ENTROPY_NO_SOURCES_DEFINED;

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -131,11 +131,12 @@ zephyr_library_sources_ifdef(CONFIG_MBEDTLS_ENABLE_HEAP
   ${NRF_SECURITY_ROOT}/src/mbedtls/mbedtls_heap.c
 )
 
-if(CONFIG_SOC_NRF52840 OR CONFIG_SOC_NRF9160)
+if (CONFIG_ENTROPY_CC310)
   zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/cc310/replacements/entropy.c)
-else()
+elseif(CONFIG_ENTROPY_NRF5_RNG)
   zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/nrf5x/entropy_nrf5x.c)
 endif()
+
 zephyr_library_link_libraries(mbedtls_common)
 nrf_security_debug_list_target_files(mbedtls_base_vanilla)
 

--- a/nrf_security/src/mbedtls/oberon/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/oberon/CMakeLists.txt
@@ -6,7 +6,6 @@
 
 get_target_property(NRF_OBERON_MBEDTLS_INCLUDE_PATH mbedcrypto_oberon_mbedtls_imported BASE_INCLUDE_PATH)
 get_target_property(NRF_OBERON_INCLUDE_PATH mbedcrypto_oberon_imported BASE_INCLUDE_PATH)
-get_target_property(NRF_PLATFORM_CC310_INCLUDE_PATH platform_cc310 BASE_INCLUDE_PATH)
 
 nrf_security_debug("######### Creating nrf_oberon noglue library #########")
 
@@ -93,7 +92,7 @@ target_include_directories(mbedcrypto_oberon_noglue PRIVATE
 if(TARGET platform_cc310)
   target_include_directories(mbedcrypto_oberon_noglue PRIVATE
     ${mbedcrypto_glue_include_path}/threading
-    ${NRF_PLATFORM_CC310_INCLUDE_PATH}
+    $<TARGET_PROPERTY:platform_cc310,BASE_INCLUDE_PATH>
   )
 endif()
 

--- a/nrf_security/src/mbedtls/shared/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/shared/CMakeLists.txt
@@ -6,8 +6,6 @@
 # The purpose of this file is to provice a set of debug commands to nrf security
 # module.
 
-get_target_property(NRF_PLATFORM_CC310_INCLUDE_PATH platform_cc310 BASE_INCLUDE_PATH)
-
 nrf_security_debug("######### Creating shared noglue library #########")
 
 #
@@ -57,14 +55,13 @@ target_sources_ifdef(CONFIG_MBEDTLS_SHA512_C
   mbedcrypto_shared PRIVATE ${ARM_MBEDTLS_PATH}/library/sha512.c
 )
 
-
 #
 # Add specific includes for threading and platform_cc310
 #
 if(TARGET platform_cc310)
   target_include_directories(mbedcrypto_shared PRIVATE
     ${mbedcrypto_glue_include_path}/threading
-    ${NRF_PLATFORM_CC310_INCLUDE_PATH}
+    $<TARGET_PROPERTY:platform_cc310,BASE_INCLUDE_PATH>
   )
 endif()
 

--- a/nrf_security/src/mbedtls/vanilla/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/vanilla/CMakeLists.txt
@@ -69,7 +69,7 @@ target_include_directories(mbedcrypto_vanilla PRIVATE
 if(TARGET platform_cc310)
   target_include_directories(mbedcrypto_vanilla PRIVATE
     ${mbedcrypto_glue_include_path}/threading
-    ${NRF_CC310_PLATFORM_BASE}/include
+    $<TARGET_PROPERTY:platform_cc310,BASE_INCLUDE_PATH>
   )
 endif()
 


### PR DESCRIPTION
-Fixed if to ensure include only if platform_cc310 is a target
-Standardized on same format in vanilla mbed TLS for platform_cc310

Ref: NCSDK-5706

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>