### PR TITLE
ci: compliance: fetch all west modules

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -35,7 +35,7 @@ jobs:
           pip3 install -U gitlint
           pip3 install -r zephyr/scripts/requirements-compliance.txt
           cd nrfxlib
-          $ZEPHYR_BASE/scripts/ci/check_compliance.py -m Codeowners -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}.. || true
+          $ZEPHYR_BASE/scripts/ci/check_compliance.py -m Codeowners -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -c origin/${BASE_REF}.. || true
 
       - name: Upload Results
         uses: actions/upload-artifact@master
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check Warnings
         run: |
-          for file in Codeowners.txt Devicetree.txt Gitlint.txt Identity.txt Nits.txt pylint.txt checkpatch.txt Kconfig.txt; do
+          for file in Codeowners.txt Gitlint.txt Identity.txt Nits.txt pylint.txt checkpatch.txt; do
             path="ncs/nrfxlib/${file}"
             if [[ -s $path ]]; then
               errors=$(cat $path)


### PR DESCRIPTION
- Fetch all west modules when running compliance check.
- Remove DeviceTree module which is not used.