### PR TITLE
Fix checkpatch issues

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,23 @@
+--mailback
+--no-tree
+--emacs
+--summary-file
+--show-types
+--max-line-length=80
+--min-conf-desc-length=1
+--typedefsfile=scripts/checkpatch/typedefsfile
+
+--ignore BRACES
+--ignore PRINTK_WITHOUT_KERN_LEVEL
+--ignore SPLIT_STRING
+--ignore VOLATILE
+--ignore CONFIG_EXPERIMENTAL
+--ignore AVOID_EXTERNS
+--ignore NETWORKING_BLOCK_COMMENT_STYLE
+--ignore DATE_TIME
+--ignore MINMAX
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore SPDX_LICENSE_TAG
+--ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--exclude ext

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.svg binary

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 /Jenkinsfile                              @thst-nordic
 /README.rst                               @ru-fu @carlescufi
 /.checkpatch.conf                         @carlescufi
+/.gitattributes                           @thst-nordic
 
 # All cmake related files
 /CMakeLists.txt                           @tejlmand

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 /LICENSE                                  @carlescufi
 /Jenkinsfile                              @thst-nordic
 /README.rst                               @ru-fu @carlescufi
+/.checkpatch.conf                         @carlescufi
 
 # All cmake related files
 /CMakeLists.txt                           @tejlmand


### PR DESCRIPTION
* sdk-nrfxlib was missing a configuration file for checkpatch; to avoid duplication just symlink it from sdk-nrf when running the compliance checks.
* Add git attribute to accept svg files as binary to avoid handling them as text files.

/cc @thst-nordic 