### PR TITLE
bsdlib: doc: added missing link between doxygen section and sphinx

### DIFF
--- a/bsdlib/doc/api.rst
+++ b/bsdlib/doc/api.rst
@@ -116,6 +116,13 @@ Power save mode enumerator
    :project: nrfxlib
    :members:
 
+Use case enumerator
+===================
+
+.. doxygengroup:: nrf_socket_gnss_use_case_modes
+   :project: nrfxlib
+   :members:
+
 GNSS socket data frames
 =======================
 


### PR DESCRIPTION
A link between a new doxygen group in the bsdlib header file and
a api.rst restructured text file was missing. So this group doesn̈́'t
appear in the public documentation online.

Manifest update: https://github.com/nrfconnect/sdk-nrf/pull/3288

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>