### PR TITLE
softdevice_controller: SoftDevice Controller as the default BLE LL

### DIFF
--- a/softdevice_controller/Kconfig
+++ b/softdevice_controller/Kconfig
@@ -25,7 +25,8 @@ if BT_CTLR
 
 choice BT_LL_CHOICE
 	prompt "Bluetooth Link Layer Selection"
-	default BT_LL_SOFTDEVICE if BT_LL_SOFTDEVICE_DEFAULT
+	default BT_LL_SW_SPLIT if BT_MESH
+	default BT_LL_SOFTDEVICE
 
 config BT_LL_SOFTDEVICE
 	bool "SoftDevice Link Layer"


### PR DESCRIPTION
For Bluetooth Mesh use BT_LL_SW_SPLIT.
For all other Bluetooth use cases, use the SoftDevice Controller.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>

Manifest update: https://github.com/nrfconnect/sdk-nrf/pull/2769