### PR TITLE
nrf_modem: Do not imply CONFIG_FPU

### DIFF
--- a/nrf_modem/Kconfig
+++ b/nrf_modem/Kconfig
@@ -1,6 +1,5 @@
 config NRF_MODEM
 	bool
-	imply FPU
 	imply FPU_SHARING
 
 choice NRF_MODEM_BUILD_STRATEGY


### PR DESCRIPTION
Removes the imply FPU kconfig entry in NRF_MODEM.

Previously, this would fail linking when TFM was enabled, as that forces
FP_SOFTABI, which there is no binary for. The intent of the original
encourage FPU usage when available, but with TFM, this is no longer
valid.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>