### PR TITLE
doc: update changelogs for 1.6.1

### DIFF
--- a/mpsl/CHANGELOG.rst
+++ b/mpsl/CHANGELOG.rst
@@ -9,6 +9,11 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+nRF Connect SDK v1.6.1
+**********************
+
+No changes in this release.
+
 nRF Connect SDK v1.6.0
 **********************
 

--- a/nfc/CHANGELOG.rst
+++ b/nfc/CHANGELOG.rst
@@ -9,6 +9,11 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+nRF Connect SDK v1.6.1
+**********************
+
+No changes in this release.
+
 nRF Connect SDK v1.6.0
 **********************
 

--- a/nrf_802154/doc/CHANGELOG.rst
+++ b/nrf_802154/doc/CHANGELOG.rst
@@ -9,6 +9,11 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+nRF Connect SDK v1.6.1
+**********************
+
+No changes in this release.
+
 nRF Connect SDK 1.6.0 - nRF 802.15.4 Radio Driver
 *************************************************
 

--- a/zboss/CHANGELOG.rst
+++ b/zboss/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changelog
 
 All notable changes to this project in |NCS| are documented in this file.
 
+nRF Connect SDK v1.6.1
+**********************
+
+No changes in this release.
 
 nRF Connect SDK v1.6.0
 **********************


### PR DESCRIPTION
Changed master heading to 1.6.1 in nrfxlib changelogs.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>