### PR TITLE
doc: change zboss api doc link

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -22,7 +22,7 @@
 
 .. _`Socket API`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
 
-.. _`ZBOSS API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss_api_doc/index.html
+.. _`ZBOSS API documentation`: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/zboss/index.html
 
 .. _`mbed TLS backend`: https://tls.mbed.org/
 


### PR DESCRIPTION
Point to a common landing page on developer.nordicsemi.com
that contains links to different ZBOSS versions.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>