### PR TITLE
nrf_security: Enable RSA by default unless TF-M is on

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1263,7 +1263,7 @@ endif # MBEDTLS_ECP_C
 menuconfig MBEDTLS_RSA_C
 	bool
 	prompt "RSA   - Rivest–Shamir–Adleman cryptosystem"
-	default n
+	default y if !BUILD_WITH_TFM
 	select CC3XX_MBEDTLS_RSA_C if CC3XX_SINGLE_BACKEND
 	select VANILLA_MBEDTLS_RSA_C if OBERON_SINGLE_BACKEND || MBEDTLS_VANILLA_SINGLE_BACKEND
 	help


### PR DESCRIPTION
RSA is needed for tests to run, but isn't available for TF-M yet.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>