### PR TITLE
nrf_security: Add deterministic ECDSA Kconfig option

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1109,6 +1109,10 @@ config MBEDTLS_ECDSA_C
 
 if MBEDTLS_ECDSA_C
 
+config MBEDTLS_ECDSA_DETERMINISTIC
+	bool "Enable deterministic ECDSA (RFC 6979)"
+	default y
+
 config MBEDTLS_ECDSA_GENKEY_ALT
 	bool
 	depends on CC3XX_MBEDTLS_ECDSA_C || OBERON_MBEDTLS_ECDSA_C

--- a/nrf_security/cmake/kconfig_mbedtls_configure.cmake
+++ b/nrf_security/cmake/kconfig_mbedtls_configure.cmake
@@ -324,6 +324,7 @@ kconfig_mbedtls_config("MBEDTLS_X509_CRL_PARSE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CSR_PARSE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CREATE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CSR_WRITE_C")
+kconfig_mbedtls_config("MBEDTLS_ECDSA_DETERMINISTIC")
 kconfig_mbedtls_config_val("MBEDTLS_ENTROPY_MAX_SOURCES"          "${CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES}")
 
 if (CONFIG_TRUSTED_EXECUTION_SECURE AND CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES GREATER_EQUAL 1)


### PR DESCRIPTION
-This exposes the MBEDTLS_ECDSA_DETERMINISTIC
 configuration as a Kconfig.
-It fixes an building error when compiling with
 noglue configuration and having the ECDSA and
 the PSA apis enabled.

Ref: NCSDK-10057

sdk-nrf PR: [pull/4873](https://github.com/nrfconnect/sdk-nrf/pull/4873)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>