### PR TITLE
doc: style: update terms for consistency

### DIFF
--- a/crypto/nrf_cc310_mbedcrypto/CHANGELOG.rst
+++ b/crypto/nrf_cc310_mbedcrypto/CHANGELOG.rst
@@ -489,7 +489,7 @@ Added a new build of nrf_cc310_mbedcrypto library for nRF9160 and nRF52 architec
 nrf_cc310_mbedcrypto - 0.9.1
 ****************************
 
-New experimental version of nrf_cc310_mbedcrypto with general bugfixes.
+New experimental version of nrf_cc310_mbedcrypto with general bug fixes.
 
 This version is dependent on the nrf_cc310_platform library for low-level initialization of the system and proper RTOS integration.
 
@@ -546,7 +546,7 @@ Added a new build of nrf_cc310_mbedcrypto library for nRF9160 and nRF52 architec
 nrf_cc310_mbedcrypto - 0.9.0
 ****************************
 
-New experimental version of nrf_cc310_mbedcrypto with general bugfixes.
+New experimental version of nrf_cc310_mbedcrypto with general bug fixes.
 
 This version is dependent on the newly added nrf_cc310_platform library for low-level  initialization of the system and proper RTOS integration.
 
@@ -603,7 +603,7 @@ Added a new build of nrf_cc310_mbedcrypto library for nRF9160 and nRF52 architec
 nrf_cc310_mbedcrypto - 0.8.1
 ****************************
 
-New experimental version of nrf_cc310_mbedcrypto with general bugfixes.
+New experimental version of nrf_cc310_mbedcrypto with general bug fixes.
 
 .. note::
   This version should be used for nRF9160 devices. Use of earlier versions may lead to
@@ -662,7 +662,7 @@ Added a new build of nrf_cc310_mbedcrypto library for nRF9160 and nRF52 architec
 nrf_cc310_mbedcrypto - 0.8.0
 ****************************
 
-New experimental version of nrf_cc310_mbedcrypto with changes to platform initialization and general bugfixes.
+New experimental version of nrf_cc310_mbedcrypto with changes to platform initialization and general bug fixes.
 
 ..warning::
    This version may lead to undefined behavior on some nRF9160 devices.

--- a/crypto/nrf_cc310_platform/CHANGELOG.rst
+++ b/crypto/nrf_cc310_platform/CHANGELOG.rst
@@ -12,7 +12,7 @@ All notable changes to this project are documented in this file.
 nrf_cc3xx_platform - 0.9.7
 **************************
 
-New version of the library with a bugfix:
+New version of the library with a bug fix:
 
 * Fixed an issue with mutex slab allocation in Zephyr RTOS platform file.
 

--- a/mpsl/CHANGELOG.rst
+++ b/mpsl/CHANGELOG.rst
@@ -24,8 +24,8 @@ Added
 * Added macro MPSL_RESERVED_PPI_CHANNELS for a bit mask of (D)PPI channels
   reserved by MPSL (DRGN-13356).
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue where Low Frequency Clock was configured incorrectly
   when the source configuration signal was set to either External Full swing or External Low swing. (DRGN-15064)
@@ -46,8 +46,8 @@ Changes
 * Added an API to use Front-End Modules, like the nRF21540 GPIO or a simple GPIO, with the protocols and an API to configure them using the application.
   Only the nRF52 series is supported.
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue where the high frequency clock and ``TIMER0`` were not turned off during idle periods shorter than 9 ms (DRGN-14152).
   This increased the average power consumption.
@@ -77,8 +77,8 @@ Changes
 * On nRF53, the fix for Errata 16 is now applied.
 * The scheduling overhead of a timeslot event is reduced.
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue on nRF53 where an assert could occur when using a timeslot.
 

--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -236,7 +236,7 @@ bsdlib 0.3.3
 
 Updated library with various changes:
 
-* Bugfix internal to the library solving issue with unresponsive sockets.
+* Bug fix internal to the library solving issue with unresponsive sockets.
 
 bsdlib 0.3.2
 ************
@@ -292,7 +292,7 @@ Updated library with various changes:
   (-nostdlib -nodefaultlibs -nostartfiles -lnosys).
 * Fixed issues with some unresolved symbols internal to the library.
 * Updated API towards bsd_os_timedwait function.
-  The time-out parameter is now an in and out parameter.
+  The timeout parameter is now an in and out parameter.
   The bsd_os implementation is now expected to set the remaining time left of the time-out value in return.
 
 bsdlib 0.2.2
@@ -307,12 +307,12 @@ Updated library with API for setting APN name when doing getaddrinfo request.
 bsdlib 0.2.1
 ************
 
-Updated library with bugfixes:
+Updated library with bug fixes:
 
 * Updated ``nrf_inbuilt_key.h`` with smaller documentation fixes.
