### PR TITLE
crypto: Add missing define

### DIFF
--- a/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_mutex.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_mutex.h
@@ -27,6 +27,8 @@ extern "C"
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_VALID       (1<<0)      /*!< Mask value indicating that the mutex is valid for use. */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ALLOCATED   (1<<1)      /*!< Mask value indicating that the mutex is allocated and requires deallocation once freed. */
 #define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ATOMIC      (1<<2)      /*!< Mask value indicating that the mutex is atomic type */
+#define NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_HW_MUTEX    (1<<3)      /*!< Mask value indicating that the mutex is hardware mutex type. */
+
 
 /** @brief Type definition of architecture neutral mutex type */
 typedef struct nrf_cc3xx_platform_mutex


### PR DESCRIPTION
It fixes building for nrf9160dk_nrf9160.
