### PR TITLE
nrf_security: Add PSA native ITS with Zephyr backend

### DIFF
--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -51,3 +51,5 @@ if (CONFIG_NRF_SECURITY_MULTI_BACKEND)
   # b. vanilla selection of ciphers only --> Renaming, but no glue
   add_subdirectory(src/mbedcrypto_glue)
 endif()
+
+add_subdirectory_ifdef(CONFIG_PSA_EITS_BACKEND_ZEPHYR src/psa)

--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1655,6 +1655,9 @@ config MBEDTLS_X509_CSR_WRITE_C
 
 endif # NRF_SECURITY_ADVANCED
 
+comment "PSA Native ITS"
+rsource "src/psa/Kconfig"
+
 endif # NRF_SECURITY_ANY_BACKEND
 
 endif # NORDIC_SECURITY_BACKEND

--- a/nrf_security/include/psa/internal_trusted_storage.h
+++ b/nrf_security/include/psa/internal_trusted_storage.h
@@ -1,0 +1,142 @@
+/** \file internal_trusted_storage.h
+ * \brief Interface of trusted storage that crypto is built on.
+ */
+/*
+ *  Copyright The Mbed TLS Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef PSA_CRYPTO_ITS_H
+#define PSA_CRYPTO_ITS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <psa/crypto_types.h>
+#include <psa/crypto_values.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \brief Flags used when creating a data entry
+ */
+typedef uint32_t psa_storage_create_flags_t;
+
+/** \brief A type for UIDs used for identifying data
+ */
+typedef uint64_t psa_storage_uid_t;
+
+#define PSA_STORAGE_FLAG_NONE        0         /**< No flags to pass */
+#define PSA_STORAGE_FLAG_WRITE_ONCE (1 << 0) /**< The data associated with the uid will not be able to be modified or deleted. Intended to be used to set bits in `psa_storage_create_flags_t`*/
+
+/**
+ * \brief A container for metadata associated with a specific uid
+ */
+struct psa_storage_info_t
+{
+    uint32_t size;                  /**< The size of the data associated with a uid **/
+    psa_storage_create_flags_t flags;    /**< The flags set when the uid was created **/
+};
+
+/** \brief PSA storage specific error codes
+ */
+#define PSA_ERROR_INVALID_SIGNATURE     ((psa_status_t)-149)
+#define PSA_ERROR_DATA_CORRUPT          ((psa_status_t)-152)
+
+#define PSA_ITS_API_VERSION_MAJOR  1  /**< The major version number of the PSA ITS API. It will be incremented on significant updates that may include breaking changes */
+#define PSA_ITS_API_VERSION_MINOR  1  /**< The minor version number of the PSA ITS API. It will be incremented in small updates that are unlikely to include breaking changes */
+
+/**
+ * \brief create a new or modify an existing uid/value pair
+ *
+ * \param[in] uid           the identifier for the data
+ * \param[in] data_length   The size in bytes of the data in `p_data`
+ * \param[in] p_data        A buffer containing the data
+ * \param[in] create_flags  The flags that the data will be stored with
+ *
+ * \return      A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                      The operation completed successfully
+ * \retval      PSA_ERROR_NOT_PERMITTED          The operation failed because the provided `uid` value was already created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      PSA_ERROR_NOT_SUPPORTED          The operation failed because one or more of the flags provided in `create_flags` is not supported or is not valid
+ * \retval      PSA_ERROR_INSUFFICIENT_STORAGE   The operation failed because there was insufficient space on the storage medium
+ * \retval      PSA_ERROR_STORAGE_FAILURE        The operation failed because the physical storage has failed (Fatal error)
+ * \retval      PSA_ERROR_INVALID_ARGUMENT       The operation failed because one of the provided pointers(`p_data`)
+ *                                               is invalid, for example is `NULL` or references memory the caller cannot access
+ */
+psa_status_t psa_its_set(psa_storage_uid_t uid,
+                         uint32_t data_length,
+                         const void *p_data,
+                         psa_storage_create_flags_t create_flags);
+
+/**
+ * \brief Retrieve the value associated with a provided uid
+ *
+ * \param[in] uid               The uid value
+ * \param[in] data_offset       The starting offset of the data requested
+ * \param[in] data_length       the amount of data requested (and the minimum allocated size of the `p_data` buffer)
+ * \param[out] p_data           The buffer where the data will be placed upon successful completion
+ * \param[out] p_data_length    The amount of data returned in the p_data buffer
+ *
+ *
+ * \return      A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                  The operation completed successfully
+ * \retval      PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided `uid` value was not found in the storage
+ * \retval      PSA_ERROR_INVALID_SIZE       The operation failed because the data associated with provided uid is larger than `data_size`
+ * \retval      PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
+ * \retval      PSA_ERROR_INVALID_ARGUMENT   The operation failed because one of the provided pointers(`p_data`, `p_data_length`)
+ *                                           is invalid. For example is `NULL` or references memory the caller cannot access.
+ *                                           In addition, this can also happen if an invalid offset was provided.
+ */
+psa_status_t psa_its_get(psa_storage_uid_t uid,
+                         uint32_t data_offset,
+                         uint32_t data_length,
+                         void *p_data,
+                         size_t *p_data_length );
+
+/**
+ * \brief Retrieve the metadata about the provided uid
+ *
+ * \param[in] uid           The uid value
+ * \param[out] p_info       A pointer to the `psa_storage_info_t` struct that will be populated with the metadata
+ *
+ * \return      A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                  The operation completed successfully
+ * \retval      PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided uid value was not found in the storage
+ * \retval      PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
+ * \retval      PSA_ERROR_INVALID_ARGUMENT   The operation failed because one of the provided pointers(`p_info`)
+ *                                           is invalid, for example is `NULL` or references memory the caller cannot access
+ */
+psa_status_t psa_its_get_info(psa_storage_uid_t uid,
+                              struct psa_storage_info_t *p_info);
+
+/**
+ * \brief Remove the provided key and its associated data from the storage
+ *
+ * \param[in] uid   The uid value
+ *
+ * \return  A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                  The operation completed successfully
+ * \retval      PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided key value was not found in the storage
+ * \retval      PSA_ERROR_NOT_PERMITTED      The operation failed because the provided key value was created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
+ */
+psa_status_t psa_its_remove(psa_storage_uid_t uid);
+
+#endif /* PSA_CRYPTO_ITS_H */

