### PR TITLE
cmake: nrf_security: use same python as rest of build system for west

### DIFF
--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -29,11 +29,11 @@ target_include_directories(mbedtls_common INTERFACE
 if(ARM_MBEDTLS_PATH)
   # Do nothing, just use the provided path
 elseif(WEST)
-  ## Use `west list` to find the mbedtls tree we use (this is not the
+  ## Use `west` to find the mbedtls tree we use (this is not the
   ## mbedtls tree distributed as a zephyr module).
   execute_process(
-    COMMAND
-    ${WEST} list mbedtls-nrf --format={posixpath}
+    COMMAND ${PYTHON_EXECUTABLE} -c
+    "from west.manifest import Manifest; manifest = Manifest.from_file(); print(manifest.get_projects(['mbedtls-nrf'])[0].posixpath)"
     OUTPUT_VARIABLE
     west_project_output
     RESULT_VARIABLE


### PR DESCRIPTION
This commit aligns the usage of west to upstream Zephyr, where Python
is used directly to ensure the same python is used for west.

This updates nrfxlib to use same principle as here: https://github.com/zephyrproject-rtos/zephyr/pull/26060

-----
Manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/2781

