### PR TITLE
nrf_security: Add module for storing keys in flash memory

### DIFF
--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -51,3 +51,5 @@ if (CONFIG_NRF_SECURITY_MULTI_BACKEND)
   # b. vanilla selection of ciphers only --> Renaming, but no glue
   add_subdirectory(src/mbedcrypto_glue)
 endif()
+
+add_subdirectory_ifdef(CONFIG_SST_SETTINGS sst_settings)

--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1524,6 +1524,9 @@ config MBEDTLS_SSL_CIPHERSUITES
 	  Warning: This field has offers no validation checks.
 	  MBEDTLS_SSL_CIPHERSUITES setting in mbed TLS config file.
 
+
+rsource "sst_settings/Kconfig"
+
 endif # NRF_SECURITY_ADVANCED
 
 endif # NRF_SECURITY_ANY_BACKEND

--- a/nrf_security/sst_settings/CMakeLists.txt
+++ b/nrf_security/sst_settings/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+zephyr_library_sources(sst_settings.c)
+zephyr_include_directories(.)

--- a/nrf_security/sst_settings/Kconfig
+++ b/nrf_security/sst_settings/Kconfig
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+config SST_SETTINGS
+	bool "Settings module for Secure Storage"
+	help
+	  Enable to get access for flashin operation based on Settings subsys.
+
+if SST_SETTINGS
+
+module = SST_SETTINGS
+module-str = Secure Storage Settings
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif

--- a/nrf_security/sst_settings/sst_settings.c
+++ b/nrf_security/sst_settings/sst_settings.c
@@ -1,0 +1,134 @@
+#include <zephyr.h>
+#include <logging/log.h>
+#include <settings/settings.h>
+
+#include "sst_settings.h"
+
+LOG_MODULE_REGISTER(sst_settings, CONFIG_SST_SETTINGS_LOG_LEVEL);
+
+#define ROOT_KEY "SST"
+#define MAX_PATH_LEN 32
+
+struct read_ctx {
+	/* Buffer for the setting. */
+	void *buff;
+
+	/* Buffer length. */
+	size_t buff_len;
+
+	/* Operation result. */
+	int status;
+};
+
+static int read_cb(const char *name, size_t len, settings_read_cb read_cb,
+		   void *cb_arg, void *param)
+{
+	int ret;
+	const char *next;
+	size_t name_len;
+	struct read_ctx *ctx = (struct read_ctx *)param;
+
+	__ASSERT(ctx->buff != NULL, "Improper value");
+
+	name_len = settings_name_next(name, &next);
+	if (name_len == 0 && len <= ctx->buff_len) {
+		ret = read_cb(cb_arg, ctx->buff, len);
+		if (ret <= 0) {
+			LOG_ERR("Failed to read the setting, ret: %d", ret);
+		}
+
+		ctx->status = ret;
+
+		return 0;
+	}
+	LOG_WRN("The setting is not present in the storage.");
+
+	/* The settings is not found, return error and stop processing */
+	return -ENOENT;
+}
+
+static int delete_cb(const char *key, size_t len, settings_read_cb read_cb,
+		     void *cb_arg, void *param)
+{
+	int ret;
+	char path[MAX_PATH_LEN];
+
+	ARG_UNUSED(len);
+	ARG_UNUSED(read_cb);
+	ARG_UNUSED(cb_arg);
+	ARG_UNUSED(param);
+
+	ret = snprintk(path, sizeof(path), "%s/%s", ROOT_KEY, key);
+	__ASSERT(ret < sizeof(path), "Setting path buffer too small.");
+
+	LOG_DBG("Removing: %s", log_strdup(path));
+
+	return settings_delete(path);
+}
+
+int sst_settings_init(void)
+{
+	return settings_subsys_init();
+}
+
+int sst_settings_get(uint32_t key, void *buff, size_t buff_len)
+{
+	int ret;
+	char path[MAX_PATH_LEN];
+	struct read_ctx read_ctx = {
+		.buff = buff,
+		.buff_len = buff_len,
+		.status = -ENOENT,
+	};
+
+	LOG_DBG("Getting key: 0x%x", key);
+
+	ret = snprintk(path, sizeof(path), "%s/%x", ROOT_KEY, key);
+	__ASSERT(ret < sizeof(path), "Setting path buffer too small.");
+
+	ret = settings_load_subtree_direct(path, read_cb, &read_ctx);
+	if (ret != 0) {
+		LOG_ERR("Failed to load setting key %d, ret %d", key, ret);
+	}
+
+	return read_ctx.status;
+}
+
+int sst_settings_set(uint32_t key, const void *buff, size_t buff_len)
+{
+	int ret;
+	char path[MAX_PATH_LEN];
+
+	LOG_DBG("Setting key: 0x%x", key);
+
+	ret = snprintk(path, sizeof(path), "%s/%x", ROOT_KEY, key);
+	__ASSERT(ret < sizeof(path), "Setting path buffer too small.");
+
+	ret = settings_save_one(path, buff, buff_len);
+	if (ret != 0) {
+		LOG_ERR("Failed to store setting %d, ret %d", key, ret);
+		return -1;
+	}
+
+	return 0;
+}
+
+int sst_settings_delete(uint32_t key)
+{
+	int ret;
+	char path[MAX_PATH_LEN];
+
+	ret = snprintk(path, sizeof(path), "%s/%x", ROOT_KEY, key);
+	__ASSERT(ret < sizeof(path), "Setting path buffer too small.");
+
+	LOG_DBG("Removing: %s", log_strdup(path));
+
+	return settings_delete(path);
+}
+
+int sst_settings_delete_all(void)
+{
+	LOG_DBG("Removing all keys from: %s", ROOT_KEY);
+
+	return settings_load_subtree_direct(ROOT_KEY, delete_cb, NULL);
+}

