### PR TITLE
Bluetooth: Mesh: Switch default BLE controller for mesh to SDC

### DIFF
--- a/softdevice_controller/Kconfig
+++ b/softdevice_controller/Kconfig
@@ -32,7 +32,6 @@ config BT_CTLR_LLPM
 
 choice BT_LL_CHOICE
 	prompt "Bluetooth Link Layer Selection"
-	default BT_LL_SW_SPLIT if BT_MESH
 	default BT_LL_SOFTDEVICE
 
 config BT_LL_SOFTDEVICE


### PR DESCRIPTION
Run Bluetooth mesh in NCS with SoftDevice Controller by default.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>