### PR TITLE
doc: add local ToC and make ToC heading consistent

### DIFF
--- a/bsdlib/doc/gnss_extension.rst
+++ b/bsdlib/doc/gnss_extension.rst
@@ -3,13 +3,17 @@
 GNSS socket
 ###########
 
+.. contents::
+   :local:
+   :depth: 2
+
 `Global navigation satellite system (GNSS)`_ socket is one of the socket types supported by the BSD library.
 This socket type is used to configure and fetch GPS position fix data from the GPS module, and to write `A-GPS`_ data to the GPS module.
 
 Creating a GNSS socket
 **********************
 
-The following code shows how to create a GNSS socket with the :c:type:`NRF_PROTO_GNSS` protocol family and the 
+The following code shows how to create a GNSS socket with the :c:type:`NRF_PROTO_GNSS` protocol family and the
 :c:type:`NRF_AF_LOCAL` proprietary address family.
 
 .. code-block:: c
@@ -45,7 +49,7 @@ The bit masks for the different types of data that can be deleted is defined in 
 Stopping the GPS
 ****************
 
-The GPS module can be stopped through the GNSS socket by using the :c:type:`NRF_SO_GNSS_STOP` socket option. 
+The GPS module can be stopped through the GNSS socket by using the :c:type:`NRF_SO_GNSS_STOP` socket option.
 A delete mask must also be supplied when stopping the GPS module as shown in the following code:
 
 .. code-block:: c

--- a/nrf_802154_sl/CHANGELOG.rst
+++ b/nrf_802154_sl/CHANGELOG.rst
@@ -3,6 +3,10 @@
 Changelog
 #########
 
+.. contents::
+   :local:
+   :depth: 2
+
 All notable changes to this project are documented in this file.
 
 nRF 802.15.4 Service Layer 0.2.0

--- a/nrf_802154_sl/README.rst
+++ b/nrf_802154_sl/README.rst
@@ -43,6 +43,6 @@ To use the library:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Subpages:
 
    CHANGELOG

--- a/zboss/README.rst
+++ b/zboss/README.rst
@@ -9,7 +9,7 @@ For detailed documentation of the ZBOSS API and instructions on how to use it, s
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
+   :caption: Subpages:
 
    CHANGELOG
    doc/zboss_configuration


### PR DESCRIPTION
All pages with sections should have a local ToC.
The heading for subpages should be "Subpages:", not "Contents:".

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>