### PR TITLE
nrf_security: kconfig: support promptless configurations

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1,8 +1,15 @@
 menu "Nordic Security"
 
+config NORDIC_SECURITY_PROMPTLESS
+	bool
+	help
+	  Internal setting to disable the Nordic security backend
+	  This setting is Kconfig internal that must be used by subsystems that
+	  provides nRF Security selection groups.
+
 config NORDIC_SECURITY_BACKEND
 	bool
-	prompt "Use Nordic provided security backend"
+	prompt "Use Nordic provided security backend" if !NORDIC_SECURITY_PROMPTLESS
 	depends on SOC_FAMILY_NRF
 	select NRFXLIB_CRYPTO
 	select ENTROPY_GENERATOR if (SOC_NRF52810 || SOC_NRF52832)


### PR DESCRIPTION
When using 'select NORDIC_SECURITY_BACKEND' is modules, such as
OpenThread or Pelion, then config settings get stuck and user cannot
select another security configuration group.

The NORDIC_SECURITY_PROMPTLESS allows modules like Pelion or OpenThread
to disable the prompt when using pre-defined configuration groups.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>