### PR TITLE
crypto: Add entry for KMU documentation for the cc3xx mbedcrypto

### DIFF
--- a/crypto/doc/api.rst
+++ b/crypto/doc/api.rst
@@ -76,6 +76,23 @@ CC3XX Platform - CTR_DRBG APIs
    :members:
 
 
+.. _crypto_api_nrf_cc3xx_mbedcrypto:
+
+nRF CC3XX mbedcrypto library
+****************************
+
+.. doxygengroup:: nrf_cc3xx_mbedcrypto
+   :project: nrfxlib
+   :members:
+
+KMU/KDR APIs
+========================
+
+.. doxygengroup:: nrf_cc3xx_mbedcrypto_kmu
+   :project: nrfxlib
+   :members:
+
+
 .. _crypto_api_nrf_oberon:
    
 nrf_oberon crypto library

--- a/crypto/doc/nrf_cc310_mbedcrypto.rst
+++ b/crypto/doc/nrf_cc310_mbedcrypto.rst
@@ -188,3 +188,8 @@ Usage restrictions
 
 On the nRF9160 SiP, the nrf_cc3xx_mbedcrypto library is restricted to only work in secure processing environment.
 The library uses mutexes to ensure single usage of hardware modules.
+
+API documentation
+=================
+
+:ref:`crypto_api_nrf_cc3xx_mbedcrypto`

--- a/crypto/nrf_cc310_mbedcrypto/include/mbedtls/cc3xx_kmu.h
+++ b/crypto/nrf_cc310_mbedcrypto/include/mbedtls/cc3xx_kmu.h
@@ -3,11 +3,18 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
 /**@file
- * @defgroup cc3xx_kmu cc3xx  APIs
- * @ingroup nrf_cc3xx_platform
+ * @defgroup nrf_cc3xx_mbedcrypto nrf_cc3xx_mbedcrypto APIs
  * @{
- * @brief The cc3xx_kmu APIs provides APIs to directly use or derive key
+ * @brief nrf_cc3xx_mbedcrypto  nrf_cc3xx_mbedcrypto library containing cc3xx
+ * APIs for the KMU or KDR peripherarls. Further documentation can be found on : https://tls.mbed.org
+ * @}
+ *
+ * @defgroup nrf_cc3xx_mbedcrypto_kmu nrf_cc3xx_mbedcrypto KMU APIs
+ * @ingroup nrf_cc3xx_mbedcrypto
+ * @{
+ * @brief The nrf_cc3xx_mbedcrypto_kmu APIs provides APIs to directly use or derive key
  *        from KMU or KDR in ARM CryptoCell devices
  */
 #ifndef CC3XX_KMU_H__

--- a/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_kmu.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_kmu.h
@@ -64,9 +64,9 @@
  *
  * @note nRF5340: Keys of 128 bits can use @ref NRF_CC3XX_PLATFORM_KMU_AES_ADDR,
  *       Keys larger than 128 bits must be split up to use two KMU slots.
- *       Use @ref NRF_CC3XX_PLATFORM_KMU_AES_ADDR_1 for the first 128 bits of
+ *       Use NRF_CC3XX_PLATFORM_KMU_AES_ADDR_1 for the first 128 bits of
  *       the key.
- *       Use @ref NRF_CC3XX_PLATFORM_KMU_AES_ADDR_2 for the subsequent bits of
+ *       Use NRF_CC3XX_PLATFORM_KMU_AES_ADDR_2 for the subsequent bits of
  *       the key.
  *
  * @param[in]   slot_id     KMU slot ID for the new key (2 - 127).


### PR DESCRIPTION

- Add reference to the API documentation in the cc3xx mbedcrypto library section
- Add the relevant category in the api.rst
- Add the correct group in the header file

Ref: NCSDK-7232

manifest pr: https://github.com/nrfconnect/sdk-nrf/pull/3435

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>