### PR TITLE
nrf_security: Fix GCM in 9160 TF-M build

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -769,7 +769,7 @@ config MBEDTLS_GCM_C
 	prompt "AES-GCM - AES Galois/Counter Mode support"
 	depends on MBEDTLS_AES_C
 	depends on OBERON_MBEDTLS_AES_C || VANILLA_MBEDTLS_AES_C || \
-			   (CC312_BACKEND && CC3XX_MBEDTLS_AES_C)
+			   (CC312_BACKEND && CC3XX_MBEDTLS_AES_C) || BUILD_WITH_TFM
 	default y
 	select CC3XX_MBEDTLS_GCM_C if CC312_BACKEND
 	help


### PR DESCRIPTION
-Added a new dependency to ensure that the configuration
 MBEDTLS_GCM_C is settable for nRF9160 devices built with TF-M

ref: NCSDK-10023

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>