### PR TITLE
crypto: Adding option for no mutex when MULTITHREADING is off

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -110,7 +110,11 @@ if (CONFIG_NRF_CC3XX_PLATFORM)
   # Add companion sources to directly to zephyr
   #
   zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_abort_zephyr.c)
-  zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_mutex_zephyr.c)
+  if (CONFIG_MULTITHREADING)
+    zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_mutex_zephyr.c)
+  else()
+    zephyr_sources(${NRF_CC3XX_PLATFORM_BASE}/src/nrf_cc3xx_platform_no_mutex_zephyr.c)
+  endif()
 endif()
 
 if (CONFIG_CC3XX_BACKEND)

--- a/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -10,6 +10,10 @@
 #include <zephyr.h>
 #include <kernel.h>
 
+BUILD_ASSERT(IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for multi-threading, but single-threading is enabled. "
+	"Please check your config build configuration!");
+
 #if defined(NRF5340_XXAA_APPLICATION)
 #include <hal/nrf_mutex.h>
 #endif /* defined(NRF5340_XXAA_APPLICATION) */

--- a/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr.h>
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for single-threading, but multi-threading is enabled. "
+	"Please check your config build configuration!");
+
+/** @brief Function to initialize the nrf_cc3xx_platform mutex APIs
+ */
+void nrf_cc3xx_platform_mutex_init(void)
+{
+	// No thread-safe mutexes are required
+}

--- a/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -10,6 +10,10 @@
 #include <zephyr.h>
 #include <kernel.h>
 
+BUILD_ASSERT(IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for multi-threading, but single-threading is enabled. "
+	"Please check your config build configuration!");
+
 #if defined(NRF5340_XXAA_APPLICATION)
 #include <hal/nrf_mutex.h>
 #endif /* defined(NRF5340_XXAA_APPLICATION) */

--- a/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
+++ b/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <zephyr.h>
+
+BUILD_ASSERT(!IS_ENABLED(CONFIG_MULTITHREADING),
+	"This file is intended for single-threading, but multi-threading is enabled. "
+	"Please check your config build configuration!");
+
+/** @brief Function to initialize the nrf_cc3xx_platform mutex APIs
+ */
+void nrf_cc3xx_platform_mutex_init(void)
+{
+	// No thread-safe mutexes are required
+}


### PR DESCRIPTION
-Added additional source file that does not initialize RTOS mutexes
 in the CryptoCell runtime library
-Added build-asserts to protect against misuse/misconfiguration

ref: NCSDK-9650

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>