### PR TITLE
crypto: Link platform and mbecrypto libs when nrf security is disabled

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -113,7 +113,7 @@ if (CONFIG_NRF_CC3XX_PLATFORM)
   zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_mutex_zephyr.c)
 endif()
 
-if (CONFIG_CC3XX_BACKEND)
+if (CONFIG_NRF_CC3XX_MBEDCRYPTO)
   if(CONFIG_SOC_NRF5340_CPUAPP)
     set (CC3XX_ARCH cc312)
   else()
@@ -146,10 +146,16 @@ if (CONFIG_CC3XX_BACKEND)
                              "${NRF_CC3XX_BASE}/include"
                              "${NRF_CC3XX_BASE}/include/mbedtls")
   target_link_libraries(mbedcrypto_cc3xx_imported INTERFACE platform_cc3xx)
+
+  if (NOT CONFIG_NORDIC_SECURITY_BACKEND)
+    target_link_libraries(platform_cc3xx INTERFACE mbedcrypto_cc3xx_imported)
+  endif()
+
   if (NOT CONFIG_NRF_SECURITY_MULTI_BACKEND)
     # Only CC3XX backend is selected for mbedtls API.
     # Thus export the alt headers through Zephyr interface library.
     zephyr_include_directories(${NRF_CC3XX_BASE}/include/mbedtls
                                ${NRF_CC3XX_BASE}/include)
   endif()
+
 endif()

--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -23,12 +23,21 @@ if NRF_CC310_BL
 	default n # Only the no-interrupts version currently verified to work with Zephyr.
 endif
 
+config NRF_CC3XX_MBEDCRYPTO
+	bool
+	depends on HW_CC3XX
+	help
+	  Use nrf_cc3xx_mbedcrypto library. This is automatically ensured
+	  when using nrf security with the cc3xx backend.
+	  Only select this setting without nrf security for special use
+	  cases, such as csrng support without nrf security.
+
 menuconfig NRF_CC3XX_PLATFORM
 	bool "nrf_cc3xx_platform HW crypto library for nRF devices with CryptoCell CC3xx."
 	select NRFXLIB_CRYPTO
 	depends on HW_CC3XX
 	help
-		To use, link with nrfxlib_crypto in CMake.
+	  To use, link with nrfxlib_crypto in CMake.
 
 if NRF_CC3XX_PLATFORM
 

--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -145,6 +145,7 @@ menuconfig CC3XX_BACKEND
 	depends on CRYPTOCELL_USABLE
 	default y
 	select NRF_CC3XX_PLATFORM
+	select NRF_CC3XX_MBEDCRYPTO
 	help
 	  Enable cc3xx backend
 

--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -152,12 +152,12 @@ if CC3XX_BACKEND
 
 config CC310_BACKEND
 	bool
-	depends on CC3XX_BACKEND && CRYPTOCELL_CC310_USABLE
+	depends on CRYPTOCELL_CC310_USABLE
 	default y
 
 config CC312_BACKEND
 	bool
-	depends on CC3XX_BACKEND && CRYPTOCELL_CC312_USABLE
+	depends on CRYPTOCELL_CC312_USABLE
 	default y
 
 


### PR DESCRIPTION
-crypto: nrf_security Kconfig cleanup 
-crypto: Link platform and mbecrypto libs when nrf security is disabled
-crypto: Link mbedcrypto_cc3xx_imported when NRF_CC3XX_PLATFORM is set

Ref: NCSDK-8125

Relevant nrf PR: [sdk-nrf/pull/3793](https://github.com/nrfconnect/sdk-nrf/pull/3793)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>