### PR TITLE
Bluetooth: controller: Add ECDH support in the softdevice controller

### DIFF
--- a/softdevice_controller/Kconfig
+++ b/softdevice_controller/Kconfig
@@ -50,6 +50,7 @@ config BT_LL_SOFTDEVICE
 	select BT_CTLR_PHY_2M_SUPPORT if HAS_HW_NRF_RADIO_BLE_2M
 	select BT_CTLR_PHY_CODED_SUPPORT if HAS_HW_NRF_RADIO_BLE_CODED
 	select BT_HAS_HCI_VS
+	select BT_CTLR_ECDH_SUPPORT
 	# The SoftDevice Controller only supports nRF52 and nRF53, it does not support nRF51
 	# or nRF91 (nRF91 doesn't even have the physical HW needed for BLE).
 	depends on (SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
@@ -99,6 +100,20 @@ config SOFTDEVICE_CONTROLLER_MULTIROLE
 
 endchoice
 
+if BT_CTLR_ECDH
+choice BT_CTLR_ECDH_LIB
+	prompt "SoftDevice ECDH library"
+
+config BT_CTLR_ECDH_LIB_OBERON
+	select NRF_OBERON
+	bool "Oberon ECDH library"
+
+config BT_CTLR_ECDH_LIB_TINYCRYPT
+	select NRF_OBERON
+	bool "TinyCrypt ECDB library"
+
+endchoice
+endif # BT_CTLR_ECDH
 
 endif # BT_LL_SOFTDEVICE
 endif # BT_CTLR


### PR DESCRIPTION
Add ECDH support in the softdevice controller, using either tinycrypt
or the oberon crypto library.
Supporting the ECDH in the controller allows the ECDH calculations
to be done on the controller side in a split host-controller build.
Using the oberon crypto library has better performance, stack and
flash usage compared to tinycrypt.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>