-* Bugfix in the ``nrf_inbuilt_key`` API to allow PSK and Identity to be provisioned successfully.
-* Bugfix in the ``nrf_inbuilt_key`` API to allow security tags in the range of 65535 to 2147483647 to be deleted, read, and listed.
-* Bugfix in proprietary trace log.
+* Bug fix in the ``nrf_inbuilt_key`` API to allow PSK and Identity to be provisioned successfully.
+* Bug fix in the ``nrf_inbuilt_key`` API to allow security tags in the range of 65535 to 2147483647 to be deleted, read, and listed.
+* Bug fix in proprietary trace log.
 
 bsdlib 0.2.0
 ************

--- a/nrf_modem/doc/ug_nrf_modem_porting_os.rst
+++ b/nrf_modem/doc/ug_nrf_modem_porting_os.rst
@@ -35,7 +35,7 @@ It is responsible for preparing IRQ for low priority Modem library scheduling an
 .. note::
    When working with an application based on Zephyr, set the IRQs to a low priority (6 or 7) and enable them before exiting the function.
 
-The function must also initialize the timers and threads (if there is a context that needs a time-out).
+The function must also initialize the timers and threads (if there is a context that needs a timeout).
 If Nordic Proprietary trace is enabled, the library generates trace data and forwards it to a medium that can be initialized or configured by using the :c:func:`nrf_modem_os_init` function.
 The forwarded trace data is handled in the :c:func:`nrf_modem_os_trace_put` function.
 See :ref:`trace_output_function` for more information.
@@ -213,7 +213,7 @@ The following message sequence diagrams show the interactions between the applic
    Trace handling, lowering priority
 
 
-#. Handling a time-out or sleep:
+#. Handling a timeout or sleep:
 
 .. figure:: images/msc_timers.svg
    :alt: Timers

--- a/softdevice_controller/CHANGELOG.rst
+++ b/softdevice_controller/CHANGELOG.rst
@@ -55,8 +55,8 @@ Changes
 
 * All libraries are now compatible with all platforms within a given family (DRGN-15118).
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue where the application could not immediately restart a connectable advertiser after a high duty cycle advertiser timed out (DRGN-13029).
 * Fixed an issue where a directed advertiser used a resolvable address as the TargetA when the local device address was set to public or random device address (DRGN-13921).
@@ -132,8 +132,8 @@ Changes
   * HCI_VS_SUBEVENT -> HCI_SUBEVENT_VS
   * hci_vs_cmd      -> hci_cmd_vs
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue in master role which could cause disconnects if there were scheduling conflicts while doing a control procedures with an instant (DRGN-11222).
 
@@ -213,8 +213,8 @@ Changes
   Use corresponding API in MPSL instead.
 * Version numbers have been removed from the libraries.
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue where the application could not immediately restart a connectable advertiser after a high duty cycle advertiser timed out.
 * Fixed an issue where a control packet could be sent twice even after the packet was ACKed.
@@ -237,8 +237,8 @@ Added
 
 * Added support for nRF52833.
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue where :c:func:`hci_data_get` could return "No data available" when there was data available.
   This issue would only occur when connected to multiple devices at the same time.
@@ -246,8 +246,8 @@ Bugfixes
 nRF Bluetooth LE Controller 0.3.0-2.prealpha
 ********************************************
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue where an assert occured when the host issued LE Write Suggested Default Data Length.
 
@@ -271,8 +271,8 @@ Added
   When enabled, one report is generated with every connection event.
   The report contains information that can be used to change the Bluetooth LE channel map.
 
-Bugfixes
-========
+Bug fixes
+=========
 
 * Fixed an issue where HCI Read Local Supported Commands command did not indicate support for HCI LE Set Privacy Mode command.
 * Fixed an issue where an ASSERT occured when setting advertising data after HCI Reset without setting advertising parameters.
@@ -314,7 +314,7 @@ Changes
 nRF Bluetooth LE Controller 0.2.0-1.prealpha
 ********************************************
 
-Updated Bluetooth LE Controller with bugfixes and updated APIs.
+Updated Bluetooth LE Controller with bug fixes and updated APIs.
 
 Added
 =====
@@ -324,8 +324,8 @@ Added
 * Added API to get Bluetooth LE Controller build revision: :c:func:`ble_controller_build_revision_get`.
 * Added separate :c:func:`ble_controller_init` API.
 
-Bugfixes
-========
+Bug fixes
+=========
 
 Fixed an issue in HCI control flow that severely limited Bluetooth LE throughput.
 


### PR DESCRIPTION
Updated terminology for "bug fix" and "timeout".
"Bugfix" and "time-out" are not allowed.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>