### PR TITLE
zboss: Add type definition for reset type

### DIFF
--- a/zboss/include/zb_osif.h
+++ b/zboss/include/zb_osif.h
@@ -414,6 +414,26 @@ zb_ret_t zb_osif_file_rotate(const zb_char_t *file_path, const zb_char_t *file_n
 void zb_reset(zb_uint8_t param);
 void zb_syslog_msg(const zb_char_t *msg);
 
+/* Possible reset sources */
+
+typedef enum zb_reset_source_e
+{
+  ZB_RESET_SRC_POWER_ON,
+  ZB_RESET_SRC_SW_RESET,
+  ZB_RESET_SRC_RESET_PIN,
+  ZB_RESET_SRC_BROWN_OUT,
+  ZB_RESET_SRC_CLOCK_LOSS,
+  ZB_RESET_SRC_OTHER,
+
+} zb_reset_source_t;
+
+/**
+ * @brief Get the reason that triggered the last reset
+ *
+ * @return zb_reset_source_t
+ * */
+zb_uint8_t zb_get_reset_source(void);
+
 /*! @} */
 
 /**


### PR DESCRIPTION
Prepare for ZBOSS update by adding a type and function declaration, required by future ZBOSS implementation.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>