### PR TITLE
nrf_security: cleanup of mbedtls glue libraries

### DIFF
--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/symbol_rename.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/symbol_strip.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/combine_archives.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/nrf_glue_library.cmake)
 
 #
 # Create an interface library with all shared compile definition and include

--- a/nrf_security/cmake/nrf_glue_library.cmake
+++ b/nrf_security/cmake/nrf_glue_library.cmake
@@ -61,3 +61,89 @@ function(nrf_security_glue_library)
   endif()
   nrf_security_debug_list_target_files(${ZEPHYR_CURRENT_LIBRARY})
 endfunction()
+
+
+function(nrf_security_shared_library)
+  cmake_parse_arguments(LIB "" "NAME" "" ${ARGN})
+  set(sources "")
+  set(ARGN_LOCAL ${ARGN})
+
+  set(index 0)
+  set(prev_index 0)
+  set(length -1)
+  foreach(arg ${ARGN_LOCAL})
+    if(${arg} STREQUAL FILES)
+      list(APPEND FILES_START_INDICES ${index})
+      if(prev_index)
+        math(EXPR  length "${index} - ${prev_index}")
+        set(FILES_INDEX_${prev_index}_LENGTH ${length})
+      endif()
+      set(prev_index ${index})
+    endif()
+    math(EXPR  index "${index} + 1")
+  endforeach()
+  set(FILES_INDEX_${prev_index}_LENGTH -1)
+
+  foreach(index ${FILES_START_INDICES})
+    list(SUBLIST ARGN_LOCAL ${index} ${FILES_INDEX_${index}_LENGTH} SUB_LIST)
+
+    # Create sublist and parse sub-args.
+    cmake_parse_arguments(SOURCE_LIST "" "" "FILES;INCLUDE;EXCLUDE" ${SUB_LIST})
+
+    list(GET SOURCE_LIST_FILES 0 file)
+    get_filename_component(file_name ${file} NAME_WE)
+    string(TOUPPER ${file_name} SETTING_UPPER)
+
+    if(CONFIG_MBEDTLS_${SETTING_UPPER}_C)
+      set(use_file True)
+      foreach(backend ${SOURCE_LIST_INCLUDE})
+        if(CONFIG_${backend}_MBEDTLS_${SETTING_UPPER}_C)
+          # include file
+          set(use_file True)
+        endif()
+      endforeach()
+
+      foreach(backend ${SOURCE_LIST_EXCLUDE})
+        if(CONFIG_${backend}_MBEDTLS_${SETTING_UPPER}_C)
+          # exclude file
+          set(use_file False)
+        endif()
+      endforeach()
+
+      if(${use_file})
+        nrf_security_debug("Adding to shared: ${SETTING_UPPER}")
+        list(APPEND sources ${SOURCE_LIST_FILES})
+      endif()
+    endif()
+  endforeach()
+
+  if(NOT sources STREQUAL "")
+    zephyr_library_named(${LIB_NAME})
+    target_sources(${LIB_NAME} PRIVATE ${sources})
+
+    #
+    # Add specific includes for threading and platform_cc3xx
+    #
+    if(TARGET platform_cc3xx)
+      target_include_directories(${LIB_NAME} PRIVATE
+        ${mbedcrypto_glue_include_path}/threading
+        $<TARGET_PROPERTY:platform_cc3xx,BASE_INCLUDE_PATH>
+      )
+    endif()
+
+    target_compile_options(${LIB_NAME} PRIVATE ${TOOLCHAIN_C_FLAGS})
+    target_ld_options(${LIB_NAME} PRIVATE ${TOOLCHAIN_LD_FLAGS})
+
+    # Where are ${common_includes} and ${config_include} defined ?
+    target_include_directories(${LIB_NAME} PRIVATE
+        ${common_includes}
+        ${config_include}
+    )
+
+    target_compile_definitions(${LIB_NAME} PRIVATE
+      -DMBEDTLS_CONFIG_FILE="nrf-config-noglue.h"
+    )
+
+    nrf_security_debug_list_target_files(${LIB_NAME})
+  endif()
+endfunction()

