### PR TITLE
nrf_security: Add SOME_PSK_ENABLED config

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -91,6 +91,11 @@ config MBEDTLS_SSL_SRV_C
 	  This setting enables SSL/TLS server functionality.
 	  Corresponds to MBEDTLS_SSL_SRV_C in mbed TLS config file.
 
+config MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED
+	bool
+	depends on MBEDTLS_TLS_LIBRARY
+	default y
+
 menu "mbed TLS memory configuration"
 
 config MBEDTLS_ENABLE_HEAP


### PR DESCRIPTION
-Adds a Kconfig variable for the
 MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED configuration
-This is needed for the TLS on zephyr to work
-PSK is always enabled in our configuration so this
 should not be configurable

sdk-nrf PR: [pull/5033](https://github.com/nrfconnect/sdk-nrf/pull/5033)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>