### PR TITLE
nrf_802154: Serialize nrf_802154_time_get() for nRF53

### DIFF
--- a/nrf_802154/serialization/include/host/nrf_802154.h
+++ b/nrf_802154/serialization/include/host/nrf_802154.h
@@ -435,4 +435,14 @@ int8_t nrf_802154_dbm_from_energy_level_calculate(uint8_t energy_level);
  */
 nrf_802154_capabilities_t nrf_802154_capabilities_get(void);
 
+/**
+ * @brief Gets the current time.
+ *
+ * The time returned by this function is to be used to calculate timing parameters for
+ * @ref nrf_802154_transmit_at and @ref nrf_802154_receive_at functions.
+ *
+ * @returns Current time in microseconds.
+ */
+uint32_t nrf_802154_time_get(void);
+
 #endif

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_datatypes.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_datatypes.h
@@ -266,6 +266,13 @@ typedef enum
      */
     SPINEL_PROP_VENDOR_NORDIC_NRF_802154_ACK_DATA_CLEAR =
         SPINEL_PROP_VENDOR_NORDIC_NRF_802154__BEGIN + 33,
+
+    /**
+     * Vendor property for nrf_802154_time_get serialization.
+     */
+    SPINEL_PROP_VENDOR_NORDIC_NRF_802154_TIME_GET =
+        SPINEL_PROP_VENDOR_NORDIC_NRF_802154__BEGIN + 34,
+
 } spinel_prop_vendor_key_t;
 
 /**
@@ -562,6 +569,16 @@ typedef enum
  * @brief Spinel data type description for nrf_802154_capabilities_get_ret.
  */
 #define SPINEL_DATATYPE_NRF_802154_CAPABILITIES_GET_RET SPINEL_DATATYPE_UINT32_S
+
+/**
+ * @brief Spinel data type description for nrf_802154_time_get.
+ */
+#define SPINEL_DATATYPE_NRF_802154_TIME_GET             SPINEL_DATATYPE_NULL_S
+
+/**
+ * @brief Spinel data type description for nrf_802154_time_get_ret.
+ */
+#define SPINEL_DATATYPE_NRF_802154_TIME_GET_RET         SPINEL_DATATYPE_UINT32_S
 
 #ifdef __cplusplus
 }

--- a/nrf_802154/serialization/src/include/nrf_802154_spinel_dec_app.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_spinel_dec_app.h
@@ -128,6 +128,21 @@ nrf_802154_ser_err_t nrf_802154_spinel_decode_prop_nrf_802154_capabilities_get_r
     nrf_802154_capabilities_t * p_capabilities);
 
 /**
+ * @brief Decode SPINEL_PROP_VENDOR_NORDIC_NRF_802154_TIME_GET.
+ *
+ * @param[in]  p_property_data    Pointer to a buffer that contains data to be decoded.
+ * @param[in]  property_data_len  Size of the @ref p_property_data buffer.
+ * @param[out] p_capabilities     Decoded capabilities.
+ *
+ * @returns zero on success or negative error value on failure.
+ *
+ */
+nrf_802154_ser_err_t nrf_802154_spinel_decode_prop_nrf_802154_time_get_ret(
+    const void * p_property_data,
+    size_t       property_data_len,
+    uint32_t   * p_time);
+
+/**
  * @brief Decode and dispatch SPINEL_CMD_PROP_VALUE_IS.
  *
  * @param[in]  p_data    Pointer to a buffer that contains data to be decoded.

--- a/nrf_802154/serialization/src/nrf_802154_spinel_dec_app.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel_dec_app.c
@@ -473,6 +473,20 @@ nrf_802154_ser_err_t nrf_802154_spinel_decode_prop_nrf_802154_capabilities_get_r
             NRF_802154_SERIALIZATION_ERROR_OK);
 }
 
+nrf_802154_ser_err_t nrf_802154_spinel_decode_prop_nrf_802154_time_get_ret(
+    const void * p_property_data,
+    size_t       property_data_len,
+    uint32_t   * p_time)
+{
+    spinel_ssize_t siz = spinel_datatype_unpack(p_property_data,
+                                                property_data_len,
+                                                SPINEL_DATATYPE_NRF_802154_TIME_GET_RET,
+                                                p_time);
+
+    return ((siz) < 0 ? NRF_802154_SERIALIZATION_ERROR_DECODING_FAILURE :
+            NRF_802154_SERIALIZATION_ERROR_OK);
+}
+
 nrf_802154_ser_err_t nrf_802154_spinel_decode_cmd_prop_value_is(
     const void * p_cmd_data,
     size_t       cmd_data_len)
@@ -511,6 +525,8 @@ nrf_802154_ser_err_t nrf_802154_spinel_decode_cmd_prop_value_is(
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_CHANNEL_GET:
         // fall through
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_CAPABILITIES_GET:
+        // fall through
+        case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_TIME_GET:
         // fall through
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_PENDING_BIT_FOR_ADDR_SET:
         // fall through

--- a/nrf_802154/serialization/src/nrf_802154_spinel_dec_net.c
+++ b/nrf_802154/serialization/src/nrf_802154_spinel_dec_net.c
@@ -873,6 +873,30 @@ static nrf_802154_ser_err_t spinel_decode_prop_nrf_802154_capabilities_get(
         caps);
 }
 
+/**
+ * @brief Decode and dispatch SPINEL_DATATYPE_NRF_802154_TIME_GET.
+ *
+ * @param[in]  p_property_data    Pointer to a buffer that contains data to be decoded.
+ * @param[in]  property_data_len  Size of the @ref p_data buffer.
+ *
+ */
+static nrf_802154_ser_err_t spinel_decode_prop_nrf_802154_time_get(
+    const void * p_property_data,
+    size_t       property_data_len)
+{
+    (void)p_property_data;
+    (void)property_data_len;
+
+    uint32_t time;
+
+    time = nrf_802154_time_get();
+
+    return nrf_802154_spinel_send_cmd_prop_value_is(
+        SPINEL_PROP_VENDOR_NORDIC_NRF_802154_TIME_GET,
+        SPINEL_DATATYPE_NRF_802154_TIME_GET_RET,
+        time);
+}
+
 nrf_802154_ser_err_t nrf_802154_spinel_decode_cmd_prop_value_set(const void * p_cmd_data,
                                                                  size_t       cmd_data_len)
 {
@@ -972,6 +996,10 @@ nrf_802154_ser_err_t nrf_802154_spinel_decode_cmd_prop_value_set(const void * p_
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_CAPABILITIES_GET:
             return spinel_decode_prop_nrf_802154_capabilities_get(p_property_data,
                                                                   property_data_len);
+
+        case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_TIME_GET:
+            return spinel_decode_prop_nrf_802154_time_get(p_property_data,
+                                                          property_data_len);
 
         case SPINEL_PROP_VENDOR_NORDIC_NRF_802154_ACK_DATA_SET:
             return spinel_decode_prop_nrf_802154_ack_data_set(p_property_data,


### PR DESCRIPTION
This commit adds serialization of nrf_802154_time_get() function
to fix build for nRF5340, where it must be serialized in order to
be available.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>