### PR TITLE
Nrf security cmake archiving fixes

### DIFF
--- a/nrf_security/cmake/combine_archives.cmake
+++ b/nrf_security/cmake/combine_archives.cmake
@@ -15,21 +15,22 @@ function(combine_archives output_archive input_archives)
   nrf_security_debug("Combining libraries to: ${output_archive}")
   set(mri_file ${CMAKE_CURRENT_BINARY_DIR}/${output_archive}.mri)
   nrf_security_debug("mri_file: ${mri_file}")
- 
+
+  set(COUNT 0)
   foreach(in_archive ${input_archives})
-    list(APPEND input_archives_path "$<TARGET_FILE:${in_archive}>")
+    list(APPEND archives_in -DARCHIVES_IN_${COUNT}=$<TARGET_FILE:${in_archive}>)
     nrf_security_debug("Adding ${in_archive} to ${output_archive}")
+    math(EXPR COUNT "${COUNT} + 1" OUTPUT_FORMAT DECIMAL)
   endforeach()
 
   add_library(${output_archive} STATIC ${ZEPHYR_BASE}/misc/empty_file.c)
   add_dependencies(${output_archive} ${input_archives})
-
   add_custom_command(TARGET ${output_archive}
                      POST_BUILD
                      COMMAND ${CMAKE_COMMAND}
-		             -DCMAKE_AR=${CMAKE_AR}
-			     -DARCHIVE_OUT=${CMAKE_CURRENT_BINARY_DIR}/lib${output_archive}.a
-			     -DARCHIVES_IN="${input_archives_path}"
-			     -P ${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_security/cmake/combine_archives_script.cmake
+                             -DCMAKE_AR=${CMAKE_AR}
+                             -DARCHIVE_OUT=${CMAKE_CURRENT_BINARY_DIR}/lib${output_archive}.a
+                             ${archives_in}
+                             -P ${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_security/cmake/combine_archives_script.cmake
   )
 endfunction(combine_archives)

--- a/nrf_security/cmake/combine_archives.cmake
+++ b/nrf_security/cmake/combine_archives.cmake
@@ -5,40 +5,38 @@
 #
 
 #
-# Function to combine multiple libraries to one single
-# This uses CMAKE_AR and an MRI script to combine multiple libraries
+# Function to combine multiple nrf security libraries to one single backend library
+# This uses CMAKE_AR to combine multiple libraries
 #
 # Items in the list "input_archives" will be resolved by the generator
 # expression $<TARGET_FILE:library_name>
 #
-function(combine_archives output_archive input_archives)
-  nrf_security_debug("Combining libraries to: ${output_archive}")
-  set(mri_file ${CMAKE_CURRENT_BINARY_DIR}/${output_archive}.mri)
-  nrf_security_debug("mri_file: ${mri_file}")
+function(nrf_security_combine_archives backend input_archives)
+  nrf_security_debug("Combining libraries to: mbedcrypto_${backend}")
 
   set(COUNT 0)
   foreach(in_archive ${input_archives})
     list(APPEND archives_in -DARCHIVES_IN_${COUNT}=$<TARGET_FILE:${in_archive}>)
-    nrf_security_debug("Adding ${in_archive} to ${output_archive}")
+    nrf_security_debug("Adding ${in_archive} to mbedcrypto_${backend}")
     math(EXPR COUNT "${COUNT} + 1" OUTPUT_FORMAT DECIMAL)
   endforeach()
 
   # This interface library allows other targets to link to the custom generated library.
-  # Together with the custom ${output_archive}_target this ensures that dependencies
-  # are setup so that linking with ${output_archive} will drive the dependencies.
-  add_library(${output_archive} INTERFACE)
-  target_link_libraries(${output_archive} INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/lib${output_archive}.a)
-  add_dependencies(${output_archive} ${output_archive}_target)
+  # Together with the custom mbedcrypto_${backend}_target this ensures that dependencies
+  # are setup so that linking with mbedcrypto_${backend} will drive the dependencies.
+  add_library(mbedcrypto_${backend} INTERFACE)
+  target_link_libraries(mbedcrypto_${backend} INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/libmbedcrypto_${backend}.a)
+  add_dependencies(mbedcrypto_${backend} mbedcrypto_${backend}_target)
 
-  add_custom_target(${output_archive}_target DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${output_archive}.a)
+  add_custom_target(mbedcrypto_${backend}_target DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libmbedcrypto_${backend}.a)
 
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib${output_archive}.a
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libmbedcrypto_${backend}.a
                      COMMAND ${CMAKE_COMMAND}
                              -DCMAKE_AR=${CMAKE_AR}
-                             -DARCHIVE_OUT=${CMAKE_CURRENT_BINARY_DIR}/lib${output_archive}.a
+                             -DARCHIVE_OUT=${CMAKE_CURRENT_BINARY_DIR}/libmbedcrypto_${backend}.a
                              ${archives_in}
                              -P ${ZEPHYR_NRFXLIB_MODULE_DIR}/nrf_security/cmake/combine_archives_script.cmake
                      ${strip_command}
                      DEPENDS ${in_archive}
   )
-endfunction(combine_archives)
+endfunction(nrf_security_combine_archives)

--- a/nrf_security/cmake/combine_archives_script.cmake
+++ b/nrf_security/cmake/combine_archives_script.cmake
@@ -10,18 +10,19 @@
 #
 set(ARCHIVE_WORK_DIR ${CMAKE_CURRENT_BINARY_DIR}/extracted_archives)
 
-string(REPLACE " " ";" list "${ARCHIVES_IN}")
 file(WRITE ${ARCHIVE_WORK_DIR}/archive_content.txt "")
 
-foreach(archive ${list})
+set(COUNT 0)
+while(ARCHIVES_IN_${COUNT})
   execute_process(
-    COMMAND ${CMAKE_AR} x ${archive}
-    COMMAND ${CMAKE_AR} t ${archive}
+    COMMAND ${CMAKE_AR} x ${ARCHIVES_IN_${COUNT}}
+    COMMAND ${CMAKE_AR} t ${ARCHIVES_IN_${COUNT}}
     OUTPUT_VARIABLE archive_content
     WORKING_DIRECTORY ${ARCHIVE_WORK_DIR}
   )
   file(APPEND ${ARCHIVE_WORK_DIR}/archive_content.txt "${archive_content}")
-endforeach()
+  math(EXPR COUNT "${COUNT} + 1" OUTPUT_FORMAT DECIMAL)
+endwhile()
 
 file(STRINGS ${ARCHIVE_WORK_DIR}/archive_content.txt content)
 execute_process(

--- a/nrf_security/cmake/symbol_rename.cmake
+++ b/nrf_security/cmake/symbol_rename.cmake
@@ -78,10 +78,13 @@ function(symbol_rename_func backend rename_template)
 
   set(BACKEND_RENAMED_LIBRARY libmbedcrypto_${MBEDTLS_BACKEND_PREFIX}_renamed.a)
 
+  get_target_property(LIB_TYPE mbedcrypto_${MBEDTLS_BACKEND_PREFIX} TYPE)
+
   add_custom_command(
     OUTPUT  ${BACKEND_RENAMED_LIBRARY}
     COMMAND ${CMAKE_OBJCOPY} ${redefine_line}
-            $<TARGET_FILE:mbedcrypto_${MBEDTLS_BACKEND_PREFIX}>
+            $<$<STREQUAL:INTERFACE_LIBRARY,${LIB_TYPE}>:$<TARGET_PROPERTY:mbedcrypto_${MBEDTLS_BACKEND_PREFIX},INTERFACE_LINK_LIBRARIES>>
+            $<$<NOT:$<STREQUAL:INTERFACE_LIBRARY,${LIB_TYPE}>>:$<TARGET_FILE:mbedcrypto_${MBEDTLS_BACKEND_PREFIX}>>
             ${BACKEND_RENAMED_LIBRARY}
     DEPENDS mbedcrypto_${MBEDTLS_BACKEND_PREFIX}
             ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${MBEDTLS_BACKEND_PREFIX}.txt
@@ -94,7 +97,7 @@ function(symbol_rename_func backend rename_template)
                    ${MBEDTLS_BACKEND_PREFIX}_renamed_target)
   set_target_properties(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_renamed
                         PROPERTIES IMPORTED_LOCATION
-                        "${CMAKE_CURRENT_BINARY_DIR}/${BACKEND_RENAMED_LIBRARY}")
+                        ${CMAKE_CURRENT_BINARY_DIR}/${BACKEND_RENAMED_LIBRARY})
 
   zephyr_append_cmake_library(mbedcrypto_${MBEDTLS_BACKEND_PREFIX}_renamed)
 endfunction()

--- a/nrf_security/cmake/symbol_rename.cmake
+++ b/nrf_security/cmake/symbol_rename.cmake
@@ -45,8 +45,8 @@ endmacro()
 # This function will create a symbol renaming script for any library
 # named mbedcrypto_<backend> corresponding to the parameter "backend"
 #
-function(symbol_rename_func backend rename_template)
-  nrf_security_debug("========== Running symbol_rename_func for ${backend} ==========")
+function(nrf_security_symbol_rename backend rename_template)
+  nrf_security_debug("========== Running nrf_security_symbol_rename for ${backend} ==========")
   string(TOUPPER "${backend}" BACKEND_NAME)
   #
   # Functionality that can be glued

--- a/nrf_security/cmake/symbol_strip.cmake
+++ b/nrf_security/cmake/symbol_strip.cmake
@@ -30,11 +30,10 @@ endmacro()
 # If is_stripped is "TRUE" this function will strip symbols from any library
 # named mbedcrypto_<backend> corresponding to the parameter "backend"
 #
-function(symbol_strip_func backend)
+function(symbol_strip_func backend strip_command)
   nrf_security_debug("========== Running symbol_strip_function for ${backend} ==========")
   string(TOUPPER "${backend}" BACKEND_NAME_UPPER)
 
-  remove_objects("${BACKEND_NAME_UPPER}_ENABLED"   ${BACKEND_NAME_UPPER} remove_line "empty_file.c.obj")
   remove_objects("MBEDTLS_AES_C"        ${BACKEND_NAME_UPPER} remove_line "aes.c.obj")
   remove_objects("MBEDTLS_AES_C"        ${BACKEND_NAME_UPPER} remove_line "aes_alt.c.obj")
   remove_objects("MBEDTLS_CCM_C"        ${BACKEND_NAME_UPPER} remove_line "ccm.c.obj")
@@ -68,15 +67,9 @@ function(symbol_strip_func backend)
   set(BACKEND_LIBRARY libmbedcrypto_${backend}.a)
 
   if (remove_line)
-    set(remove_object_command ${CMAKE_AR} d ${BACKEND_LIBRARY} ${remove_line})
+    set(${strip_command} COMMAND ${CMAKE_AR} d ${BACKEND_LIBRARY} ${remove_line} PARENT_SCOPE)
     nrf_security_debug("Objects stripped from mbedcrypto_${backend}: ${remove_line}")
   else()
     nrf_security_debug("No remove_line from mbedcrypto_${backend}")
   endif()
-
-  add_custom_command(
-    TARGET mbedcrypto_${backend}
-    POST_BUILD
-    COMMAND ${remove_object_command}
-  )
 endfunction()

--- a/nrf_security/cmake/symbol_strip.cmake
+++ b/nrf_security/cmake/symbol_strip.cmake
@@ -30,7 +30,7 @@ endmacro()
 # If is_stripped is "TRUE" this function will strip symbols from any library
 # named mbedcrypto_<backend> corresponding to the parameter "backend"
 #
-function(symbol_strip_func backend strip_command)
+function(nrf_security_symbol_strip backend strip_command)
   nrf_security_debug("========== Running symbol_strip_function for ${backend} ==========")
   string(TOUPPER "${backend}" BACKEND_NAME_UPPER)
 

--- a/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
@@ -105,19 +105,19 @@ endif(CONFIG_NRF_SECURITY_GLUE_LIBRARY)
 # CC310: Rename glued symbols to prevent collision
 #
 if (CONFIG_CC3XX_BACKEND)
-  symbol_rename_func("cc3xx" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
+  nrf_security_symbol_rename("cc3xx" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
 endif()
 
 #
 # nrf_oberon: Rename glued symbols to prevent collisions
 #
 if (CONFIG_OBERON_BACKEND AND CONFIG_NRF_SECURITY_GLUE_LIBRARY)
-  symbol_rename_func("oberon" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
+  nrf_security_symbol_rename("oberon" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
 endif()
 
 #
 # Vanilla: Rename glued symbols to prevent collision
 #
 if (CONFIG_MBEDTLS_VANILLA_BACKEND AND CONFIG_NRF_SECURITY_GLUE_LIBRARY)
-  symbol_rename_func("vanilla" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
+  nrf_security_symbol_rename("vanilla" ${CMAKE_CURRENT_LIST_DIR}/symbol_rename.template.txt)
 endif()

--- a/nrf_security/src/mbedtls/cc310/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/cc310/CMakeLists.txt
@@ -54,8 +54,8 @@ set(cc3xx_libs
   mbedcrypto_cc3xx_noglue
 )
 
-combine_archives(mbedcrypto_cc3xx "${cc3xx_libs}")
-symbol_strip_func(cc3xx)
+symbol_strip_func(cc3xx strip_command)
+combine_archives(mbedcrypto_cc3xx "${cc3xx_libs}" "${strip_command}")
 
 #
 # Copy alternate files to generated folder (if enabled in backend)

--- a/nrf_security/src/mbedtls/cc310/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/cc310/CMakeLists.txt
@@ -54,8 +54,8 @@ set(cc3xx_libs
   mbedcrypto_cc3xx_noglue
 )
 
-symbol_strip_func(cc3xx strip_command)
-combine_archives(mbedcrypto_cc3xx "${cc3xx_libs}" "${strip_command}")
+nrf_security_symbol_strip(cc3xx strip_command)
+nrf_security_combine_archives(cc3xx "${cc3xx_libs}" "${strip_command}")
 
 #
 # Copy alternate files to generated folder (if enabled in backend)

--- a/nrf_security/src/mbedtls/oberon/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/oberon/CMakeLists.txt
@@ -115,8 +115,8 @@ set(oberon_libs
 # Create the actual mbedcrypto_oberon library containing
 # all backend-specific
 #
-combine_archives(mbedcrypto_oberon "${oberon_libs}")
-symbol_strip_func(oberon)
+symbol_strip_func(oberon strip_command)
+combine_archives(mbedcrypto_oberon "${oberon_libs}" "${strip_command}")
 
 #
 # Copy the replacement _alt.h files by from nrf_oberon by enabled feature

--- a/nrf_security/src/mbedtls/oberon/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/oberon/CMakeLists.txt
@@ -115,8 +115,8 @@ set(oberon_libs
 # Create the actual mbedcrypto_oberon library containing
 # all backend-specific
 #
-symbol_strip_func(oberon strip_command)
-combine_archives(mbedcrypto_oberon "${oberon_libs}" "${strip_command}")
+nrf_security_symbol_strip(oberon strip_command)
+nrf_security_combine_archives(oberon "${oberon_libs}" "${strip_command}")
 
 #
 # Copy the replacement _alt.h files by from nrf_oberon by enabled feature


### PR DESCRIPTION
Headlines in this PR:

Using custom target for combined backend libraries
- Removes empty_file.c
- Remove need for POST_BUILD

Changing list into individual CMake arguments when combining libraries
- Fixes issues with quoting of lists

CMake code cleanup

--------
Manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/3298