--- a/nrf_security/sst_settings/sst_settings.h
+++ b/nrf_security/sst_settings/sst_settings.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef SST_SETTINGS_H_
+#define SST_SETTINGS_H_
+
+#include <zephyr/types.h>
+
+/**
+ * Performs any initialization for the settings subsystem.
+ *
+ */
+int sst_settings_init(void);
+
+/// Fetches the value of a setting
+/** This function fetches the value of the setting identified
+ *  by key and write it to the memory pointed to by buff.
+ *
+ *  @param[in]     key       The key associated with the requested setting.
+ *  @param[out]    buff      A pointer to where the value of the setting should be written.
+ *  @param[inout]  buff_len  A pointer to the length of the buff. When called, this pointer should point to an
+ *                           integer containing the maximum value size that can be written to buff.
+ *
+ *  @retval > 0: Number of bytes read. The given setting was found and fetched successfully.
+ *  @retval <= 0: The given setting was not found in the setting store.
+ */
+int sst_settings_get(uint32_t key, void *buff, size_t buff_len);
+
+/// Sets or replaces the value of a setting
+/** This function sets or replaces the value of a setting
+ *  identified by key.
+ *
+ *  @param[in]  key       The key associated with the setting to change.
+ *  @param[in]  buff      A pointer to where the new value of the setting should be read from.
+ *  @param[in]  buff_len  The length of the buffer pointed to by buff.
+ *
+ *  @retval 0   The given setting was set.
+ *  @retval !=  The setting failed.
+ */
+int sst_settings_set(uint32_t key, const void *buff, size_t buff_len);
+
+/// Removes a setting from the setting store
+/** This function deletes a specific value from the
+ *  setting identified by key from the settings store.
+ *
+ *  @param[in] key       The key associated with the requested setting.
+ *
+ *  @retval 0 on success.
+ *  @retval non-zero on failure.
+ */
+int sst_settings_delete(uint32_t key);
+
+/// Removes all settings from the setting store
+/** This function deletes all settings from the settings
+ *  store.
+ */
+int sst_settings_delete_all(void);
+
+#endif // SST_SETTINGS_H_


### PR DESCRIPTION
The sst_settings module make use of Zephyr's "settings" module for providing access to persistent storage in a key/value manner.