### PR TITLE
doc: nrf_modem: Add note regarding cipher suite support

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -16,6 +16,8 @@
 
 .. _`nRF9160 modem firmware zip file`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#98C9E2578566420786ABD40B695FDB9B
 
+.. _`nRF9160 modem TLS cipher suites`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#infotabs
+
 .. ### Other links
 
 .. _`Beej's Guide to Network Programming`: https://beej.us/guide/bgnet/
@@ -42,3 +44,5 @@
 .. _`Zephyr`: https://www.zephyrproject.org
 
 .. _`NMEA report sample`: http://aprs.gids.nl/nmea/#gsa
+
+.. _`IANA`: https://en.wikipedia.org/wiki/Internet_Assigned_Numbers_Authority

--- a/nrf_modem/README.rst
+++ b/nrf_modem/README.rst
@@ -33,7 +33,7 @@ For more information, see :ref:`nrf_modem_ug_porting`.
    doc/supported_features
    doc/limitations
    doc/architecture
-   doc/security_tags
+   doc/tls_dtls_configuration
    doc/extensions
    doc/ug_nrf_modem_porting_os
    doc/CHANGELOG

--- a/nrf_modem/doc/tls_dtls_configuration.rst
+++ b/nrf_modem/doc/tls_dtls_configuration.rst
@@ -1,11 +1,16 @@
+.. _tls_dtls_configuration:
+
+TLS/DTLS configuration
+######################
+
+The modem on an nRF9160 device is equipped with a full IPv4/IPv6 stack with TLS/DTLS support.
+
 .. _security_tags:
 
 Security tags
-#############
+*************
 
-The modem on an nRF9160 device is equipped with a full IPv4/IPv6 stack with DTLS/TLS support.
 To use the cryptographic functions in the modem, the application must provision the security credentials to the modem.
-
 To be able to provision credentials, the modem must be in offline mode.
 The credentials are provisioned through AT commands (see `Credential storage management %CMNG`_).
 If you are using the |NCS| to build your application, you can use the :ref:`nrf:modem_key_mgmt` library to manage credentials.
@@ -65,3 +70,25 @@ In this case, either security tag 4 or security tag 5 can be used for operations
    :alt: Using multiple security tags
 
    Using multiple security tags
+
+Supported cipher suites
+***********************
+
+See the `nRF9160 modem TLS cipher suites`_ summary page for a full list of TLS/DTLS cipher suites supported by the modem.
+
+Each cipher suite is recognized by an official identification number, which is registered at `IANA`_.
+You can narrow down the set of cipher suites that is used for a specific TLS/DTLS connection with :c:func:`nrf_setsockopt`.
+For example, see the following code:
+
+.. code-block:: c
+
+   /* TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA */
+   nrf_sec_cipher_t cipher_list[] = { 0xC014 };
+
+   err = nrf_setsockopt(fd, NRF_SOL_TLS, NRF_SO_CIPHERSUITE_LIST, cipher_list, sizeof(cipher_list));
+   if (err) {
+      /* Failed to set up cipher suite list. */
+      return -1;
+   }
+
+Note that as in the case of other TLS/DTLS socket options, you must do this configuration before connecting to the server.


### PR DESCRIPTION
Add information of the supported cipher suites as a reference to the
modem documentation. Add simple example on how cipher suites used for
TLS session can be configured with socket options.

NCSDK-7725

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>