### PR TITLE
Update modem documentation to reflect AT socket requirement for datagram socket type

### DIFF
--- a/nrf_modem/doc/at_commands.rst
+++ b/nrf_modem/doc/at_commands.rst
@@ -35,7 +35,7 @@ The following code example shows how to send an AT command and receive the respo
    int func(void)
    {
        // Create a socket for AT commands.
-       int fd = nrf_socket(NRF_AF_LTE, 0, NRF_PROTO_AT);
+       int fd = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
 
        // Write the AT command.
        nrf_write(fd, "AT+CEREG=2", 10);


### PR DESCRIPTION
In version 0.6.2 of bsdlib the creation of sockets became more stringent:
> Improved validation of family, type, and protocol arguments in socket().

Subsequently the [sdk-nrf](https://github.com/nrfconnect/sdk-nrf/commit/76dcd07af33b3d8f43aee0f9114c9187040d0ce8) examples and libraries were adapted to reflect this new situation. However, the bsdlib documentation was not changed to reflect this.

When trying to create an AT socket with a `0` (zero) as the socket type parameter (as per documentation), a `NRF_EPROTOTYPE` error is thrown. Instead, a datagram type socket should be opened. This merge request updates the documentation to reflect this.