### PR TITLE
nrf_security: fix warning when building nrf52833

### DIFF
--- a/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
+++ b/nrf_security/src/backend/nrf5x/entropy_nrf5x.c
@@ -14,7 +14,7 @@ int mbedtls_hardware_poll(void *data,
                           size_t len,
                           size_t *olen )
 {
-    struct device *dev;
+    const struct device *dev;
     size_t chunk_size;
 
     (void)data;


### PR DESCRIPTION
On latest zephyr upmerge consts were added to devices, however this file
was skipped.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>