### PR TITLE
mpsl: Kconfig: select IEEE802154_NRF5_EXT_IRQ_MGMT

### DIFF
--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -8,6 +8,7 @@ config MPSL
 	bool "Nordic Multi Protocol Service Layer (MPSL)"
 	# MPSL only supports nRF52 and nRF53, it does not support nRF51 or nRF91.
 	select ZERO_LATENCY_IRQS
+	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
 	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
 	help
 	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,

--- a/nfc/doc/type_2_tag.rst
+++ b/nfc/doc/type_2_tag.rst
@@ -334,9 +334,9 @@ To program a tag, complete the following steps:
       /* Callback for NFC events */
       static void nfc_callback(void * context,
                                enum nfc_t4t_event event,
-                               const u8_t * data,
+                               const uint8_t * data,
                                size_t data_length,
-                               u32_t flags)
+                               uint32_t flags)
       {
       ...
       }
@@ -354,8 +354,8 @@ To program a tag, complete the following steps:
 
      .. code-block:: c
 
-        u8_t ndef_msg_buf[] = ...; // Buffer with the user NDEF message
-        u32_t len           = sizeof(ndef_msg_buf);
+        uint8_t ndef_msg_buf[] = ...; // Buffer with the user NDEF message
+        uint32_t len           = sizeof(ndef_msg_buf);
         /* Set created message as the NFC payload. */
         err = nfc_t2t_payload_set(ndef_msg_buf, len);
         if (err) {
@@ -368,8 +368,8 @@ To program a tag, complete the following steps:
 
      .. code-block:: c
 
-        u8_t tlv_buf[] = ...; // Buffer with the user TLV structure
-        u32_t len           = sizeof(tlv_buf);
+        uint8_t tlv_buf[] = ...; // Buffer with the user TLV structure
+        uint32_t len           = sizeof(tlv_buf);
         /* Set created TLV structure as the NFC payload. */
         err = nfc_t2t_payload_raw_set(tlv_buf, len);
         if (err) {

--- a/nfc/include/nfc_t2t_lib.h
+++ b/nfc/include/nfc_t2t_lib.h
@@ -78,7 +78,7 @@ enum nfc_t2t_param_id {
  */
 typedef void (*nfc_t2t_callback_t)(void *context,
 				   enum nfc_t2t_event event,
-				   const u8_t *data,
+				   const uint8_t *data,
 				   size_t data_length);
 
 /**@brief Function for registering the application callback for event
@@ -157,7 +157,7 @@ int nfc_t2t_parameter_get(enum nfc_t2t_param_id id,
  *
  * @retval Zero on success or (negative) error code otherwise.
  */
-int nfc_t2t_payload_set(const u8_t *payload, size_t payload_length);
+int nfc_t2t_payload_set(const uint8_t *payload, size_t payload_length);
 
 /** @brief Function for registering the raw payload to send on reception of a
  *  READ request.
@@ -188,7 +188,7 @@ int nfc_t2t_payload_set(const u8_t *payload, size_t payload_length);
  * @retval 0 If the operation was successful. If one of the arguments was
  * invalid, an error code is returned.
  */
-int nfc_t2t_payload_raw_set(const u8_t *payload,
+int nfc_t2t_payload_raw_set(const uint8_t *payload,
 			    size_t payload_length);
 
 /** @brief Function for registering the sequence of internal bytes.
@@ -210,7 +210,7 @@ int nfc_t2t_payload_raw_set(const u8_t *payload,
  * @retval 0 If the operation was successful. If the data was not NULL and the
  * data length was not 10, an error code is returned.
  */
-int nfc_t2t_internal_set(const u8_t *data, size_t data_length);
+int nfc_t2t_internal_set(const uint8_t *data, size_t data_length);
 
 /** @brief Function for activating the NFC frontend.
  *

--- a/nfc/include/nfc_t4t_lib.h
+++ b/nfc/include/nfc_t4t_lib.h
@@ -163,9 +163,9 @@ enum nfc_t4t_param_id {
  */
 typedef void (*nfc_t4t_callback_t)(void *context,
 				   enum nfc_t4t_event event,
-				   const u8_t *data,
+				   const uint8_t *data,
 				   size_t data_length,
-				   u32_t flags);
+				   uint32_t flags);
 
 /** @brief Register the application callback for event signaling.
  *
@@ -211,7 +211,7 @@ int nfc_t4t_setup(nfc_t4t_callback_t callback, void *context);
  * @retval -ENOTSUP If the new buffer has a different length than the first one.
  * @retval -EFAULT If the provided buffer is the currently used buffer.
  */
-int nfc_t4t_ndef_rwpayload_set(u8_t *emulation_buffer,
+int nfc_t4t_ndef_rwpayload_set(uint8_t *emulation_buffer,
 			       size_t buffer_length);
 
 /** @brief Set emulationBuffer and Content for a NDEF Tag emulation that is
@@ -229,7 +229,7 @@ int nfc_t4t_ndef_rwpayload_set(u8_t *emulation_buffer,
  * @retval -EINVAL Invalid argument (e.g. NULL pointer).
  * @retval -ENOTSUP Emulation is in running stated.
  */
-int nfc_t4t_ndef_staticpayload_set(const u8_t *emulation_buffer,
+int nfc_t4t_ndef_staticpayload_set(const uint8_t *emulation_buffer,
 				   size_t buffer_length);
 
 /** @brief Send a raw response PDU after getting a Request PDU callback.
@@ -250,7 +250,7 @@ int nfc_t4t_ndef_staticpayload_set(const u8_t *emulation_buffer,
  * @retval -EINVAL Invalid argument (e.g. NULL pointer).
  * @retval -ENOTSUP Emulation is in running state.
  */
-int nfc_t4t_response_pdu_send(const u8_t *pdu, size_t pdu_length);
+int nfc_t4t_response_pdu_send(const uint8_t *pdu, size_t pdu_length);
 
 /** @brief Set an NFC parameter.
  *

--- a/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
+++ b/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
@@ -15,7 +15,7 @@ int mbedtls_hardware_poll(void *data,
                           size_t *olen )
 {
     struct device *dev;
-    u8_t buffer[MBEDTLS_ENTROPY_MAX_GATHER] = { 0 };
+    uint8_t buffer[MBEDTLS_ENTROPY_MAX_GATHER] = { 0 };
     int ret;
     
     (void)data;


### PR DESCRIPTION
nrf: https://github.com/nrfconnect/sdk-nrf/pull/2585

This is a new Kconfig option introduced in upstream Zephyr in commit
7f66fd84e849dccfd388a4b5a40563829a0f38c6 ("drivers: ieee802154: fix
nrf5 initialization with external irq source"). When enabled, the
zephyr driver does not configure the radio IRQ, so it is required for
use with MPSL.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>