### PR TITLE
nrf_security: Configure the ECDSA_DETERMINISTIC early

### DIFF
--- a/nrf_security/cmake/kconfig_mbedtls_configure.cmake
+++ b/nrf_security/cmake/kconfig_mbedtls_configure.cmake
@@ -156,6 +156,7 @@ kconfig_mbedtls_config("MBEDTLS_SSL_PROTO_TLS1_2")
 kconfig_mbedtls_config("MBEDTLS_SSL_TLS_C")
 kconfig_mbedtls_config("MBEDTLS_SSL_SRV_C")
 kconfig_mbedtls_config("MBEDTLS_SSL_CLI_C")
+kconfig_mbedtls_config("MBEDTLS_ECDSA_DETERMINISTIC")
 
 #
 # CC3XX flags for threading and platform zeroize
@@ -324,7 +325,6 @@ kconfig_mbedtls_config("MBEDTLS_X509_CRL_PARSE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CSR_PARSE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CREATE_C")
 kconfig_mbedtls_config("MBEDTLS_X509_CSR_WRITE_C")
-kconfig_mbedtls_config("MBEDTLS_ECDSA_DETERMINISTIC")
 kconfig_mbedtls_config_val("MBEDTLS_ENTROPY_MAX_SOURCES"          "${CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES}")
 
 if (CONFIG_TRUSTED_EXECUTION_SECURE AND CONFIG_MBEDTLS_ENTROPY_MAX_SOURCES GREATER_EQUAL 1)


### PR DESCRIPTION
-This is a fix for the fix in the commit: 8aa0425
-The previous fix populated the cmake variable late and
  it didn't make it available when the configuration file
  for single oberon/vanilla was created.

sdk-nrf PR: [pull/4928](https://github.com/nrfconnect/sdk-nrf/pull/4928)

Ref: NCSDK-10057

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>