### PR TITLE
nrf_802154: Fix Thread vendor-specific IE OUI

### DIFF
--- a/nrf_802154/driver/include/nrf_802154_const.h
+++ b/nrf_802154/driver/include/nrf_802154_const.h
@@ -193,7 +193,7 @@
 
 #define IE_VENDOR_THREAD_SUBTYPE_OFFSET 3                                            ///< Thread Vendor-specific IE subtype offset
 #define IE_VENDOR_THREAD_DATA_OFFSET    4                                            ///< Thread Vendor-specific IE DATA offset
-#define IE_VENDOR_THREAD_OUI            0xf4ce36                                     ///< Thread Vendor-specific IE OUI
+#define IE_VENDOR_THREAD_OUI            0xeab89b                                     ///< Thread Vendor-specific IE OUI
 #define IE_VENDOR_THREAD_SIZE_MIN       4                                            ///< Thread Vendor-specific IE minimum length
 
 #define IE_VENDOR_THREAD_ACK_PROBING_ID 0x00                                         ///< Thread Vendor-specific ACK Probing IE subtype ID

--- a/nrf_802154/driver/src/nrf_802154_trx.c
+++ b/nrf_802154/driver/src/nrf_802154_trx.c
@@ -395,6 +395,10 @@ static void fem_for_tx_reset(bool cca)
     nrf_timer_task_trigger(NRF_802154_TIMER_INSTANCE, NRF_TIMER_TASK_SHUTDOWN);
 }
 
+#if defined(NRF52840_XXAA) || \
+    defined(NRF52833_XXAA) || \
+    defined(NRF52820_XXAA) || \
+    defined(NRF52811_XXAA)
 /** @brief Applies DEVICE-CONFIG-254.
  *
  * Shall be called after every RADIO peripheral reset.
@@ -424,6 +428,8 @@ static void device_config_254_apply_tx(void)
         *p_radio_reg3 = ficr_reg3;
     }
 }
+
+#endif
 
 void nrf_802154_trx_module_reset(void)
 {
@@ -457,11 +463,16 @@ void nrf_802154_trx_enable(void)
 
     nrf_radio_reset();
 
+#if defined(NRF52840_XXAA) || \
+    defined(NRF52833_XXAA) || \
+    defined(NRF52820_XXAA) || \
+    defined(NRF52811_XXAA)
     // Apply DEVICE-CONFIG-254 if needed.
     if (mpsl_fem_device_config_254_apply_get())
     {
         device_config_254_apply_tx();
     }
+#endif
 
     nrf_radio_packet_conf_t packet_conf;
 


### PR DESCRIPTION
This commit aligns the value of Thread vendor-specific IE OUI
with the correct value from the specification.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>