### PR TITLE
nrf_modem: fix doxygen warning in nrf_socket.h

### DIFF
--- a/nrf_modem/include/nrf_socket.h
+++ b/nrf_modem/include/nrf_socket.h
@@ -1669,8 +1669,6 @@ void nrf_freeaddrinfo(struct nrf_addrinfo *p_res);
  */
 int nrf_setdnsaddr(int family, const void *in_addr);
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fix doxygen warning.