--- a/nrf_security/cmake/nrf_glue_library.cmake
+++ b/nrf_security/cmake/nrf_glue_library.cmake
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+function(nrf_security_glue_library)
+  set(option ALT)
+  set(single BACKEND)
+  set(multi FILES)
+  cmake_parse_arguments(GLUE_LIB "${option}" "${single}" "${multi}" ${ARGN})
+  set(sources "")
+
+  foreach(file ${GLUE_LIB_FILES})
+    get_filename_component(file_name ${file} NAME_WE)
+
+    if(DEFINED GLUE_LIB_BACKEND)
+      string(REPLACE "cc310" "cc3xx" file_name ${file_name})
+      string(REPLACE "_${GLUE_LIB_BACKEND}" "" setting ${file_name})
+      string(TOUPPER ${setting} SETTING_UPPER)
+      string(TOUPPER ${GLUE_LIB_BACKEND} BACKEND_UPPER)
+
+      if(CONFIG_GLUE_${BACKEND_UPPER}_MBEDTLS_${SETTING_UPPER}_C)
+        nrf_security_debug("Adding to ${BACKEND_UPPER}_glue: ${SETTING_UPPER}")
+        list(APPEND sources ${file})
+      endif()
+    endif()
+
+    if(GLUE_LIB_ALT)
+      string(REPLACE "_alt" "" setting ${file_name})
+      string(TOUPPER ${setting} SETTING_UPPER)
+
+      if(CONFIG_GLUE_MBEDTLS_${SETTING_UPPER}_C)
+        nrf_security_debug("Adding to glue: ${SETTING_UPPER}")
+        list(APPEND sources ${file})
+      endif()
+    endif()
+  endforeach()
+
+  if(NOT sources STREQUAL "")
+    if(GLUE_LIB_ALT)
+      zephyr_library_named(mbedcrypto_glue)
+    else()
+      zephyr_library_named(mbedcrypto_glue_${GLUE_LIB_BACKEND})
+      zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=${GLUE_LIB_BACKEND})
+      add_dependencies(mbedcrypto_glue_${GLUE_LIB_BACKEND} mbedcrypto_${GLUE_LIB_BACKEND}_renamed)
+
+      add_custom_command(
+        TARGET mbedcrypto_glue_${GLUE_LIB_BACKEND}
+        POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY}
+                --redefine-syms
+                ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${GLUE_LIB_BACKEND}.txt
+                $<TARGET_FILE:mbedcrypto_glue_${GLUE_LIB_BACKEND}>
+        DEPENDS mbedcrypto_${GLUE_LIB_BACKEND}_renamed
+      )
+    endif()
+
+    zephyr_library_sources(${sources})
+    zephyr_library_link_libraries(mbedtls_common_glue)
+  endif()
+  nrf_security_debug_list_target_files(${ZEPHYR_CURRENT_LIBRARY})
+endfunction()

--- a/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
+++ b/nrf_security/src/mbedcrypto_glue/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Nordic Semiconductor
+# Copyright (c) 2019-2021 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
@@ -16,36 +16,10 @@ if(CONFIG_NRF_SECURITY_GLUE_LIBRARY)
   )
   target_link_libraries(mbedtls_common_glue INTERFACE mbedtls_common)
 
-
-  if(CONFIG_GLUE_MBEDTLS_AES_C)
-    nrf_security_debug("Adding to glue: AES")
-  endif()
-
-  if(CONFIG_GLUE_MBEDTLS_CCM_C)
-    nrf_security_debug("Adding to glue: CCM")
-  endif()
-
-  if(CONFIG_GLUE_MBEDTLS_DHM_C)
-    nrf_security_debug("Adding to glue: DHM")
-  endif()
-
   #
   # Create the glue wrapper library
   #
