### PR TITLE
zigbee: Fix for scheduling zboss callbacks

### DIFF
--- a/zboss/include/osif/zb_osif_platform.h
+++ b/zboss/include/osif/zb_osif_platform.h
@@ -73,6 +73,30 @@ zb_bool_t zb_osif_timer_is_on(void);
 void zb_osif_enable_all_inter(void);
 void zb_osif_disable_all_inter(void);
 
+#define ZB_SCHEDULE_APP_CALLBACK(func, param) \
+	zigbee_schedule_callback(func, param)
+
+#define ZB_SCHEDULE_APP_CALLBACK2(func, param, user_param) \
+	zigbee_schedule_callback2(func, param, user_param)
+
+#define ZB_SCHEDULE_APP_ALARM(func, param, timeout_bi) \
+	zigbee_schedule_alarm(func, param, timeout_bi)
+
+#define ZB_SCHEDULE_APP_ALARM_CANCEL(func, param) \
+	zigbee_schedule_alarm_cancel(func, param)
+
+#define zb_buf_get_out_delayed(func) \
+	zigbee_get_out_buf_delayed(func)
+
+#define zb_buf_get_in_delayed(func) \
+	zigbee_get_in_buf_delayed(func)
+
+#define zb_buf_get_out_delayed_ext(func, param, max_size) \
+	zigbee_get_out_buf_delayed_ext(func, param, max_size)
+
+#define zb_buf_get_in_delayed_ext(func, param, max_size) \
+	zigbee_get_in_buf_delayed_ext(func, param, max_size)
+
 #ifdef ZB_STACK_REGRESSION_TESTING_API
 
 #define ZB_ENABLE_ALL_INTER()                          \

--- a/zboss/include/zboss_api_buf.h
+++ b/zboss/include/zboss_api_buf.h
@@ -276,7 +276,9 @@ void *zb_buf_alloc_left_func(TRACE_PROTO zb_bufid_t buf, zb_uint_t size);
  * @param callback - callback to call.
  * @return RET_OK or error code.
  */
+#ifndef zb_buf_get_out_delayed
 #define zb_buf_get_out_delayed(callback) zb_buf_get_out_delayed_func(TRACE_CALL (callback))
+#endif /* zb_buf_get_out_delayed */
 
 /**
  * @brief Allocate IN buffer, call a callback when the buffer is available.
@@ -288,7 +290,9 @@ void *zb_buf_alloc_left_func(TRACE_PROTO zb_bufid_t buf, zb_uint_t size);
  * @param callback - callback to call.
  * @return RET_OK or error code.
  */
+#ifndef zb_buf_get_in_delayed
 #define zb_buf_get_in_delayed(callback) zb_buf_get_in_delayed_func(TRACE_CALL (callback))
+#endif /* zb_buf_get_in_delayed */
 
 /**
  * @brief Allocate OUT buffer, call a callback when the buffer is available.
@@ -303,7 +307,9 @@ void *zb_buf_alloc_left_func(TRACE_PROTO zb_bufid_t buf, zb_uint_t size);
    a fraction of buffer or long buffers. Special value 0 means "single default buffer".
  * @return RET_OK or error code.
  */
+#ifndef zb_buf_get_out_delayed_ext
 #define zb_buf_get_out_delayed_ext(callback,arg,max_size) zb_buf_get_out_delayed_ext_func(TRACE_CALL (callback),(arg),(max_size))
+#endif /* zb_buf_get_out_delayed_ext */
 
 /**
  * @brief Allocate IN buffer, call a callback when the buffer is available.
@@ -318,8 +324,9 @@ void *zb_buf_alloc_left_func(TRACE_PROTO zb_bufid_t buf, zb_uint_t size);
  * a fraction of buffer or long buffers. Special value 0 means "single default buffer".
  * @return RET_OK or error code.
  */
+#ifndef zb_buf_get_in_delayed_ext
 #define zb_buf_get_in_delayed_ext(callback,arg,max_size) zb_buf_get_in_delayed_ext_func(TRACE_CALL (callback),(arg),(max_size))
-
+#endif /* zb_buf_get_in_delayed_ext */
 
 /**
  * @brief Free packet buffer and put it into freelist.

--- a/zboss/include/zboss_api_core.h
+++ b/zboss/include/zboss_api_core.h
@@ -308,7 +308,9 @@ zb_ret_t zb_schedule_app_callback(zb_callback_t func, zb_uint8_t param,
 
    See sched sample
  */
+#ifndef ZB_SCHEDULE_APP_CALLBACK
 #define ZB_SCHEDULE_APP_CALLBACK(func, param) zb_schedule_app_callback(func, param, ZB_FALSE, 0, ZB_FALSE)
+#endif /* ZB_SCHEDULE_APP_CALLBACK */
 
 /**
    Schedule two-param callback execution.
@@ -323,7 +325,9 @@ zb_ret_t zb_schedule_app_callback(zb_callback_t func, zb_uint8_t param,
    @return RET_OK or RET_OVERFLOW.
    See sched sample
  */
+#ifndef ZB_SCHEDULE_APP_CALLBACK2
 #define ZB_SCHEDULE_APP_CALLBACK2(func, param, user_param) zb_schedule_app_callback((zb_callback_t)(func),  param, ZB_TRUE, user_param, ZB_FALSE)
+#endif /* ZB_SCHEDULE_APP_CALLBACK2 */
 
 /** @cond internals_doc */
 zb_ret_t zb_schedule_app_alarm(zb_callback_t func, zb_uint8_t param, zb_time_t run_after);
@@ -344,7 +348,9 @@ zb_ret_t zb_schedule_app_alarm(zb_callback_t func, zb_uint8_t param, zb_time_t r
 
    See any sample
  */
+#ifndef ZB_SCHEDULE_APP_ALARM
 #define ZB_SCHEDULE_APP_ALARM(func, param, timeout_bi) zb_schedule_app_alarm(func, param, timeout_bi)
+#endif /* ZB_SCHEDULE_APP_ALARM */
 
 /**
    Special parameter for zb_schedule_alarm_cancel(): cancel alarm once without
@@ -388,7 +394,9 @@ zb_ret_t zb_schedule_alarm_cancel(zb_callback_t func, zb_uint8_t param, zb_uint8
 
    See reporting_srv sample
  */
+#ifndef ZB_SCHEDULE_APP_ALARM_CANCEL
 #define ZB_SCHEDULE_APP_ALARM_CANCEL(func, param) zb_schedule_alarm_cancel((func), (param), NULL)
+#endif /* ZB_SCHEDULE_APP_ALARM_CANCEL */
 
 /**
    Cancel scheduled alarm and get buffer.


### PR DESCRIPTION
Fix for scheduling zboss callbacks
Redefined ZBOSS macros to use thread safe functions.

Depends on: #2416