### PR TITLE
openthread: Add install_openthread_libraries target

### DIFF
--- a/openthread/CMakeLists.txt
+++ b/openthread/CMakeLists.txt
@@ -6,6 +6,8 @@
 include(${NRFXLIB_DIR}/common.cmake)
 nrfxlib_calculate_lib_path(lib_path)
 
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/extensions.cmake)
+
 function(checkOpenthreadVersion)
   file(READ "${ZEPHYR_OPENTHREAD_MODULE_DIR}/../include/openthread/instance.h" INSTANCE_FILE_CONTENT)
   string(REGEX MATCH "#define[ ]*OPENTHREAD_API_VERSION[ ]*\\(([0-9]+)\\)" MACRO_DEF "${INSTANCE_FILE_CONTENT}")
@@ -20,6 +22,36 @@ function(checkOpenthreadVersion)
     message(WARNING "The Openthread source code version (${OPENTHREAD_SOURCE_API_VERSION}) is not equal to compiled Openthread library version (${OPENTHREAD_LIB_API_VERSION}).")
   endif()
 endfunction()
+
+if(CONFIG_OPENTHREAD_SOURCES)
+  message(DEBUG "Building OT from sources, config file will be generated.")
+
+  set(OPENTHREAD_CONFIG_FILE "${CMAKE_BINARY_DIR}/openthread_lib_configuration.txt")
+
+  openthread_libs_configuration_write(${OPENTHREAD_CONFIG_FILE})
+
+  nrfxlib_calculate_lib_path(lib_path)
+  set(OPENTHREAD_DST_DIR "${CMAKE_CURRENT_LIST_DIR}/${lib_path}/v${CONFIG_OPENTHREAD_THREAD_VERSION}")
+  set(OPENTHREAD_HEADERS_DIR "${ZEPHYR_OPENTHREAD_MODULE_DIR}/../include")
+
+  add_custom_target(install_openthread_libraries
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-ftd> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-mtd> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-radio> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-cli-ftd> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-cli-mtd> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-ncp-ftd> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-ncp-mtd> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:openthread-rcp> "${OPENTHREAD_DST_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      ${OPENTHREAD_HEADERS_DIR}
+      ${NRFXLIB_DIR}/openthread/include
+    COMMAND ${CMAKE_COMMAND} -E copy
+     ${OPENTHREAD_CONFIG_FILE}
+     ${NRFXLIB_DIR}/openthread/
+    )
+endif()
 
 if (CONFIG_OPENTHREAD_LIBRARY_1_1)
   set(version_dir "v1.1")

--- a/openthread/cmake/extensions.cmake
+++ b/openthread/cmake/extensions.cmake
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Store the configuration of the compiled OpenThread libraries
+# and set source and destination paths.
+function(openthread_libs_configuration_write CONFIG_FILE)
+  find_package(Git QUIET)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND           ${GIT_EXECUTABLE} rev-parse HEAD
+      WORKING_DIRECTORY ${ZEPHYR_OPENTHREAD_MODULE_DIR}
+      RESULT_VARIABLE   git_return
+      OUTPUT_VARIABLE   openthread_git_hash
+      )
+endif()
+
+  # Store all OT related variables
+  get_cmake_property(_variableNames VARIABLES)
+  foreach (_variableName ${_variableNames})
+    if("${_variableName}" MATCHES "^CONFIG_OPENTHREAD_.*|^OT_.*")
+      list(APPEND OPENTHREAD_SETTINGS "${_variableName}=${${_variableName}}\n")
+    endif()
+  endforeach()
+
+  list(SORT OPENTHREAD_SETTINGS)
+  list(INSERT OPENTHREAD_SETTINGS 0 "OpenThread_commit=${openthread_git_hash}\n")
+  FILE(WRITE ${CONFIG_FILE} ${OPENTHREAD_SETTINGS})
+
+endfunction(openthread_libs_configuration_write)


### PR DESCRIPTION
With this extension OpenThread libraries will be able to use OpenThread
stack build from source to overwrite the nrfxlib binaries.

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>

Functionality extracted from: https://github.com/nrfconnect/sdk-nrf/pull/2655