### PR TITLE
MPSL and SDC on nrf53 can only run on the network core

### DIFF
--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -11,7 +11,7 @@ config MPSL
 	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
 	select NRF_802154_MULTIPROTOCOL_SUPPORT if NRF_802154_RADIO_DRIVER
 	select MULTITHREADING_LOCK
-	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
+	depends on (SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
 	help
 	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,
 	  providing services for single and multi-protocol implementations.

--- a/softdevice_controller/Kconfig
+++ b/softdevice_controller/Kconfig
@@ -43,7 +43,7 @@ config BT_LL_SOFTDEVICE
 	select BT_HAS_HCI_VS
 	# The SoftDevice Controller only supports nRF52 and nRF53, it does not support nRF51
 	# or nRF91 (nRF91 doesn't even have the physical HW needed for BLE).
-	depends on (SOC_SERIES_NRF52X || SOC_SERIES_NRF53X)
+	depends on (SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
 	help
 	  Use SoftDevice Link Layer implementation.
 
@@ -73,7 +73,7 @@ config SOFTDEVICE_CONTROLLER_S132
 	select BT_CTLR_ADV_EXT_SUPPORT
 
 config SOFTDEVICE_CONTROLLER_S140
-	depends on (SOC_NRF52811 || SOC_NRF52820 || SOC_NRF52840 || SOC_NRF52833 || SOC_SERIES_NRF53X)
+	depends on (SOC_NRF52811 || SOC_NRF52820 || SOC_NRF52840 || SOC_NRF52833 || SOC_NRF5340_CPUNET)
 	select BT_CTLR_DATA_LEN_UPDATE_SUPPORT
 	select BT_CTLR_ADV_EXT_SUPPORT
 	select BT_CTLR_PHY_CODED_SUPPORT


### PR DESCRIPTION
Manifest update: https://github.com/nrfconnect/sdk-nrf/pull/3294