### PR TITLE
nrf_security: Disabling CMAC gluing

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -177,8 +177,7 @@ if NRF_SECURITY_ANY_BACKEND
 config NRF_SECURITY_GLUE_LIBRARY
 	bool
 	depends on NRF_SECURITY_MULTI_BACKEND
-	depends on GLUE_MBEDTLS_AES_C || GLUE_MBEDTLS_CMAC_C || \
-			   GLUE_MBEDTLS_CCM_C || GLUE_MBEDTLS_DHM_C
+	depends on GLUE_MBEDTLS_AES_C || GLUE_MBEDTLS_CCM_C || GLUE_MBEDTLS_DHM_C
 	default y
 
 menuconfig NRF_SECURITY_RNG
@@ -571,7 +570,7 @@ config MBEDTLS_AES_256_CMAC_C
 
 config MBEDTLS_CMAC_ALT
 	bool
-	depends on CC3XX_MBEDTLS_CMAC_C || GLUE_MBEDTLS_CMAC_C
+	depends on CC3XX_MBEDTLS_CMAC_C
 	default y
 
 config CC3XX_MBEDTLS_CMAC_C
@@ -585,56 +584,41 @@ config VANILLA_MBEDTLS_CMAC_C
 
 if NRF_SECURITY_MULTI_BACKEND
 
-config GLUE_MBEDTLS_CMAC_C
+choice
 	bool
-	depends on GLUE_MBEDTLS_AES_C
-	default y
+	prompt "Backend selection"
+	depends on NRF_SECURITY_MULTI_BACKEND
+	default CHOICE_CC3XX_MBEDTLS_CMAC_C
 
-config GLUE_CC3XX_MBEDTLS_CMAC_C
-	bool
-	depends on CC3XX_MBEDTLS_AES_C
-	depends on GLUE_MBEDTLS_AES_C
-	default y
-
-config GLUE_OBERON_MBEDTLS_CMAC_C
-	bool
-	depends on OBERON_MBEDTLS_AES_C
-	depends on GLUE_MBEDTLS_AES_C
-	default y
-
-config GLUE_VANILLA_MBEDTLS_CMAC_C
-	bool
-	depends on VANILLA_MBEDTLS_AES_C
-	depends on GLUE_MBEDTLS_AES_C
-	default y
-
-config CC3XX_MBEDTLS_CMAC_C
+config CHOICE_CC3XX_MBEDTLS_CMAC_C
 	bool "cc310 (CMAC using AES-128)"
 	depends on CC3XX_MBEDTLS_AES_C && CC310_BACKEND
-	default y
+	select CC3XX_MBEDTLS_CMAC_C
 	help
 	  HW accelerated CMAC support using AES-128
 
-config CC3XX_MBEDTLS_CMAC_C
+config CHOICE_CC3XX_MBEDTLS_CMAC_C
 	bool "cc312 (CMAC using AES-128, AES-192, AES-256)"
 	depends on CC3XX_MBEDTLS_AES_C && CC312_BACKEND
-	default y
+	select CC3XX_MBEDTLS_CMAC_C
 	help
 	  HW accelerated CMAC support using AES-128, AES-192, AES-256
 
-config OBERON_MBEDTLS_CMAC_C
+config CHOICE_OBERON_MBEDTLS_CMAC_C
 	bool "nrf_oberon (CMAC using AES-128, AES-192, AES-256)"
 	depends on OBERON_MBEDTLS_AES_C
-	default y
+	select OBERON_MBEDTLS_CMAC_C
 	help
 	  CMAC support using AES-128, AES-192, AES-256
 
-config VANILLA_MBEDTLS_CMAC_C
+config CHOICE_VANILLA_MBEDTLS_CMAC_C
 	bool "mbed TLS (CMAC using AES-128, AES-192, AES-256)"
-	depends on VANILLA_MBEDTLS_AES_C && !OBERON_MBEDTLS_CMAC_C
-	default y
+	depends on VANILLA_MBEDTLS_AES_C
+	select VANILLA_MBEDTLS_CMAC_C
 	help
 	  CMAC support using AES-128, AES-192, AES-256
+
+endchoice # CMAC backend selection
 
 endif # NRF_SECURITY_MULTI_BACKEND (CMAC)
 
@@ -794,7 +778,7 @@ config VANILLA_MBEDTLS_CHACHA20_C
 choice
 	bool
 	prompt "Backend selection"
-	depends on 	NRF_SECURITY_MULTI_BACKEND
+	depends on NRF_SECURITY_MULTI_BACKEND
 	default CHOICE_CC3XX_MBEDTLS_CHACHA20_C
 
 config CHOICE_CC3XX_MBEDTLS_CHACHA20_C

--- a/nrf_security/doc/api.rst
+++ b/nrf_security/doc/api.rst
@@ -35,16 +35,6 @@ mbedcrypto AES CCM glue
    :members:
 
 
-.. _nrf_security_api_mbedcrypto_glue_cmac:
-
-mbedcrypto CMAC glue
-====================
-
-.. doxygengroup:: mbedcrypto_glue_cmac
-   :project: nrfxlib
-   :members:
-
-
 .. _nrf_security_api_mbedcrypto_glue_dhm:
 
 mbedcrypto DHM glue

