### PR TITLE
nrf_security: Make use of mbedtls user config

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1568,6 +1568,90 @@ config MBEDTLS_PK_WRITE_C
 	help
 	  Enable generic public key write functions.
 
+config MBEDTLS_SSL_RENEGOTIATION
+	bool "SSL - Renegotiation"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable support for TLS renegotiation.
+
+config MBEDTLS_SSL_ALPN
+	bool "SSL - RFC 7301 ALP Negotiation"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable support for RFC 7301 Application Layer Protocol Negotiation.
+
+config MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+	bool "SSL - DTLS client port reuse"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable server-side support for clients that reconnect from the same port.
+
+config MBEDTLS_SSL_DTLS_BADMAC_LIMIT
+	bool "SSL - DTLS bad MAC limit"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable support for a limit of records with bad MAC.
+
+config MBEDTLS_SSL_SESSION_TICKETS
+	bool "SSL - RFC 5077 session tickets support"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable support for RFC 5077 session tickets in SSL.
+
+config MBEDTLS_SSL_SERVER_NAME_INDICATION
+	bool "SSL - RFC 6066 SNI"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable support for RFC 6066 server name indication (SNI) in SSL.
+
+config MBEDTLS_SSL_CACHE_C
+	bool "SSL - cache"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable simple SSL cache implementation.
+
+config MBEDTLS_SSL_TICKET_C
+	bool "SSL - tickets"
+	depends on MBEDTLS_TLS_LIBRARY
+	help
+	  Enable an implementation of TLS server-side callbacks for session tickets.
+
+config MBEDTLS_X509_CHECK_KEY_USAGE
+	bool "X.509 - check key usage"
+	depends on MBEDTLS_X509_LIBRARY
+	help
+	  Enable verification of the keyUsage extension (CA and leaf certificates).
+
+config MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+	bool "X.509 - check extended key usage"
+	depends on MBEDTLS_X509_LIBRARY
+	help
+	  Enable verification of the extendedKeyUsage extension (leaf certificates).
+
+config MBEDTLS_X509_CRL_PARSE_C
+	bool "X.509 - CRL parsing"
+	depends on MBEDTLS_X509_LIBRARY
+	help
+	  Enable X.509 CRL parsing.
+
+config MBEDTLS_X509_CSR_PARSE_C
+	bool "X.509 - CSR parsing"
+	depends on MBEDTLS_X509_LIBRARY
+	help
+	  Enable X.509 Certificate Signing Requests (CSR) parsing.
+
+config MBEDTLS_X509_CREATE_C
+	bool "X.509 - creating certificates core"
+	depends on MBEDTLS_X509_LIBRARY
+	help
+	  Enable X.509 core for creating certificates.
+
+config MBEDTLS_X509_CSR_WRITE_C
+	bool "X.509 - CSR writing"
+	depends on MBEDTLS_X509_LIBRARY
+	help
+	  Enable creating X.509 Certificate Signing Requests (CSR).
+
 endif # NRF_SECURITY_ADVANCED
 
 endif # NRF_SECURITY_ANY_BACKEND

--- a/nrf_security/cmake/kconfig_mbedtls_configure.cmake
+++ b/nrf_security/cmake/kconfig_mbedtls_configure.cmake
@@ -293,6 +293,24 @@ endif()
 set(MBEDTLS_ARC4_C False)
 
 #
+# Defines currently not grouped
+#
+kconfig_mbedtls_config("MBEDTLS_SSL_RENEGOTIATION")
+kconfig_mbedtls_config("MBEDTLS_SSL_ALPN")
+kconfig_mbedtls_config("MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE")
+kconfig_mbedtls_config("MBEDTLS_SSL_DTLS_BADMAC_LIMIT")
+kconfig_mbedtls_config("MBEDTLS_SSL_SESSION_TICKETS")
+kconfig_mbedtls_config("MBEDTLS_SSL_SERVER_NAME_INDICATION")
+kconfig_mbedtls_config("MBEDTLS_SSL_CACHE_C")
+kconfig_mbedtls_config("MBEDTLS_SSL_TICKET_C")
+kconfig_mbedtls_config("MBEDTLS_X509_CHECK_KEY_USAGE")
+kconfig_mbedtls_config("MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE")
+kconfig_mbedtls_config("MBEDTLS_X509_CRL_PARSE_C")
+kconfig_mbedtls_config("MBEDTLS_X509_CSR_PARSE_C")
+kconfig_mbedtls_config("MBEDTLS_X509_CREATE_C")
+kconfig_mbedtls_config("MBEDTLS_X509_CSR_WRITE_C")
+
+#
 # Compare the following with check-config.h in mbed TLS
 #
 mbedtls_config_define_depends("MBEDTLS_SSL_DTLS_ANTI_REPLAY"

--- a/nrf_security/cmake/kconfig_mbedtls_configure.cmake
+++ b/nrf_security/cmake/kconfig_mbedtls_configure.cmake
@@ -65,6 +65,10 @@ endmacro()
 #
 file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/include/)
 
+# User config file
+#
+kconfig_mbedtls_config_val("MBEDTLS_USER_CONFIG_FILE"	"${CONFIG_MBEDTLS_USER_CONFIG_FILE}")
+
 # Enabling core functionality
 #
 kconfig_mbedtls_config("MBEDTLS_AES_C")

