### PR TITLE
mpsl: 802154 multiprotocol support

### DIFF
--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -9,6 +9,7 @@ config MPSL
 	# MPSL only supports nRF52 and nRF53, it does not support nRF51 or nRF91.
 	select ZERO_LATENCY_IRQS
 	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
+	select NRF_802154_MULTIPROTOCOL_SUPPORT if NRF_802154_RADIO_DRIVER
 	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
 	help
 	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,


### PR DESCRIPTION
802154 radio driver uses MPSL api to provide multiprotocol support. It seems it is a good place to active this feature.

Corresponding sdk-nrd PR: https://github.com/nrfconnect/sdk-nrf/pull/2766