### PR TITLE
nrf_security: Removing alias Edwards25519 and Edwards448

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1243,14 +1243,14 @@ config MBEDTLS_ECP_DP_BP512R1_ENABLED
 	  MBEDTLS_ECP_DP_BP512R1_ENABLED setting in mbed TLS config file.
 
 config MBEDTLS_ECP_DP_CURVE25519_ENABLED
-	bool "Enable Curve25519 aka Edwards25519"
+	bool "Enable Curve25519"
 	depends on !OBERON_MBEDTLS_ECP_C
 	default n
 	help
 	  MBEDTLS_ECP_DP_CURVE25519_ENABLED setting in mbed TLS config file.
 
 config MBEDTLS_ECP_DP_CURVE448_ENABLED
-	bool "Enable Curve448 aka Edwards448"
+	bool "Enable Curve448"
 	depends on !OBERON_MBEDTLS_ECP_C
 	depends on VANILLA_MBEDTLS_ECP_C
 	default n

--- a/nrf_security/doc/backend_config.rst
+++ b/nrf_security/doc/backend_config.rst
@@ -548,8 +548,6 @@ Feature support
 |           |                   |             | secp224r1  |
 |           |                   +-------------+------------+
 |           |                   | Curve25519  | Curve25519 |
-|           |                   |             +------------+
-|           |                   |             | Ed25519    |
 |           +-------------------+-------------+------------+
 |           | Original mbed TLS | NIST        | secp192r1  |
 |           |                   |             +------------+
@@ -782,9 +780,9 @@ The following table shows the curves that can be enabled.
 +-----------------------------+-----------------------------------------------------+--------------------------+
 | Brainpool bp512r1           | :option:`CONFIG_MBEDTLS_ECP_DP_BP512R1_ENABLED`     | Original mbed TLS only   |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Curve25519 / Edwards25519   | :option:`CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED`  |                          |
+| Curve25519                  | :option:`CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Curve448 / Edwards448       | :option:`CONFIG_MBEDTLS_ECP_DP_CURVE448_ENABLED`    | Original mbed TLS only   |
+| Curve448                    | :option:`CONFIG_MBEDTLS_ECP_DP_CURVE448_ENABLED`    | Original mbed TLS only   |
 +-----------------------------+-----------------------------------------------------+--------------------------+
 
 .. note::


### PR DESCRIPTION
-Removing Edwards25519 (alias for Curve25519) to prevent
 assuming this configuration means Ed25519 is supported.
-Removing Edwards448 (alias for Curve448) to prevent
 assuming this configuration means Ed448 is supported.
 
manifest pr: https://github.com/nrfconnect/sdk-nrf/pull/3968

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>