### PR TITLE
compliancecheck: using KconfigBasic compliance check instead of Kconfig

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -60,7 +60,7 @@ jobs:
         # debug
         ls -la
         git log --pretty=oneline | head -n 10
-        $ZEPHYR_BASE/scripts/ci/check_compliance.py -m Codeowners -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}..
+        $ZEPHYR_BASE/scripts/ci/check_compliance.py -m Codeowners -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m KconfigBasic -c origin/${BASE_REF}..
 
     - name: Upload Results
       uses: actions/upload-artifact@master


### PR DESCRIPTION
Using `compliancecheck` in sdk-nrf generates >500 undefined Kconfig
symbol references. Many of those are false warnings, but to allow time
for proper cleanup, then this commit resorts to only do KconfigBasic
check.

This means that undefined Kconfig symbols in the Kconfig tree are
reported but not outside the tree, such as source code, rst files, conf
files.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>