### PR TITLE
nrf_security: cmake: refactor library re-archiving and fix archive globbing expression

### DIFF
--- a/nrf_security/cmake/archive_folder.cmake
+++ b/nrf_security/cmake/archive_folder.cmake
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+#
+# Script used to add object files to archive.
+#
+# The script requires the following parameters to be set
+# CMAKE_AR : Archiver to use for extracting
+# LIBRARY  : Library to which objects from FOLDER should be added.
+# FOLDER   : Folder containing objects to add to archive.
+#
+file(GLOB files ${FOLDER}/*)
+
+execute_process(COMMAND ${CMAKE_AR} q ${LIBRARY} ${files})

--- a/nrf_security/cmake/extensions.cmake
+++ b/nrf_security/cmake/extensions.cmake
@@ -601,7 +601,11 @@ function(nrf_security_target_embed_libraries)
   foreach(arc ${archive})
     add_custom_command(TARGET ${SEC_LIBS_TARGET}
       POST_BUILD
-      COMMAND ${CMAKE_AR} q $<TARGET_FILE:${SEC_LIBS_TARGET}> ${arc}/*
+      COMMAND ${CMAKE_COMMAND}
+          -DCMAKE_AR=${CMAKE_AR}
+          -DLIBRARY=$<TARGET_FILE:${SEC_LIBS_TARGET}>
+          -DFOLDER=${arc}
+          -P ${NRF_SECURITY_ROOT}/cmake/archive_folder.cmake
     )
   endforeach()
 endfunction()

--- a/nrf_security/cmake/extensions.cmake
+++ b/nrf_security/cmake/extensions.cmake
@@ -550,25 +550,45 @@ function(nrf_security_target_embed_libraries)
       get_property(imported_library_location TARGET ${target} PROPERTY IMPORTED_LOCATION)
     endif()
 
+    get_filename_component(library_file ${imported_library_location} NAME_WE)
+
     execute_process(
       COMMAND
         ${CMAKE_COMMAND}
           -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name}
+    )
+    execute_process(
+      COMMAND
+        ${CMAKE_COMMAND}
+          -E remove -f ${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name}.mon
+    )
+
+    if(NOT TARGET ${backend_name}_extract)
+      add_custom_target(${backend_name}_extract
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name}.mon
+      )
+    endif()
+
+    add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name}.mon
+      COMMAND ${CMAKE_COMMAND}
+          -DCMAKE_AR=${CMAKE_AR}
+          -DSTRIP="$<TARGET_PROPERTY:${backend_name}_extract,STRIP_LIST>"
+          -DLIBRARIES="$<TARGET_PROPERTY:${backend_name}_extract,LIBRARIES>"
+          -DMONITOR_FILE=${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name}.mon
+          -P ${NRF_SECURITY_ROOT}/cmake/libraries_extract.cmake
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name}
     )
 
     set(strip_list)
     nrf_security_symbol_strip(${backend_name} strip_list)
 
     if(DEFINED strip_list)
-      set(strip_command COMMAND ${CMAKE_COMMAND} -E remove ${strip_list})
+      set_property(TARGET ${backend_name}_extract APPEND PROPERTY STRIP_LIST ${strip_list})
     endif()
+    set_property(TARGET ${backend_name}_extract APPEND PROPERTY LIBRARIES ${imported_library_location})
 
-    add_custom_command(TARGET ${SEC_LIBS_TARGET}
-      POST_BUILD
-      COMMAND ${CMAKE_AR} x ${imported_library_location}
-      ${strip_command}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name}
-    )
+    add_dependencies(${SEC_LIBS_TARGET} ${backend_name}_extract)
 
     list(APPEND archive ${CMAKE_CURRENT_BINARY_DIR}/objects/${backend_name})
   endforeach()

--- a/nrf_security/cmake/libraries_extract.cmake
+++ b/nrf_security/cmake/libraries_extract.cmake
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+#
+# Script used to extract and strip imported libraries.
+# This script is called with add_custom_command command on imported libraries
+#
+# The script requires the following parameters to be set
+# CMAKE_AR    : Archiver to use for extracting
+# LIBRARIES   : List of libraries to extract
+# STRIP       : List of extracted object files that should be removed
+# MONITOR_FILE: Monitor file to create when library has been extracted
+#
+# Note: Files will be extracted to the current directory.
+#
+foreach(lib ${LIBRARIES})
+  execute_process(COMMAND ${CMAKE_AR} x ${lib})
+endforeach()
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${STRIP})
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E touch ${MONITOR_FILE})


### PR DESCRIPTION
nrf_security: use cmake script for TFM header copy on windows

Fixes: NCSDK-10008

CMake / Ninja generator will create a bat file for command invocation
when the command line execution exceeds a certain length.

Unfortunately SES-NE invokes said bat file wrongly, so instead we create
a CMake script to be invoked in windows for the header copy operation.

---------

nrf_security: cmake: refactor library re-archiving

Fixes: NCSDK-10008

SES-NE has a limitation on how long a POST_BUILD command from the
build.ninja it can handle.

When that length is exceeded then post build commands are truncated in
the middle and thus causing unexpected behavior.

This commit creates a <backend>_extract build target which can then be
set as a depedency to the static library. As the extract target is a
dependency it will be executed prior to the build of the static library.
This ensures that the post build step of adding objects to the static
library can now be safely done as the post build step is now within the
limits of SES-NE.

---------

 nrf_security: cmake: using archive script when archiving a folder

Fixes: NCSDK-10008

When archiving extracted objects from imported nRF security libraries
then a globbing expression in the form of: `ar q <library> <folder>/*`
is used.

Unfortunately, SES-NE treat the `*` as a filename and not a globbing
expression which results in `ar` to fail as there is no file named `*`.

This is handled by introducing archive_folder.cmake script which takes
the folder as an argument and then globs for all files in that folder.

The list of files is then passed directly to the `ar` command including
the library, and thus no globbing is needed directly on `ar`.