--- a/nrf_security/doc/backend_config.rst
+++ b/nrf_security/doc/backend_config.rst
@@ -126,20 +126,19 @@ Multiple backends
 
 CMAC can be enabled by setting the :option:`CONFIG_MBEDTLS_CMAC_C` Kconfig variable, and one or more of the following Kconfig variables:
 
-+--------------+-----------------------------+-----------------------------------------------------------------+
-| Algorithm    | Support                     | Configurations                                                  |
-+==============+=============================+=================================================================+
-| CMAC         | Glue                        | cc3xx: :option:`CONFIG_CC3XX_MBEDTLS_CMAC_C`                    |
-|              |                             |                                                                 |
-|              |                             | nrf_oberon: :option:`CONFIG_OBERON_MBEDTLS_CMAC_C`              |
-|              |                             |                                                                 |
-|              |                             | Original mbed TLS: :option:`CONFIG_VANILLA_MBEDTLS_CMAC_C`      |
-+--------------+-----------------------------+-----------------------------------------------------------------+
++--------------+-----------------------------+--------------------------------------------------------------------+
+| Algorithm    | Support                     | Configurations                                                     |
++==============+=============================+====================================================================+
+| CMAC         | Choice                      | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_CMAC_C`                |
+|              |                             |                                                                    |
+|              |                             | nrf_oberon: :option:`CONFIG_CHOICE_OBERON_MBEDTLS_CMAC_C`          |
+|              |                             |                                                                    |
+|              |                             | Original mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_CMAC_C`  |
++--------------+-----------------------------+--------------------------------------------------------------------+
 
 .. note::
+   * For features provided with :ref:`Choice<nrf_security_backend_config_multiple>` support, the enabled backend that is first in order is selected by default.
    * The :ref:`nrf_security_backends_cc3xx` is limited to key sizes of 128 bits on devices with Arm CryptoCell cc310.
-   * If both :ref:`nrf_security_backends_oberon` and :ref:`nrf_security_backends_orig_mbedtls` is enabled, the implementation from
-     nrf_oberon backend will provide support for CMAC.
 
 AEAD configurations
 *******************

--- a/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
@@ -25,10 +25,6 @@ if(CONFIG_NRF_SECURITY_GLUE_LIBRARY)
     nrf_security_debug("Adding to glue: CCM")
   endif()
 
-  if(CONFIG_GLUE_MBEDTLS_CMAC_C)
-    nrf_security_debug("Adding to glue: CMAC")
-  endif()
-
   if(CONFIG_GLUE_MBEDTLS_DHM_C)
     nrf_security_debug("Adding to glue: DHM")
   endif()

--- a/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
@@ -16,9 +16,6 @@ zephyr_library_sources_ifdef(CONFIG_GLUE_CC3XX_MBEDTLS_AES_C
 zephyr_library_sources_ifdef(CONFIG_GLUE_CC3XX_MBEDTLS_CCM_C
   ${CMAKE_CURRENT_LIST_DIR}/ccm_cc310.c
 )
-zephyr_library_sources_ifdef(CONFIG_GLUE_CC3XX_MBEDTLS_CMAC_C
-  ${CMAKE_CURRENT_LIST_DIR}/cmac_cc310.c
-)
 zephyr_library_sources_ifdef(CONFIG_GLUE_CC3XX_MBEDTLS_DHM_C
   ${CMAKE_CURRENT_LIST_DIR}/dhm_cc310.c
 )

--- a/nrf_security/src/mbedcrypto_glue/oberon/oberon_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/oberon/oberon_glue.cmake
@@ -21,10 +21,6 @@ zephyr_library_sources_ifdef(CONFIG_GLUE_OBERON_MBEDTLS_CCM_C
   ${CMAKE_CURRENT_LIST_DIR}/ccm_oberon.c
 )
 
-zephyr_library_sources_ifdef(CONFIG_GLUE_OBERON_MBEDTLS_CMAC_C
-  ${CMAKE_CURRENT_LIST_DIR}/cmac_oberon.c
-)
-
 zephyr_library_sources(${ZEPHYR_BASE}/misc/empty_file.c)
 zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=oberon)
 zephyr_library_link_libraries(mbedtls_common_glue)

--- a/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
@@ -19,9 +19,6 @@ zephyr_library_sources_ifdef(CONFIG_GLUE_VANILLA_MBEDTLS_AES_C
 zephyr_library_sources_ifdef(CONFIG_GLUE_VANILLA_MBEDTLS_CCM_C
   ${CMAKE_CURRENT_LIST_DIR}/ccm_vanilla.c
 )
-zephyr_library_sources_ifdef(CONFIG_GLUE_VANILLA_MBEDTLS_CMAC_C
-  ${CMAKE_CURRENT_LIST_DIR}/cmac_vanilla.c
-)
 zephyr_library_sources_ifdef(CONFIG_GLUE_VANILLA_MBEDTLS_DHM_C
   ${CMAKE_CURRENT_LIST_DIR}/dhm_vanilla.c
 )


### PR DESCRIPTION
-Disabling CMAC glue in nrf_security due to memory complexities
-Changed CMAC: "Glue" => "Choice" (single backend enabled)
-Added CHOICE_XXXX_MBEDTLS_CMAC_C for backend selection in Kconfig
-Updated documentation for CMAC: "Glue" => "Choice"

manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/3122

ref: NCSDK-5883

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>