### PR TITLE
softdevice_controller: Rename to SOFTDEVICE_CONTROLLER_PERIPHERAL

### DIFF
--- a/softdevice_controller/CMakeLists.txt
+++ b/softdevice_controller/CMakeLists.txt
@@ -19,7 +19,7 @@ if(CONFIG_BT_LL_SOFTDEVICE)
       "(${SOFTDEVICE_CONTROLLER_LIB_PATH} doesn't exist.)")
   endif()
 
-  if(CONFIG_SOFTDEVICE_CONTROLLER_PERIPH)
+  if(CONFIG_SOFTDEVICE_CONTROLLER_PERIPHERAL)
     set(softdevice_controller_variant peripheral)
   elseif(CONFIG_SOFTDEVICE_CONTROLLER_CENTRAL)
     set(softdevice_controller_variant central)

--- a/softdevice_controller/Kconfig
+++ b/softdevice_controller/Kconfig
@@ -71,11 +71,11 @@ choice SOFTDEVICE_CONTROLLER_VARIANT
 						     BT_CTLR_PHY_CODED || \
 						     SOC_NRF5340_CPUNET)
 	default SOFTDEVICE_CONTROLLER_CENTRAL if BT_CENTRAL
-	default SOFTDEVICE_CONTROLLER_PERIPH if BT_PERIPHERAL
+	default SOFTDEVICE_CONTROLLER_PERIPHERAL if BT_PERIPHERAL
 	help
 	  Select a SoftDevice Controller variant.
 
-config SOFTDEVICE_CONTROLLER_PERIPH
+config SOFTDEVICE_CONTROLLER_PERIPHERAL
 	bool "SoftDevice Controller peripheral library optimized for peripheral role applications"
 	depends on !BT_CENTRAL && !BT_CTLR_LLPM && !BT_CTLR_ADV_EXT && !BT_CTLR_PHY_CODED
 	help


### PR DESCRIPTION
Using PERIPHERAL instead of PERIPH matches the library name and
the naming convention of the other configurations.
