### PR TITLE
nrf_modem: add note regarding `nrf_select` support

### DIFF
--- a/nrf_modem/doc/api.rst
+++ b/nrf_modem/doc/api.rst
@@ -205,6 +205,9 @@ File descriptor sets are used as input to the nrf_select() function for doing I/
 multiplexing. The maximum number of descriptors contained in a set is defined by
 NRF_FD_SETSIZE.
 
+.. note::
+   :c:func:`nrf_select` is currently not supported.
+
 .. doxygengroup:: nrf_fd_set_api
    :project: nrfxlib
    :members:


### PR DESCRIPTION
This commit adds a note to the `nrf_select` documentation
description specifying that the functionality is currently
not supported.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>