### PR TITLE
checkpatch: Exclude folders that contain 3rd-party code

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -20,4 +20,4 @@
 --ignore FILE_PATH_CHANGES
 --ignore SPDX_LICENSE_TAG
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
---exclude ext
+--exclude doc,mpsl,nrf_802154_sl,openthread,softdevice_controller,zboss,crypto,nrf_security


### PR DESCRIPTION
Exclude folder that cannot comply with the NCS coding standards due to
them including code that is developed by 3rd-party teams or companies.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>