-  zephyr_library_named(mbedcrypto_glue)
-  zephyr_library_sources(${ZEPHYR_BASE}/misc/empty_file.c)
-
-  #
-  # Add glued files if enabled
-  #
-  zephyr_library_sources_ifdef(CONFIG_GLUE_MBEDTLS_AES_C    aes_alt.c)
-  zephyr_library_sources_ifdef(CONFIG_GLUE_MBEDTLS_CCM_C    ccm_alt.c)
-  zephyr_library_sources_ifdef(CONFIG_GLUE_MBEDTLS_CMAC_C   cmac_alt.c)
-  zephyr_library_sources_ifdef(CONFIG_GLUE_MBEDTLS_DHM_C    dhm_alt.c)
-
-  zephyr_library_link_libraries(mbedtls_common_glue)
-  nrf_security_debug_list_target_files(mbedcrypto_glue)
-
+  nrf_security_glue_library(ALT FILES aes_alt.c ccm_alt.c cmac_alt.c dhm_alt.c)
 
   #
   # Create glue libraries for backends (if enabled)

--- a/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/cc310/cc310_glue.cmake
@@ -5,39 +5,11 @@
 #
 nrf_security_debug("######### Creating cc310 glue library #########")
 
-zephyr_library_named(mbedcrypto_glue_cc3xx)
-
 #
-# Adding cc310 backend glue files
+# Create the cc3xx glue library
 #