--- a/nrf_security/src/psa/CMakeLists.txt
+++ b/nrf_security/src/psa/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+zephyr_library()
+zephyr_include_directories(../../include/)
+zephyr_library_sources(psa_eits.c)
+
+if(CONFIG_PSA_EITS_BACKEND_ZEPHYR)
+        zephyr_library_sources(psa_eits_zephyr_settings.c)
+endif()

--- a/nrf_security/src/psa/Kconfig
+++ b/nrf_security/src/psa/Kconfig
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+menuconfig PSA_NATIVE_ITS
+	bool "PSA native Internal Trusted Storage"
+	depends on CC310_BACKEND
+
+if PSA_NATIVE_ITS
+
+choice
+	prompt "Backend selection for PSA native ITS"
+	help
+	  Select backend for PSA native Internal Trusted Storage
+
+config CHOICE_BACKEND_ZEPHYR_SETTINGS
+	bool "Zephyr Settings"
+	select PSA_EITS_BACKEND_ZEPHYR
+
+endchoice
+
+menuconfig PSA_EITS_BACKEND_ZEPHYR
+	bool "Native ITS backend based on Zephyr Settings subsystem"
+	select FLASH
+	select FLASH_MAP
+	select FLASH_PAGE_LAYOUT
+	select MPU_ALLOW_FLASH_WRITE
+	select NVS
+	select SETTINGS
+	depends on CHOICE_BACKEND_ZEPHYR_SETTINGS
+	help
+	  Enable to get access for flashing operation based on Zephyr Settings
+	  subsystem.
+
+if PSA_EITS_BACKEND_ZEPHYR
+
+config PSA_EITS_READ_BUFF_SIZE
+	int "The size of the buffer used when reading with an offset"
+	default 2048
+
+module = PSA_EITS_BACKEND_ZEPHYR
+module-str = PSA EITS Zephyr backend
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif # PSA_EITS_BACKEND_ZEPHYR
+
+endif # PSA_NATIVE_ITS

