### PR TITLE
crypto: Add atomic variant for CC310 locking

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -34,6 +34,31 @@ if NRF_CC3XX_PLATFORM
 config HW_CC3XX_INTERRUPT
 	bool "Use interrupt version of nrf cc3xx platform library" if !(CC3XX_BACKEND || NRF_CC310_BL)
 
+choice CC3XX_LOCK_VARIANT
+	prompt "CC3XX lock variant"
+	default CC3XX_MUTEX_LOCK
+
+config CC3XX_MUTEX_LOCK
+	bool "Use mutex variables for mutually exclusive access to CC3XX resources"
+	help
+	  Enables exclusive access to the ARM CryptoCell hardware using an RTOS
+	  mutex that has priority inheritance. The mutex lock is safe across threads
+	  and/or interrupts with different priority. Using an RTOS mutex comes
+	  at a cost of lower performance.
+
+config CC3XX_ATOMIC_LOCK
+	bool "Use atomic variables for mutually exclusive access to CC3XX resources"
+	help
+	  Using atomic operations is the fastest way to ensure mutually exclusive
+	  access to the ARM CryptoCell hardware.
+	  Warning: If this configuration is set, every execution requiring use of
+	  the ARM CryptoCell hardware must happen in the same priority. Calling into
+	  mbed TLS APIs from a higher priority while an ongoing operation will lead
+	  to undefined behavior. It is highy recommended to to do all cryptographic
+	  operations in one single thread if this configuration is set.
+
+endchoice
+
 endif
 
 endmenu

--- a/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_mutex.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_mutex.h
@@ -26,6 +26,7 @@ extern "C"
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_INVALID        (0)         /*!< Mask indicating that the mutex is invalid (not initialized or allocated). */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_VALID       (1<<0)      /*!< Mask value indicating that the mutex is valid for use. */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ALLOCATED   (1<<1)      /*!< Mask value indicating that the mutex is allocated and requires deallocation once freed. */
+#define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ATOMIC      (1<<2)      /*!< Mask value indicating that the mutex is atomic type */
 
 /** @brief Type definition of architecture neutral mutex type */
 typedef struct nrf_cc3xx_platform_mutex

--- a/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_mutex.h
+++ b/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_mutex.h
@@ -26,6 +26,7 @@ extern "C"
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_INVALID        (0)         /*!< Mask indicating that the mutex is invalid (not initialized or allocated). */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_VALID       (1<<0)      /*!< Mask value indicating that the mutex is valid for use. */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ALLOCATED   (1<<1)      /*!< Mask value indicating that the mutex is allocated and requires deallocation once freed. */
+#define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ATOMIC      (1<<2)      /*!< Mask value indicating that the mutex is atomic type */
 
 /** @brief Type definition of architecture neutral mutex type */
 typedef struct nrf_cc3xx_platform_mutex

--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -51,6 +51,7 @@ config GENERATE_MBEDTLS_CFG_FILE
 config MBEDTLS_X509_LIBRARY
 	bool
 	prompt "Create mbed TLS x509 library"
+	select MBEDTLS_PK_C
 	help
 	  Create the mbed x509 library for handling of certificates.
 
@@ -1554,6 +1555,18 @@ config MBEDTLS_SSL_CIPHERSUITES
 	  This list can only be used for restricting cipher suites available in the system.
 	  Warning: This field has offers no validation checks.
 	  MBEDTLS_SSL_CIPHERSUITES setting in mbed TLS config file.
+
+config MBEDTLS_PK_C
+	bool "PK - Enable the generic public (asymetric) key layer"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable generic public key wrappers.
+
+config MBEDTLS_PK_WRITE_C
+	bool "Enable the generic public (asymetric) key writer"
+	depends on MBEDTLS_PK_C
+	help
+	  Enable generic public key write functions.
 
 endif # NRF_SECURITY_ADVANCED
 


### PR DESCRIPTION
New lock variant fasten mutually exclusive access to CC3XX resources at the expense of a need to handle potential access failure
in the upper layer.

needed by: https://github.com/nrfconnect/sdk-nrf/pull/3339