### PR TITLE
doc: nfc: remove references to missing symbols

### DIFF
--- a/nfc/include/nfc_t2t_lib.h
+++ b/nfc/include/nfc_t2t_lib.h
@@ -203,6 +203,7 @@ int nfc_t2t_payload_raw_set(const u8_t *payload,
  *
  * @note When modifying the internal bytes, remember that they must be
  *	 consistent with the NFC hardware register settings
+ *	 (see @ref nfc_t2t_format_internal).
  *
  * @param data Pointer to the memory area containing the data.
  * @param data_length Size of the data in bytes.

--- a/nfc/include/nfc_t4t_lib.h
+++ b/nfc/include/nfc_t4t_lib.h
@@ -42,7 +42,8 @@
  *
  * @note If you are using nRF52832 chip (in IC rev. Engineering B or
  * Engineering C) or if You are using nRF52840 chip (in IC rev. Engineering A,
- * B or C) library will use TIMER 4 to apply workarounds for the anomalies.
+ * B or C) library will use TIMER 4 to apply workarounds for the anomalies
+ * listed in @ref nfc_fixes.h
  */
 
 #include <zephyr/types.h>


### PR DESCRIPTION
This reverts commit 4974ac1b3b4caa186f64341811f1844c559698c1.