### PR TITLE
Min tfm

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1571,6 +1571,7 @@ config MBEDTLS_PK_C
 config MBEDTLS_PK_WRITE_C
 	bool "Enable the generic public (asymetric) key writer"
 	depends on MBEDTLS_PK_C
+	default y if MBEDTLS_USE_PSA_CRYPTO
 	help
 	  Enable generic public key write functions.
 

--- a/nrf_security/Kconfig.psa
+++ b/nrf_security/Kconfig.psa
@@ -22,7 +22,6 @@ config MBEDTLS_USE_PSA_CRYPTO
 	bool "PSA APIs for X.509 and TLS library"
 	default y if BUILD_WITH_TFM
 	select NRF_SECURITY_ADVANCED
-	imply MBEDTLS_PK_WRITE_C
 	help
 	  Corresponds to MBEDTLS_USE_PSA_CRYPTO setting in mbed TLS config file.
 


### PR DESCRIPTION
kconfig: don't imply pk_write_c 

Instead, default y if MBEDTLS_USE_PSA_CRYPTO is set.
This gives the same functionality seen from the user, but allows
for defconfig overrides of the default.