--- a/nrf_security/src/psa/psa_eits.c
+++ b/nrf_security/src/psa/psa_eits.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <psa/internal_trusted_storage.h>
+
+#include "psa_eits_backend.h"
+
+psa_status_t psa_its_set( psa_storage_uid_t uid, uint32_t data_length,
+                          const void *p_data,
+                          psa_storage_create_flags_t create_flags )
+{
+    if ( p_data == NULL || data_length == 0 )
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    return psa_its_set_backend( uid, data_length, p_data, create_flags );
+}
+
+psa_status_t psa_its_get( psa_storage_uid_t uid, uint32_t data_offset,
+                          uint32_t data_length, void *p_data,
+                          size_t *p_data_length )
+{
+    if ( p_data == NULL || p_data_length == NULL || data_length == 0 )
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    return psa_its_get_backend( uid, data_offset, data_length, p_data,
+                                p_data_length );
+}
+
+psa_status_t psa_its_get_info( psa_storage_uid_t uid,
+                               struct psa_storage_info_t *p_info )
+{
+    if ( p_info == NULL )
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    return psa_its_get_info_backend( uid, p_info );
+}
+
+psa_status_t psa_its_remove( psa_storage_uid_t uid )
+{
+    return psa_its_remove_backend( uid );
+}

--- a/nrf_security/src/psa/psa_eits_backend.h
+++ b/nrf_security/src/psa/psa_eits_backend.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#ifndef PSA_EITS_BACKEND_H
+#define PSA_EITS_BACKEND_H
+
+#include <psa/internal_trusted_storage.h>
+
+/**
+ * \brief create a new or modify an existing uid/value pair
+ *
+ * \param[in] uid           the identifier for the data
+ * \param[in] data_length   The size in bytes of the data in `p_data`
+ * \param[in] p_data        A buffer containing the data
+ * \param[in] create_flags  The flags that the data will be stored with
+ *
+ * \return      A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                      The operation completed successfully
+ * \retval      PSA_ERROR_NOT_PERMITTED          The operation failed because the provided `uid` value was already created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      PSA_ERROR_NOT_SUPPORTED          The operation failed because one or more of the flags provided in `create_flags` is not supported or is not valid
+ * \retval      PSA_ERROR_INSUFFICIENT_STORAGE   The operation failed because there was insufficient space on the storage medium
+ * \retval      PSA_ERROR_STORAGE_FAILURE        The operation failed because the physical storage has failed (Fatal error)
+ * \retval      PSA_ERROR_INVALID_ARGUMENT       The operation failed because one of the provided pointers(`p_data`)
+ *                                               is invalid, for example is `NULL` or references memory the caller cannot access
+ */
+psa_status_t psa_its_set_backend( psa_storage_uid_t uid, uint32_t data_length,
+                                  const void *p_data,
+                                  psa_storage_create_flags_t create_flags );
+
+/**
+ * \brief Retrieve the value associated with a provided uid
+ *
+ * \param[in] uid               The uid value
+ * \param[in] data_offset       The starting offset of the data requested
+ * \param[in] data_length       the amount of data requested (and the minimum allocated size of the `p_data` buffer)
+ * \param[out] p_data           The buffer where the data will be placed upon successful completion
+ * \param[out] p_data_length    The amount of data returned in the p_data buffer
+ *
+ *
+ * \return      A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                  The operation completed successfully
+ * \retval      PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided `uid` value was not found in the storage
+ * \retval      PSA_ERROR_INVALID_SIZE       The operation failed because the data associated with provided uid is larger than `data_size`
+ * \retval      PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
+ * \retval      PSA_ERROR_INVALID_ARGUMENT   The operation failed because one of the provided pointers(`p_data`, `p_data_length`)
+ *                                           is invalid. For example is `NULL` or references memory the caller cannot access.
+ *                                           In addition, this can also happen if an invalid offset was provided.
+ */
+psa_status_t psa_its_get_backend( psa_storage_uid_t uid, uint32_t data_offset,
+                                  uint32_t data_length, void *p_data,
+                                  size_t *p_data_length );
+
+/**
+ * \brief Retrieve the metadata about the provided uid
+ *
+ * \param[in] uid           The uid value
+ * \param[out] p_info       A pointer to the `psa_storage_info_t` struct that will be populated with the metadata
+ *
+ * \return      A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                  The operation completed successfully
+ * \retval      PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided uid value was not found in the storage
+ * \retval      PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
+ * \retval      PSA_ERROR_INVALID_ARGUMENT   The operation failed because one of the provided pointers(`p_info`)
+ *                                           is invalid, for example is `NULL` or references memory the caller cannot access
+ */
+psa_status_t psa_its_get_info_backend( psa_storage_uid_t uid,
+                                       struct psa_storage_info_t *p_info );
+
+/**
+ * \brief Remove the provided key and its associated data from the storage
+ *
+ * \param[in] uid   The uid value
+ *
+ * \return  A status indicating the success/failure of the operation
+ *
+ * \retval      PSA_SUCCESS                  The operation completed successfully
+ * \retval      PSA_ERROR_DOES_NOT_EXIST     The operation failed because the provided key value was not found in the storage
+ * \retval      PSA_ERROR_NOT_PERMITTED      The operation failed because the provided key value was created with PSA_STORAGE_WRITE_ONCE_FLAG
+ * \retval      PSA_ERROR_STORAGE_FAILURE    The operation failed because the physical storage has failed (Fatal error)
+ */
+psa_status_t psa_its_remove_backend( psa_storage_uid_t uid );
+
+#endif /* PSA_EITS_BACKEND_H */