-zephyr_library_sources_ifdef(CONFIG_GLUE_CC3XX_MBEDTLS_AES_C
-  ${CMAKE_CURRENT_LIST_DIR}/aes_cc310.c
-)
-zephyr_library_sources_ifdef(CONFIG_GLUE_CC3XX_MBEDTLS_CCM_C
-  ${CMAKE_CURRENT_LIST_DIR}/ccm_cc310.c
-)
-zephyr_library_sources_ifdef(CONFIG_GLUE_CC3XX_MBEDTLS_DHM_C
-  ${CMAKE_CURRENT_LIST_DIR}/dhm_cc310.c
-)
-
-zephyr_library_sources(${ZEPHYR_BASE}/misc/empty_file.c)
-
-zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=cc3xx)
-zephyr_library_link_libraries(mbedtls_common_glue)
-nrf_security_debug_list_target_files(mbedcrypto_glue_cc3xx)
-
-add_dependencies(mbedcrypto_glue_cc3xx mbedcrypto_cc3xx_renamed)
-
-#
-# Rename the external symbols as referenced through the glue files
-# The APIs will match cc3xx_mbedtls_<xxxx> after this.
-#
-add_custom_command(
-  TARGET mbedcrypto_glue_cc3xx
-  POST_BUILD
-  COMMAND ${CMAKE_OBJCOPY}
-          --redefine-syms
-          ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_cc3xx.txt
-          $<TARGET_FILE:mbedcrypto_glue_cc3xx>
-  DEPENDS mbedcrypto_cc3xx_renamed
+nrf_security_glue_library(BACKEND cc3xx
+                          FILES ${CMAKE_CURRENT_LIST_DIR}/aes_cc310.c
+                                ${CMAKE_CURRENT_LIST_DIR}/ccm_cc310.c
+                                ${CMAKE_CURRENT_LIST_DIR}/dhm_cc310.c
 )

--- a/nrf_security/src/mbedcrypto_glue/oberon/oberon_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/oberon/oberon_glue.cmake
@@ -8,37 +8,7 @@ nrf_security_debug("######### Creating oberon glue library #########")
 #
 # Create the Oberon glue library
 #
-zephyr_library_named(mbedcrypto_glue_oberon)
-
-#
-# Adding Oberon backend glue files
-#
-zephyr_library_sources_ifdef(CONFIG_GLUE_OBERON_MBEDTLS_AES_C
-  ${CMAKE_CURRENT_LIST_DIR}/aes_oberon.c
-)
-
-zephyr_library_sources_ifdef(CONFIG_GLUE_OBERON_MBEDTLS_CCM_C
-  ${CMAKE_CURRENT_LIST_DIR}/ccm_oberon.c
-)
-
-zephyr_library_sources(${ZEPHYR_BASE}/misc/empty_file.c)
-zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=oberon)
-zephyr_library_link_libraries(mbedtls_common_glue)
-
-add_dependencies(mbedcrypto_glue_oberon mbedcrypto_oberon_renamed)
-
-nrf_security_debug_list_target_files(mbedcrypto_glue_oberon)
-
-#
-# Rename the external symbols as referenced through the glue files
-# The APIs will match oberon_mbedtls_<xxxx> after this.
-#
-
-add_custom_command(
-  TARGET mbedcrypto_glue_oberon
-  POST_BUILD
-  COMMAND ${CMAKE_OBJCOPY}
-          --redefine-syms ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_oberon.txt
-          $<TARGET_FILE:mbedcrypto_glue_oberon>
-  DEPENDS mbedcrypto_oberon_renamed
+nrf_security_glue_library(BACKEND oberon
+                          FILES ${CMAKE_CURRENT_LIST_DIR}/aes_oberon.c
+                                ${CMAKE_CURRENT_LIST_DIR}/ccm_oberon.c
 )

--- a/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
+++ b/nrf_security/src/mbedcrypto_glue/vanilla/vanilla_glue.cmake
@@ -8,35 +8,8 @@ nrf_security_debug("######### Creating vanilla glue library #########")
 #
 # Create the vanilla glue library
 #
-zephyr_library_named(mbedcrypto_glue_vanilla)
-
-#
-# Adding vanilla backend glue files
-#
-zephyr_library_sources_ifdef(CONFIG_GLUE_VANILLA_MBEDTLS_AES_C
-  ${CMAKE_CURRENT_LIST_DIR}/aes_vanilla.c
-)
-zephyr_library_sources_ifdef(CONFIG_GLUE_VANILLA_MBEDTLS_CCM_C
-  ${CMAKE_CURRENT_LIST_DIR}/ccm_vanilla.c
-)
-zephyr_library_sources_ifdef(CONFIG_GLUE_VANILLA_MBEDTLS_DHM_C
-  ${CMAKE_CURRENT_LIST_DIR}/dhm_vanilla.c
-)
-
-zephyr_library_sources(${ZEPHYR_BASE}/misc/empty_file.c)
-zephyr_library_compile_definitions(MBEDTLS_BACKEND_PREFIX=vanilla)
-zephyr_library_link_libraries(mbedtls_common_glue)
-
-add_dependencies(mbedcrypto_glue_vanilla mbedcrypto_vanilla_renamed)
-
-nrf_security_debug_list_target_files(mbedcrypto_glue_vanilla)
-
-add_custom_command(
-  TARGET mbedcrypto_glue_vanilla
-  POST_BUILD
-  COMMAND ${CMAKE_OBJCOPY}
-          --redefine-syms
-          ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_vanilla.txt
-          $<TARGET_FILE:mbedcrypto_glue_vanilla>
-  DEPENDS mbedcrypto_vanilla_renamed
+nrf_security_glue_library(BACKEND vanilla
+                          FILES ${CMAKE_CURRENT_LIST_DIR}/aes_vanilla.c
+                                ${CMAKE_CURRENT_LIST_DIR}/ccm_vanilla.c
+                                ${CMAKE_CURRENT_LIST_DIR}/dhm_vanilla.c
 )

--- a/nrf_security/src/mbedtls/shared/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/shared/CMakeLists.txt
@@ -15,82 +15,21 @@ nrf_security_debug("######### Creating shared noglue library #########")
 # features not provided by the specific backend
 #
 # All features added here can't be glued
+
+nrf_security_shared_library(
+  NAME mbedcrypto_shared
+  FILES ${ARM_MBEDTLS_PATH}/library/chacha20.c INCLUDE VANILLA OBERON EXCLUDE CC3XX
+  FILES ${ARM_MBEDTLS_PATH}/library/poly1305.c INCLUDE VANILLA OBERON EXCLUDE CC3XX
+  FILES ${ARM_MBEDTLS_PATH}/library/chachapoly.c INCLUDE VANILLA EXCLUDE CC3XX
+  FILES ${ARM_MBEDTLS_PATH}/library/rsa.c ${ARM_MBEDTLS_PATH}/library/rsa_internal.c INCLUDE VANILLA EXCLUDE CC3XX
+  FILES ${ARM_MBEDTLS_PATH}/library/sha512.c
+#  FILES dhm.c BACKEND OBERON
+)
+# ToDo DHM.
+## Special case: Oberon only backend and enabled DHM
+#if (CONFIG_MBEDTLS_DHM_C AND CONFIG_OBERON_BACKEND)
 #
-add_library(mbedcrypto_shared STATIC
-  ${ZEPHYR_BASE}/misc/empty_file.c
-)
-
-
-if (CONFIG_VANILLA_MBEDTLS_CHACHA20_C OR CONFIG_OBERON_MBEDTLS_CHACHA20_C OR
-  (CONFIG_MBEDTLS_CHACHA20_C AND NOT CONFIG_CC3XX_MBEDTLS_CHACHA20_C))
-
-
-  target_sources(mbedcrypto_shared PRIVATE
-    ${ARM_MBEDTLS_PATH}/library/chacha20.c
-  )
-endif()
-
-
-if (CONFIG_VANILLA_MBEDTLS_POLY1305_C OR CONFIG_OBERON_MBEDTLS_POLY1305_C OR
-  (CONFIG_MBEDTLS_POLY1305_C AND NOT CONFIG_CC3XX_MBEDTLS_POLY1305_C))
-
-
-
-  target_sources(mbedcrypto_shared PRIVATE
-    ${ARM_MBEDTLS_PATH}/library/poly1305.c
-  )
-endif()
-
-if (CONFIG_VANILLA_MBEDTLS_CHACHAPOLY_C OR
-  (CONFIG_MBEDTLS_CHACHAPOLY_C AND NOT CONFIG_CC3XX_MBEDTLS_CHACHAPOLY_C))
-
-  target_sources(mbedcrypto_shared PRIVATE
-    ${ARM_MBEDTLS_PATH}/library/chachapoly.c
-  )
-endif()
-
-if (CONFIG_VANILLA_MBEDTLS_RSA_C OR
-   (CONFIG_MBEDTLS_RSA_C AND NOT CONFIG_CC3XX_MBEDTLS_RSA_C))
-
-  target_sources(mbedcrypto_shared PRIVATE
-    ${ARM_MBEDTLS_PATH}/library/rsa.c
-    ${ARM_MBEDTLS_PATH}/library/rsa_internal.c
-  )
-
-endif()
-
-target_sources_ifdef(CONFIG_MBEDTLS_SHA512_C
-  mbedcrypto_shared PRIVATE ${ARM_MBEDTLS_PATH}/library/sha512.c
-)
-
-# Special case: Oberon only backend and enabled DHM
-if (CONFIG_MBEDTLS_DHM_C AND CONFIG_OBERON_BACKEND)
-
-  target_sources(mbedcrypto_shared PRIVATE
-    ${ARM_MBEDTLS_PATH}/library/dhm.c
-  )
-endif()
-
-#
-# Add specific includes for threading and platform_cc3xx
-#
-if(TARGET platform_cc3xx)
-  target_include_directories(mbedcrypto_shared PRIVATE
-    ${mbedcrypto_glue_include_path}/threading
-    $<TARGET_PROPERTY:platform_cc3xx,BASE_INCLUDE_PATH>
-  )
-endif()
-
-target_compile_options(mbedcrypto_shared PRIVATE ${TOOLCHAIN_C_FLAGS})
-target_ld_options(mbedcrypto_shared PRIVATE ${TOOLCHAIN_LD_FLAGS})
-
-target_include_directories(mbedcrypto_shared PRIVATE
-    ${common_includes}
-    ${config_include}
-)
-
-target_compile_definitions(mbedcrypto_shared PRIVATE
-  -DMBEDTLS_CONFIG_FILE="nrf-config-noglue.h"
-)
-
-nrf_security_debug_list_target_files(mbedcrypto_shared)
+#  target_sources(mbedcrypto_shared PRIVATE
+#    ${ARM_MBEDTLS_PATH}/library/dhm.c
+#  )
+#endif()


### PR DESCRIPTION
Fixes: NCSDK-6991

This commit contains no functional changes and is a pure cleanup of the
CMake code.

It creates the function `nrf_security_glue_library()` which removes
several lines of duplicated code, and as part of this cleanup the use
of empty_file.c has been removed.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>