### PR TITLE
nrf_security: introducing real_mbedcrypto and real_mbedx509 targets

### DIFF
--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -4,7 +4,17 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 set(NRF_SECURITY_ROOT ${CMAKE_CURRENT_LIST_DIR})
-set(mbedcrypto_target mbedcrypto)
+
+if(TARGET mbedcrypto)
+  # pelion-dm creates mbedcrypto and mbedx509 as INTERFACE libraries
+  # This results in library name collision, so therefore we are redifining for
+  # Nordic security backend.
+  set(mbedcrypto_target real_mbedcrypto)
+  set(mbedx509_target   real_mbedx509)
+else()
+  set(mbedcrypto_target mbedcrypto)
+  set(mbedx509_target mbedx509)
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/nrf_security_debug.cmake)
 

--- a/nrf_security/src/mbedtls/CMakeLists.txt
+++ b/nrf_security/src/mbedtls/CMakeLists.txt
@@ -195,14 +195,14 @@ nrf_security_library(BASE ${mbedcrypto_target}_base_vanilla
 # Library for x.509
 #
 if (CONFIG_MBEDTLS_X509_LIBRARY AND NOT CONFIG_MBEDTLS_PSA_CRYPTO_SPM)
-  add_library(${MBEDTLS_TARGET_PREFIX}mbedx509 STATIC
+  add_library(${MBEDTLS_TARGET_PREFIX}${mbedx509_target} STATIC
     ${src_x509}
   )
 
   # Add options from Zephyr build
-  nrf_security_add_zephyr_options(${MBEDTLS_TARGET_PREFIX}mbedx509)
+  nrf_security_add_zephyr_options(${MBEDTLS_TARGET_PREFIX}${mbedx509_target})
 
-  target_link_libraries(${MBEDTLS_TARGET_PREFIX}mbedx509
+  target_link_libraries(${MBEDTLS_TARGET_PREFIX}${mbedx509_target}
     PRIVATE
       ${mbedcrypto_target}
   )
@@ -223,7 +223,7 @@ if (CONFIG_MBEDTLS_TLS_LIBRARY AND NOT CONFIG_MBEDTLS_PSA_CRYPTO_SPM)
 
   target_link_libraries(${MBEDTLS_TARGET_PREFIX}mbedtls
     PRIVATE
-      ${MBEDTLS_TARGET_PREFIX}mbedx509
+      ${MBEDTLS_TARGET_PREFIX}${mbedx509_target}
       ${mbedcrypto_target}
   )
 


### PR DESCRIPTION
The pelion-dm defines mbedcrypto and mbedx509 as interface libraries.

This results in duplicate library definitions as nRF Security creates
the same libraries.

This commit introduces an existence check for mbedcrypto library and in
case such library is already existing, the target library name in nRF
Security will be real_mbedcrypto and real_mbedx509 instead.

This commit can be reverted when the root cause is fixed in pelion-dm
repo.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>