### PR TITLE
doc: zboss: update changelog header

### DIFF
--- a/zboss/CHANGELOG.rst
+++ b/zboss/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog
 
 All notable changes to this project in |NCS| are documented in this file.
 
-Master branch
-*************
+nRF Connect SDK v1.5.1
+**********************
 
 Changes
 =======


### PR DESCRIPTION
Updated header to NCS 1.5.1 after release took place.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>