### PR TITLE
doc: use intersphinx to resolve nrf links

### DIFF
--- a/bsdlib/doc/security_tags.rst
+++ b/bsdlib/doc/security_tags.rst
@@ -8,7 +8,7 @@ To use the cryptographic functions in the modem, the application must provision 
 
 To be able to provision credentials, the modem must be in offline mode.
 The credentials are provisioned through AT commands (see `Credential storage management %CMNG`_).
-If you are using the |NCS| to build your application, you can use the `Modem key management`_ library to manage credentials.
+If you are using the |NCS| to build your application, you can use the :ref:`nrf:modem_key_mgmt` library to manage credentials.
 If you prefer a graphical tool, use `LTE Link Monitor`_ instead.
 To manage credentials with LTE Link Monitor, your device must be running an |NCS| application.
 

--- a/doc/links.txt
+++ b/doc/links.txt
@@ -14,14 +14,6 @@
 
 .. _`nRF9160 modem firmware zip file`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#98C9E2578566420786ABD40B695FDB9B
 
-.. ### Links to nrf (not a good way to link)
-
-.. _`Modem key management`: ../../../nrf/include/modem/modem_key_mgmt.html
-
-.. _`NFC Data Exchange Format (NDEF)`: ../../../nrf/ug_nfc.html#nfc-data-exchange-format-ndef
-
-.. _`Working with NFC`: ../../nrf/ug_nfc.html
-
 .. ### Other links
 
 .. _`Beej's Guide to Network Programming`: https://beej.us/guide/bgnet/

--- a/nfc/README.rst
+++ b/nfc/README.rst
@@ -6,7 +6,7 @@ Near Field Communication (NFC)
 Near Field Communication (NFC) is a technology for wireless transfer of small amounts of data between two devices.
 The provided NFC libraries are RTOS-agnostic and built for Nordic Semiconductor nRF52 and nRF53 Series SoCs.
 
-See the `Working with NFC`_ user guide for information about how to use the libraries in the |NCS|.
+See the :ref:`nrf:ug_nfc` user guide for information about how to use the libraries in the |NCS|.
 
 The following libraries are available:
 

--- a/nfc/doc/type_2_tag.rst
+++ b/nfc/doc/type_2_tag.rst
@@ -348,7 +348,7 @@ To program a tag, complete the following steps:
       }
 
 #. Configure the data for the tag.
-   You can provide the data as NDEF message (recommended, see `NFC Data Exchange Format (NDEF)`_) or as a raw TLV structure (advanced usage, see Type 2 Tag :ref:`t2t_memory_layout`).
+   You can provide the data as NDEF message (recommended, see :ref:`nrf:ug_nfc_ndef`) or as a raw TLV structure (advanced usage, see Type 2 Tag :ref:`t2t_memory_layout`).
 
    * Set an NDEF message:
 

--- a/nfc/doc/type_4_tag.rst
+++ b/nfc/doc/type_4_tag.rst
@@ -54,7 +54,7 @@ It consists of following fields:
    * - NDEF Message
      - NLEN bytes
      - NDEF message.
-       See `NFC Data Exchange Format (NDEF)`_.
+       See :ref:`nrf:ug_nfc_ndef`.
 
 As you see, the NDEF file adds one additional field in comparison to the raw NDEF message.
 It is called NLEN and is required for an NDEF file.


### PR DESCRIPTION
Remove links to nrf documentation from links.txt file, and add proper link references to be resolved by intersphinx.

JIRA: NCSDK-3934