### PR TITLE
Add braces around ARM_MBEDTLS_PATH in nrf_security/CMakeLists.txt

### DIFF
--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(mbedtls_common INTERFACE
   ${generated_includes}
 )
 
-get_mbedtls_dir(ARM_MBEDTLS_PATH)
+get_mbedtls_dir(${ARM_MBEDTLS_PATH})
 
 set(mbedcrypto_glue_include_path
   "${CMAKE_CURRENT_LIST_DIR}/include/mbedcrypto_glue/mbedtls"


### PR DESCRIPTION
Otherwise the string "ARM_MBEDTLS_PATH" gets passed to `get_mbedtls_dir` instead the value of the variable `ARM_MBEDTLS_PATH`.
Without the braces, its not possible to pass the actual path to `get_mbedtls_dir`.