### PR TITLE
nrf_security: Expand hardware entropy wrapper to non-secure domain

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1652,6 +1652,12 @@ config MBEDTLS_X509_CSR_WRITE_C
 	help
 	  Enable creating X.509 Certificate Signing Requests (CSR).
 
+config MBEDTLS_ENTROPY_MAX_SOURCES
+	int "Maximum number of entropy sources"
+	default 1
+	help
+	  Maximum number of entropy sources supported.
+
 endif # NRF_SECURITY_ADVANCED
 
 endif # NRF_SECURITY_ANY_BACKEND

--- a/nrf_security/cmake/kconfig_mbedtls_configure.cmake
+++ b/nrf_security/cmake/kconfig_mbedtls_configure.cmake
@@ -309,6 +309,11 @@ kconfig_mbedtls_config("MBEDTLS_X509_CRL_PARSE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CSR_PARSE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CREATE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CSR_WRITE_C")
+kconfig_mbedtls_config_val("MBEDTLS_ENTROPY_MAX_SOURCES"          "${CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES}")
+
+if (CONFIG_TRUSTED_EXECUTION_SECURE AND CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES GREATER_EQUAL 1)
+  message(FATAL_ERROR "When building trusted firmware CryptoCell must be the only entropy source (CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES set to 1)")
+endif()
 
 #
 # Compare the following with check-config.h in mbed TLS

--- a/nrf_security/configs/nrf-config.h.template
+++ b/nrf_security/configs/nrf-config.h.template
@@ -3394,7 +3394,7 @@ it is (2^48 - 1), our restriction is :  (int - 0xFFFF - 0xF).*/
 #cmakedefine MBEDTLS_ECP_FIXED_POINT_OPTIM @MBEDTLS_ECP_FIXED_POINT_OPTIM@ /**< Enable fixed-point speed-up */
 
 /* Entropy options */
-#define MBEDTLS_ENTROPY_MAX_SOURCES                  1   /**< Maximum number of sources supported */
+#cmakedefine MBEDTLS_ENTROPY_MAX_SOURCES             @MBEDTLS_ENTROPY_MAX_SOURCES@ /**< Maximum number of sources supported */
 #define MBEDTLS_ENTROPY_MAX_GATHER                   144 /**< Maximum amount requested from entropy sources */
 //#define MBEDTLS_ENTROPY_MIN_HARDWARE               32 /**< Default minimum number of bytes required for the hardware entropy source mbedtls_hardware_poll() before entropy is released */
 

--- a/nrf_security/src/backend/entropy/entropy_poll.c
+++ b/nrf_security/src/backend/entropy/entropy_poll.c
@@ -3,11 +3,12 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <assert.h>
+
 #include <zephyr.h>
 #include <device.h>
 #include <drivers/entropy.h>
 #include <mbedtls/entropy.h>
+#include <mbedtls/entropy_poll.h>
 
 int mbedtls_hardware_poll(void *data,
                           unsigned char *output,

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -132,9 +132,10 @@ zephyr_library_sources_ifdef(CONFIG_MBEDTLS_ENABLE_HEAP
   ${NRF_SECURITY_ROOT}/src/mbedtls/mbedtls_heap.c
 )
 
-if (CONFIG_ENTROPY_CC3XX)
-elseif(CONFIG_ENTROPY_NRF5_RNG OR CONFIG_ENTROPY_NRF_LL_SOFTDEVICE)
-  zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/nrf5x/entropy_nrf5x.c)
+if ((CONFIG_ENTROPY_CC3XX AND CONFIG_TRUSTED_EXECUTION_NONSECURE) OR
+    CONFIG_ENTROPY_NRF5_RNG OR
+    CONFIG_ENTROPY_NRF_LL_SOFTDEVICE)
+  zephyr_library_sources(${NRF_SECURITY_ROOT}/src/backend/entropy/entropy_poll.c)
 endif()
 
 zephyr_library_link_libraries(mbedtls_common)


### PR DESCRIPTION
Build the implementation of mbedtls_hardware_poll
that MbedTLS library can use to obtain entropy from cryptocell
even when call is done from non-secure domain.

Jira:NCSDK-8203

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>