### PR TITLE
cmake: fixing user provided ARM_MBEDTLS_PATH

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -41,8 +41,8 @@ function(nrfxlib_calculate_lib_path lib_path)
   set(${lib_path} "lib/${arch_soc_dir}/${float_dir}${short_wchar}" PARENT_SCOPE)
 endfunction()
 
-function(get_mbedtls_dir ARM_MBEDTLS_PATH)
-  if(EXISTS ${ARM_MBEDTLS_PATH})
+function(get_mbedtls_dir ARM_MBEDTLS_PATH_ARG)
+  if(EXISTS ${${ARM_MBEDTLS_PATH_ARG}})
   # Do nothing, just use the provided path
   elseif(WEST)
   ## Use `west` to find the mbedtls tree we use (this is not the
@@ -53,13 +53,12 @@ function(get_mbedtls_dir ARM_MBEDTLS_PATH)
       OUTPUT_VARIABLE west_project_output
       RESULT_VARIABLE result
     )
-    string(REGEX REPLACE "[\r\n]+" "" ${ARM_MBEDTLS_PATH} "${west_project_output}")
+    string(REGEX REPLACE "[\r\n]+" "" arm_mbedtls_path "${west_project_output}")
     if(${result})
       message(FATAL_ERROR "Failed to find mbedtls, cannot build security libraries")
     endif()
+    set(${ARM_MBEDTLS_PATH_ARG} ${arm_mbedtls_path} PARENT_SCOPE)
   else()
     message(FATAL_ERROR "west not installed, please provide ARM_MBEDTLS_PATH to CMake to support security libraries")
   endif()
-
-  set(ARM_MBEDTLS_PATH ${ARM_MBEDTLS_PATH} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
The `get_mbedtls_dir()` function was not handling user provided
ARM_MBEDTLS_PATH properly, as it was hiding the outer CMake variable
due to function argument of the same name.

This is now fixed by renaming the function argument from
ARM_MBEDTLS_PATH to ARM_MBEDTLS_PATH_ARG

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-----

Manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/3810