### PR TITLE
checkpatch: Fix checkpatch.conf format

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -20,4 +20,12 @@
 --ignore FILE_PATH_CHANGES
 --ignore SPDX_LICENSE_TAG
 --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
---exclude doc,mpsl,nrf_802154_sl,openthread,softdevice_controller,zboss,crypto,nrf_security
+
+--exclude doc
+--exclude mpsl
+--exclude nrf_802154_sl
+--exclude openthread
+--exclude softdevice_controller
+--exclude zboss
+--exclude crypto
+--exclude nrf_security


### PR DESCRIPTION
For whatever reason checkpatch doesn't like a comma-separated list for
the set of excludes.