### PR TITLE
bsdlib: doc: specify relationship between PVT and NMEA

### DIFF
--- a/bsdlib/doc/gnss_extension.rst
+++ b/bsdlib/doc/gnss_extension.rst
@@ -260,6 +260,8 @@ The following code shows how the the position data is displayed based on the :c:
 
 Fixes are always received in the ``pvt`` format.
 The format of this frame is defined in the GNSS API documentation of :cpp:type:`nrf_gnss_pvt_data_frame_t`.
+If NMEA strings are enabled, NMEA strings are always sent after the corresponding PVT notification.
+For example, if a PVT notification indicates a good fix, this applies to all the subsequent NMEA strings that are sent in between the current PVT notification and the next PVT notification.
 
 A-GPS data
 **********


### PR DESCRIPTION
Adding information about the relationship between PVT notifications
and NMEA strings.

Manifest update PR: https://github.com/nrfconnect/sdk-nrf/pull/2793

Signed-of-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>