### PR TITLE
doc: add Bluetooth specification link

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -61,3 +61,5 @@
 .. _`NMEA`: https://www.gpsworld.com/what-exactly-is-gps-nmea-data/
 
 .. _`NMEA report sample`: http://aprs.gids.nl/nmea/#gsa
+
+.. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/specs/core-specification/


### PR DESCRIPTION
Adds link to Bluetooth specification to doc/links.txt

Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>