--- a/nrf_security/src/psa/psa_eits_zephyr_settings.c
+++ b/nrf_security/src/psa/psa_eits_zephyr_settings.c
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <zephyr.h>
+#include <init.h>
+#include <logging/log.h>
+#include <settings/settings.h>
+#include <sys/printk.h>
+#include <storage/flash_map.h>
+
+#include "psa_eits_backend.h"
+
+LOG_MODULE_REGISTER(psa_eits_zephyr_settings,
+		    CONFIG_PSA_EITS_BACKEND_ZEPHYR_LOG_LEVEL);
+
+#define ROOT_KEY "EITS"
+#define MAX_PATH_LEN 32
+
+struct read_info_ctx {
+    /* A container for metadata associated with a specific uid */
+    struct psa_storage_info_t *info;
+
+    /* Operation result. */
+    psa_status_t status;
+};
+
+struct read_data_ctx {
+    /* Buffer for the data associated with a specific uid */
+    void *buff;
+
+    /* Buffer length. */
+    size_t buff_len;
+
+    /* Operation result. */
+    psa_status_t status;
+};
+
+static int read_info_cb( const char *name, size_t len, settings_read_cb read_cb,
+                         void *cb_arg, void *param )
+{
+    int ret;
+    const char *next;
+    size_t next_len;
+    struct read_info_ctx *ctx = (struct read_info_ctx *) param;
+
+    __ASSERT( ctx != NULL, "Improper value" );
+    __ASSERT( ctx->info != NULL, "Improper value" );
+
+    next_len = settings_name_next( name, &next );
+
+    if ( !strncmp( name, "data", next_len ) )
+    {
+        ctx->info->size = len;
+        LOG_DBG( "read: <%s_.size> = %d", name, len );
+
+        return 0;
+    }
+
+    if ( !strncmp( name, "flags", next_len ) )
+    {
+        ret = read_cb( cb_arg, &ctx->info->flags, sizeof( ctx->info->flags ) );
+        if ( ret <= 0 )
+        {
+            LOG_ERR( "Failed to read the setting, ret: %d", ret );
+            ctx->status = PSA_ERROR_STORAGE_FAILURE;
+        }
+        ctx->status = PSA_SUCCESS;
+        LOG_DBG( "read: <%s> = %d", name, ctx->info->flags );
+
+        return 0;
+    }
+
+    return -ENOENT;
+}
+
+static int read_data_cb( const char *name, size_t len, settings_read_cb read_cb,
+                         void *cb_arg, void *param )
+{
+    int ret;
+    const char *next;
+    size_t next_len;
+    struct read_data_ctx *ctx = (struct read_data_ctx *) param;
+
+    __ASSERT( ctx != NULL, "Improper value" );
+    __ASSERT( ctx->buff != NULL, "Improper value" );
+
+    next_len = settings_name_next( name, &next );
+    if ( next_len == 0 )
+    {
+        if ( len > ctx->buff_len )
+        {
+            ctx->status = PSA_ERROR_BUFFER_TOO_SMALL;
+            return -ENOENT;
+        }
+
+        ret = read_cb( cb_arg, ctx->buff, len );
+        if ( ret <= 0 )
+        {
+            LOG_ERR( "Failed to read the setting, ret: %d", ret );
+            ctx->status = PSA_ERROR_STORAGE_FAILURE;
+        }
+        ctx->status = PSA_SUCCESS;
+        LOG_DBG( "read: <%s/data>", name );
+
+        return 0;
+    }
+    LOG_WRN( "The setting: %s is not present in the storage.", name );
+
+    /* The settings is not found, return error and stop processing */
+    return -ENOENT;
+}
+
+static psa_status_t is_write_once_set( psa_storage_uid_t uid,
+                                       bool *is_write_once )
+{
+    psa_status_t status;
+    struct psa_storage_info_t info = {
+        .size = 0,
+        .flags = 0,
+    };
+
+    __ASSERT( is_write_once != NULL, "Improper value" );
+
+    status = psa_its_get_info( uid, &info );
+    if ( status != PSA_SUCCESS )
+    {
+        return status;
+    }
+
+    *is_write_once = info.flags & PSA_STORAGE_FLAG_WRITE_ONCE;
+
+    return PSA_SUCCESS;
+}
+
+static void create_data_path( psa_storage_uid_t uid, char *buff,
+                              size_t buff_size )
+{
+    __ASSERT( buff != NULL, "Impropert value" );
+
+    int ret = snprintk( buff, buff_size, "%s/%" PRIx64 "/data", ROOT_KEY, uid );
+
+    __ASSERT( ret < buff_size, "Buffer size is too small." );
+}
+
+static void create_flags_path( psa_storage_uid_t uid, char *buff,
+                               size_t buff_size )
+{
+    __ASSERT( buff != NULL, "Impropert value" );
+
+    int ret = snprintk( buff, buff_size, "%s/%" PRIx64 "/flags", ROOT_KEY,
+                        uid );
+
+    __ASSERT( ret < buff_size, "Buffer size is too small." );
+}
+
+static psa_status_t read_data( psa_storage_uid_t uid,
+                               struct read_data_ctx *read_data_ctx )
+{
+    int ret;
+    char path[MAX_PATH_LEN];
+
+    create_data_path( uid, path, sizeof( path ) );
+
+    ret = settings_load_subtree_direct( path, read_data_cb, read_data_ctx );
+    if ( ret != 0 )
+    {
+        LOG_ERR( "Failed to load data for uid: %" PRIx64 ", ret %d", uid, ret );
+        return PSA_ERROR_STORAGE_FAILURE;
+    }
+
+    return read_data_ctx->status;
+}
+
+static psa_status_t read_data_with_offset( psa_storage_uid_t uid,
+                                           uint32_t data_offset,
+                                           uint32_t data_length, void *p_data,
+                                           size_t *p_data_length,
+                                           struct read_data_ctx *read_data_ctx )
+{
+    uint8_t buff[CONFIG_PSA_EITS_READ_BUFF_SIZE];
+
+    struct psa_storage_info_t info = {
+        .size = 0,
+        .flags = 0,
+    };
+
+    psa_status_t status = psa_its_get_info( uid, &info );
+    if ( status != PSA_SUCCESS )
+    {
+        return status;
+    }
+
+    if ( data_offset >= info.size )
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    if ( info.size - data_offset > data_length )
+    {
+        return PSA_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    __ASSERT( CONFIG_PSA_EITS_READ_BUFF_SIZE >= info.size,
+              "CONFIG_PSA_EITS_READ_BUFF_SIZE too small" );
+
+    read_data_ctx->buff = buff;
+    read_data_ctx->buff_len = sizeof( buff );
+
+    status = read_data( uid, read_data_ctx );
+    if ( status == PSA_SUCCESS )
+    {
+        *p_data_length = info.size - data_offset;
+        memcpy( p_data, buff + data_offset, *p_data_length );
+    }
+
+    return status;
+}
+
+psa_status_t psa_its_set_backend( psa_storage_uid_t uid, uint32_t data_length,
+                                  const void *p_data,
+                                  psa_storage_create_flags_t create_flags )
+{
+    char path[MAX_PATH_LEN];
+    psa_status_t status;
+    bool is_write_once;
+
+    LOG_DBG( "Setting uid: %" PRIx64, uid );
+
+    /* Check that the arguments are valid */
+    if ( p_data == NULL || data_length == 0 )
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    /* Check that the create_flags does not contain any unsupported flags */
+    if ( create_flags & ~( PSA_STORAGE_FLAG_WRITE_ONCE ) )
+    {
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+
+    status = is_write_once_set( uid, &is_write_once );
+    if ( status != PSA_SUCCESS && status != PSA_ERROR_DOES_NOT_EXIST )
+    {
+        return status;
+    }
+
+    if ( status == PSA_SUCCESS && is_write_once )
+    {
+        return PSA_ERROR_NOT_PERMITTED;
+    }
+
+    /* Store flags associated with the stored data */
+    create_flags_path( uid, path, sizeof( path ) );
+    if ( settings_save_one( path, (const void *) &create_flags,
+                            sizeof( create_flags ) ) )
+    {
+        LOG_ERR( "Failed to store flags for uid: %" PRIx64, uid );
+        return PSA_ERROR_STORAGE_FAILURE;
+    }
+
+    /* Store data */
+    create_data_path( uid, path, sizeof( path ) );
+    if ( settings_save_one( path, p_data, data_length ) )
+    {
+        LOG_ERR( "Failed to store data for uid: %" PRIx64, uid );
+        return PSA_ERROR_STORAGE_FAILURE;
+    }
+
+    return PSA_SUCCESS;
+}
+
+psa_status_t psa_its_get_backend( psa_storage_uid_t uid, uint32_t data_offset,
+                                  uint32_t data_length, void *p_data,
+                                  size_t *p_data_length )
+{
+    psa_status_t status;
+
+    struct read_data_ctx read_data_ctx = {
+        .buff = p_data,
+        .buff_len = data_length,
+        .status = PSA_ERROR_DOES_NOT_EXIST,
+    };
+
+    LOG_DBG( "Getting data for uid: 0x%" PRIx64, uid );
+
+    if ( p_data == NULL || p_data_length == NULL || data_length == 0 )
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    if ( data_offset != 0 )
+    {
+        return read_data_with_offset( uid, data_offset, data_length, p_data,
+                                      p_data_length, &read_data_ctx );
+    }
+    else
+    {
+        status = read_data( uid, &read_data_ctx );
+        if ( status == PSA_SUCCESS )
+        {
+            *p_data_length = data_length;
+        }
+
+        return status;
+    }
+}
+
+psa_status_t psa_its_get_info_backend( psa_storage_uid_t uid,
+                                       struct psa_storage_info_t *p_info )
+{
+    int ret;
+    char path[MAX_PATH_LEN];
+    struct read_info_ctx read_info_ctx = {
+        .info = p_info,
+        .status = PSA_ERROR_DOES_NOT_EXIST,
+    };
+
+    LOG_DBG( "Getting info for uid: 0x%" PRIx64, uid );
+
+    if ( p_info == NULL )
+    {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    ret = snprintk( path, sizeof( path ), "%s/%" PRIx64, ROOT_KEY, uid );
+    __ASSERT( ret < sizeof( path ), "Setting path buffer too small." );
+
+    ret = settings_load_subtree_direct( path, read_info_cb, &read_info_ctx );
+    if ( ret != 0 )
+    {
+        LOG_ERR( "Failed to load info for uid: %" PRIx64 ", ret %d", uid, ret );
+        return PSA_ERROR_STORAGE_FAILURE;
+    }
+
+    return read_info_ctx.status;
+}
+
+psa_status_t psa_its_remove_backend( psa_storage_uid_t uid )
+{
+    psa_status_t status;
+    bool is_write_once;
+    char path[MAX_PATH_LEN];
+
+    LOG_DBG( "Removing data for uid: %" PRIx64, uid );
+
+    status = is_write_once_set( uid, &is_write_once );
+    if ( status != PSA_SUCCESS )
+    {
+        return status;
+    }
+
+    if ( is_write_once )
+    {
+        return PSA_ERROR_NOT_PERMITTED;
+    }
+
+    create_flags_path( uid, path, sizeof( path ) );
+    if ( settings_delete( path ) )
+    {
+        return PSA_ERROR_STORAGE_FAILURE;
+    }
+
+    create_data_path( uid, path, sizeof( path ) );
+    if ( settings_delete( path ) )
+    {
+        return PSA_ERROR_STORAGE_FAILURE;
+    }
+
+    return PSA_SUCCESS;
+}
+
+static int zephyr_settings_init( const struct device *device )
+{
+    int ret;
+
+    ARG_UNUSED( device );
+
+    ret = settings_subsys_init();
+    if ( ret != 0 )
+    {
+        LOG_ERR( "settings_subsys_init failed (ret %d)", ret );
+    }
+
+    return ret;
+}
+
+SYS_INIT( zephyr_settings_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY );


### PR DESCRIPTION
The Zephyr backend is based on Zephyr Settings subsystem.
The current implementation of PSA EITS is still missing with encryption part.

Reference sdk-nrf PR: https://github.com/nrfconnect/sdk-nrf/pull/3806