### PR TITLE
Fixes for Doxygen 1.8.17

### DIFF
--- a/bsdlib/include/nrf_socket.h
+++ b/bsdlib/include/nrf_socket.h
@@ -1516,5 +1516,3 @@ int nrf_setdnsaddr(int family, const void *in_addr);
 #endif
 
 #endif // NRF_SOCKET_H__
-
-/**@} */

--- a/crypto/nrf_cc310_platform/include/nrf_cc310_platform.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc310_platform.h
@@ -34,5 +34,3 @@ extern "C"
 #endif
 
 #endif /* NRF_CC310_PLATFORM_H__ */
-
-/** @} */

--- a/crypto/nrf_cc310_platform/include/nrf_cc310_platform_abort.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc310_platform_abort.h
@@ -18,6 +18,4 @@
 
 #define nrf_cc310_platform_abort_init nrf_cc3xx_platform_abort_init
 
-#endif /* NRF_CC310_PLATFORM_DEFINES_H__ */
-
-/** @} */
+#endif /* NRF_CC310_PLATFORM_ABORT_H__ */

--- a/crypto/nrf_cc310_platform/include/nrf_cc310_platform_defines.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc310_platform_defines.h
@@ -32,5 +32,3 @@ extern "C"
 #endif
 
 #endif /* NRF_CC310_PLATFORM_DEFINES_H__ */
-
-/** @} */

--- a/crypto/nrf_cc310_platform/include/nrf_cc310_platform_entropy.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc310_platform_entropy.h
@@ -21,5 +21,3 @@ extern "C"
 #endif
 
 #endif /* NRF_CC310_PLATFORM_ENTROPY_H__ */
-
-/** @} */

--- a/crypto/nrf_cc310_platform/include/nrf_cc310_platform_mutex.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc310_platform_mutex.h
@@ -40,6 +40,4 @@ extern "C"
 }
 #endif
 
-#endif /* NRF_CC3XX_PLATFORM_MUTEX_H__ */
-
-/** @} */
+#endif /* NRF_CC310_PLATFORM_MUTEX_H__ */

--- a/nfc/include/nfc_t4t_lib.h
+++ b/nfc/include/nfc_t4t_lib.h
@@ -206,8 +206,7 @@ int nfc_t4t_setup(nfc_t4t_callback_t callback, void *context);
  * @param buffer_length Length of buffer (maximum writable NDEF size)
  *
  * @retval 0 Success.
- * @retval -EINVAL Invalid argument (e.g. wrong data length).
- * @retval -EINVAL Invalid argument (e.g. NULL pointer).
+ * @retval -EINVAL Invalid argument (e.g. wrong data length, NULL pointer).
  * @retval -ENOTSUP If the new buffer has a different length than the first one.
  * @retval -EFAULT If the provided buffer is the currently used buffer.
  */
@@ -225,8 +224,7 @@ int nfc_t4t_ndef_rwpayload_set(uint8_t *emulation_buffer,
  * @param buffer_length Length of contained NDEF payload message
  *
  * @retval 0 Success.
- * @retval -EINVAL Invalid argument (e.g. wrong data length).
- * @retval -EINVAL Invalid argument (e.g. NULL pointer).
+ * @retval -EINVAL Invalid argument (e.g. wrong data length, NULL pointer).
  * @retval -ENOTSUP Emulation is in running stated.
  */
 int nfc_t4t_ndef_staticpayload_set(const uint8_t *emulation_buffer,
@@ -246,8 +244,7 @@ int nfc_t4t_ndef_staticpayload_set(const uint8_t *emulation_buffer,
  * @param pdu_length Length of PDU.
  *
  * @retval 0 Success.
- * @retval -EINVAL Invalid argument (e.g. wrong data length).
- * @retval -EINVAL Invalid argument (e.g. NULL pointer).
+ * @retval -EINVAL Invalid argument (e.g. wrong data length, NULL pointer).
  * @retval -ENOTSUP Emulation is in running state.
  */
 int nfc_t4t_response_pdu_send(const uint8_t *pdu, size_t pdu_length);
@@ -261,8 +258,7 @@ int nfc_t4t_response_pdu_send(const uint8_t *pdu, size_t pdu_length);
  * @param data_length Size of the buffer containing the data to set.
  *
  * @retval 0 Success.
- * @retval -EINVAL Invalid argument (e.g. wrong data length).
- * @retval -EINVAL Invalid argument (e.g. NULL pointer).
+ * @retval -EINVAL Invalid argument (e.g. wrong data length, NULL pointer).
  */
 int nfc_t4t_parameter_set(enum nfc_t4t_param_id id,
 			  void *data,
@@ -281,8 +277,7 @@ int nfc_t4t_parameter_set(enum nfc_t4t_param_id id,
  * data.
  *
  * @retval 0 Success.
- * @retval -EINVAL Invalid argument (e.g. wrong data length).
- * @retval -EINVAL Invalid argument (e.g. NULL pointer).
+ * @retval -EINVAL Invalid argument (e.g. wrong data length, NULL pointer).
  */
 int nfc_t4t_parameter_get(enum nfc_t4t_param_id id,
 			  void *data,


### PR DESCRIPTION
* Doxygen 1.8.17 warns on duplicating return values; aggregate the duplicates in a single paragraph.
* Doxygen 1.8.17 warns on closing groups that were not previously opened, so get rid of those group closes. Should have no effect on 1.8.13.