--- a/nrf_security/configs/nrf-config.h.template
+++ b/nrf_security/configs/nrf-config.h.template
@@ -3721,6 +3721,7 @@ it is (2^48 - 1), our restriction is :  (int - 0xFFFF - 0xF).*/
  * Allow user to override any previous default.
  *
  */
+#cmakedefine MBEDTLS_USER_CONFIG_FILE	"@MBEDTLS_USER_CONFIG_FILE@"
 #if defined(MBEDTLS_USER_CONFIG_FILE)
 #include MBEDTLS_USER_CONFIG_FILE
 #endif

--- a/nrf_security/configs/nrf-config.h.template
+++ b/nrf_security/configs/nrf-config.h.template
@@ -1561,7 +1561,7 @@
  *          configuration of this extension).
  *
  */
-//#define MBEDTLS_SSL_RENEGOTIATION
+#cmakedefine MBEDTLS_SSL_RENEGOTIATION
 
 /**
  * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
@@ -1687,7 +1687,7 @@
  *
  * Comment this macro to disable support for ALPN.
  */
-//#define MBEDTLS_SSL_ALPN
+#cmakedefine MBEDTLS_SSL_ALPN
 
 /**
  * \def MBEDTLS_SSL_DTLS_ANTI_REPLAY
@@ -1736,7 +1736,7 @@
  *
  * Comment this to disable support for clients reusing the source port.
  */
-//#define MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
+#cmakedefine MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE
 
 /**
  * \def MBEDTLS_SSL_DTLS_BADMAC_LIMIT
@@ -1747,7 +1747,7 @@
  *
  * Requires: MBEDTLS_SSL_PROTO_DTLS
  */
-//#define MBEDTLS_SSL_DTLS_BADMAC_LIMIT
+#cmakedefine MBEDTLS_SSL_DTLS_BADMAC_LIMIT
 
 /**
  * \def MBEDTLS_SSL_SESSION_TICKETS
@@ -1761,7 +1761,7 @@
  *
  * Comment this macro to disable support for SSL session tickets
  */
-//#define MBEDTLS_SSL_SESSION_TICKETS
+#cmakedefine MBEDTLS_SSL_SESSION_TICKETS
 
 /**
  * \def MBEDTLS_SSL_EXPORT_KEYS
@@ -1782,7 +1782,7 @@
  *
  * Comment this macro to disable support for server name indication in SSL
  */
-//#define MBEDTLS_SSL_SERVER_NAME_INDICATION
+#cmakedefine MBEDTLS_SSL_SERVER_NAME_INDICATION
 
 /**
  * \def MBEDTLS_SSL_TRUNCATED_HMAC
@@ -1995,7 +1995,7 @@
  *
  * Comment to skip keyUsage checking for both CA and leaf certificates.
  */
-//#define MBEDTLS_X509_CHECK_KEY_USAGE
+#cmakedefine MBEDTLS_X509_CHECK_KEY_USAGE
 
 /**
  * \def MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
@@ -2008,7 +2008,7 @@
  *
  * Comment to skip extendedKeyUsage checking for certificates.
  */
-//#define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
+#cmakedefine MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
 
 /**
  * \def MBEDTLS_X509_RSASSA_PSS_SUPPORT
@@ -3116,7 +3116,7 @@
  *
  * Requires: MBEDTLS_SSL_CACHE_C
  */
-//#define MBEDTLS_SSL_CACHE_C
+#cmakedefine MBEDTLS_SSL_CACHE_C
 
 /**
  * \def MBEDTLS_SSL_COOKIE_C
@@ -3138,7 +3138,7 @@
  *
  * Requires: MBEDTLS_CIPHER_C
  */
-//#define MBEDTLS_SSL_TICKET_C
+#cmakedefine MBEDTLS_SSL_TICKET_C
 
 /**
  * \def MBEDTLS_SSL_CLI_C
@@ -3285,7 +3285,7 @@
  *
  * This module is required for X.509 CRL parsing.
  */
-//#define MBEDTLS_X509_CRL_PARSE_C
+#cmakedefine MBEDTLS_X509_CRL_PARSE_C
 
 /**
  * \def MBEDTLS_X509_CSR_PARSE_C
@@ -3299,7 +3299,7 @@
  *
  * This module is used for reading X.509 certificate request.
  */
-//#define MBEDTLS_X509_CSR_PARSE_C
+#cmakedefine MBEDTLS_X509_CSR_PARSE_C
 
 /**
  * \def MBEDTLS_X509_CREATE_C
@@ -3312,7 +3312,7 @@
  *
  * This module is the basis for creating X.509 certificates and CSRs.
  */
-//#define MBEDTLS_X509_CREATE_C
+#cmakedefine MBEDTLS_X509_CREATE_C
 
 /**
  * \def MBEDTLS_X509_CRT_WRITE_C
@@ -3338,7 +3338,7 @@
  *
  * This module is required for X.509 certificate request writing.
  */
-//#define MBEDTLS_X509_CSR_WRITE_C
+#cmakedefine MBEDTLS_X509_CSR_WRITE_C
 
 /**
  * \def MBEDTLS_XTEA_C


### PR DESCRIPTION
Use zephyr's option to pass path to user config.

Jira:NCSDK-7689

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>