### PR TITLE
crypto: Add mutual exclusive peripheral lock variant for CC312

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -51,6 +51,21 @@ config CC3XX_ATOMIC_LOCK
 	help
 	  Using atomic operations is the fastest way to ensure mutually exclusive
 	  access to the ARM CryptoCell hardware.
+
+	  Warning: If this configuration is set, every execution requiring use of
+	  the ARM CryptoCell hardware must happen in the same priority. Calling into
+	  mbed TLS APIs from a higher priority while an ongoing operation will lead
+	  to undefined behavior. It is highy recommended to to do all cryptographic
+	  operations in one single thread if this configuration is set.
+
+config CC3XX_HW_MUTEX_LOCK
+	bool "Use hardware mutex for mutually exclusive access to CC3XX resources"
+	depends on SOC_NRF5340_CPUAPP
+	help
+	  A mutual exclusive peripheral is the fastest way to ensure mutually
+	  exclusive access to the ARM CryptoCell hardware on platform which support
+	  it. The MUTEX peripheral is nRF53 platform specific solution.
+
 	  Warning: If this configuration is set, every execution requiring use of
 	  the ARM CryptoCell hardware must happen in the same priority. Calling into
 	  mbed TLS APIs from a higher priority while an ongoing operation will lead

--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -26,6 +26,7 @@ endif
 menuconfig NRF_CC3XX_PLATFORM
 	bool "nrf_cc3xx_platform HW crypto library for nRF devices with CryptoCell CC3xx."
 	select NRFXLIB_CRYPTO
+	depends on HW_CC3XX
 	help
 		To use, link with nrfxlib_crypto in CMake.
 

--- a/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_mutex.h
+++ b/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_mutex.h
@@ -26,7 +26,8 @@ extern "C"
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_INVALID        (0)         /*!< Mask indicating that the mutex is invalid (not initialized or allocated). */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_VALID       (1<<0)      /*!< Mask value indicating that the mutex is valid for use. */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ALLOCATED   (1<<1)      /*!< Mask value indicating that the mutex is allocated and requires deallocation once freed. */
-#define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ATOMIC      (1<<2)      /*!< Mask value indicating that the mutex is atomic type */
+#define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ATOMIC      (1<<2)      /*!< Mask value indicating that the mutex is atomic type. */
+#define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_HW_MUTEX    (1<<3)      /*!< Mask value indicating that the mutex is hardware mutex type. */
 
 /** @brief Type definition of architecture neutral mutex type */
 typedef struct nrf_cc3xx_platform_mutex


### PR DESCRIPTION
Make use of mutual exclusive peripheral on nRF53 Series devices for CC312 locking.

sdk-nrf linked PR: https://github.com/nrfconnect/sdk-nrf/pull/3736