### PR TITLE
doc: clean up links to subpages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,25 +3,22 @@
 nrfxlib
 #######
 
-nrfxlib is a repository that contains RTOS-independent libraries and modules to be
-used with Nordic Semiconductor SoCs.
+nrfxlib is a repository that contains RTOS-independent libraries and modules to be used with Nordic Semiconductor SoCs.
 
-Supported SoCs
-**************
 
-Each library and module in this repository supports a different set of SoCs from Nordic
-Semiconductor. Refer to their respective documentation for more information.
+Each library and module in this repository supports a different set of SoCs from Nordic Semiconductor.
+Refer to their respective documentation for more information.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Libraries:
+   :caption: Contents:
 
    bsdlib/README
    crypto/README
    mpsl/README
-   nrf_security/README
    nfc/README
+   nrf_security/README
    openthread/README
+   nrf_rpc/README
    softdevice_controller/README
    zboss/README
-   nrf_rpc/README

--- a/bsdlib/README.rst
+++ b/bsdlib/README.rst
@@ -29,7 +29,7 @@ For more information, see :ref:`bsdlib_ug_porting`.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    doc/supported_features
    doc/limitations

--- a/bsdlib/doc/extensions.rst
+++ b/bsdlib/doc/extensions.rst
@@ -16,6 +16,7 @@ Extensions are available for:
 
 .. toctree::
    :maxdepth: 2
+   :caption: Subpages:
 
    pdn_extension
    at_commands

--- a/crypto/README.rst
+++ b/crypto/README.rst
@@ -5,7 +5,7 @@ Crypto Libraries
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    nrf_cc310_platform/CHANGELOG.rst
    nrf_cc310_bl/CHANGELOG

--- a/mpsl/README.rst
+++ b/mpsl/README.rst
@@ -33,7 +33,7 @@ This library provides the following key features:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    CHANGELOG
    doc/mpsl

--- a/nfc/README.rst
+++ b/nfc/README.rst
@@ -36,7 +36,7 @@ Each library is distributed in both soft-float and hard-float builds.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    CHANGELOG
    doc/integration_notes

--- a/nrf_rpc/README.rst
+++ b/nrf_rpc/README.rst
@@ -20,34 +20,8 @@ nRF RPC requires the Zephyr Project fork of TinyCBOR, because of API differences
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    doc/architecture
    doc/usage
-
-API documentation
-=================
-
-.. _nrf_rpc_core_api_documentation:
-
-Core API documentation
-----------------------
-
-This API uses pointers to raw packet data.
-:ref:`nrf_rpc_cbor_api_documentation` provides serialization layer over it that uses TinyCBOR.
-
-.. doxygengroup:: nrf_rpc
-   :project: nrfxlib
-   :members:
-
-.. _nrf_rpc_cbor_api_documentation:
-
-TinyCBOR API documentation
---------------------------
-
-This API is built on top of the core nRF RPC API and it is not independent.
-See :ref:`nrf_rpc_core_api_documentation` for more information on how to use nRF RPC together with TinyCBOR.
-
-.. doxygengroup:: nrf_rpc_cbor
-   :project: nrfxlib
-   :members:
+   doc/api

--- a/nrf_rpc/doc/api.rst
+++ b/nrf_rpc/doc/api.rst
@@ -1,0 +1,28 @@
+.. nrf_rpc_api:
+
+API documentation
+#################
+
+.. _nrf_rpc_core_api_documentation:
+
+Core API documentation
+----------------------
+
+This API uses pointers to raw packet data.
+:ref:`nrf_rpc_cbor_api_documentation` provides serialization layer over it that uses TinyCBOR.
+
+.. doxygengroup:: nrf_rpc
+   :project: nrfxlib
+   :members:
+
+.. _nrf_rpc_cbor_api_documentation:
+
+TinyCBOR API documentation
+--------------------------
+
+This API is built on top of the core nRF RPC API and it is not independent.
+See :ref:`nrf_rpc_core_api_documentation` for more information on how to use nRF RPC together with TinyCBOR.
+
+.. doxygengroup:: nrf_rpc_cbor
+   :project: nrfxlib
+   :members:

--- a/nrf_security/README.rst
+++ b/nrf_security/README.rst
@@ -10,7 +10,7 @@ hardware accelerated cryptography.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    doc/nrf_security
    doc/api

--- a/softdevice_controller/README.rst
+++ b/softdevice_controller/README.rst
@@ -81,7 +81,7 @@ Proprietary feature support:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    CHANGELOG
    doc/softdevice_controller


### PR DESCRIPTION
Make sure links to subpages are at the bottom of the page
and have a "Subpages:" heading.
Also, fix the order of libraries in the doc to be alphabetical.

Ref. NCSDK-6532

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>