### PR TITLE
doc: use kconfig role

### DIFF
--- a/nrf_rpc/template/nrf_rpc_os_tmpl.h
+++ b/nrf_rpc/template/nrf_rpc_os_tmpl.h
@@ -138,7 +138,7 @@ void nrf_rpc_os_tls_set(void *data);
  * If there is no available context then this function waits for it.
  *
  * @return Context index between 0 and
- *         @option{CONFIG_NRF_RPC_CMD_CTX_POOL_SIZE} - 1.
+ *         @kconfig{CONFIG_NRF_RPC_CMD_CTX_POOL_SIZE} - 1.
  */
 uint32_t nrf_rpc_os_ctx_pool_reserve();
 

--- a/nrf_security/doc/adv_backend_config.rst
+++ b/nrf_security/doc/adv_backend_config.rst
@@ -22,16 +22,16 @@ Before modifying the default settings, see this `article on reducing Mbed TLS me
 AES tables in ROM
 *****************
 
-You can set the :option:`CONFIG_MBEDTLS_AES_ROM_TABLES` Kconfig variable to place the AES lookup tables in ROM instead of RAM.
+You can set the :kconfig:`CONFIG_MBEDTLS_AES_ROM_TABLES` Kconfig variable to place the AES lookup tables in ROM instead of RAM.
 This decreases the RAM usage by about 8 KB with an additional cost of about 8 KB of ROM.
 Note that executing operations in ROM is slower.
-If the configuration :option:`CONFIG_MBEDTLS_AES_FEWER_TABLES` is set, then the size moved from RAM to ROM is about 2 KB.
+If the configuration :kconfig:`CONFIG_MBEDTLS_AES_FEWER_TABLES` is set, then the size moved from RAM to ROM is about 2 KB.
 
-+------------------------------------------------+---------+-------+-----+
-| Option                                         | Default | Min   | Max |
-+================================================+=========+=======+=====+
-| :option:`CONFIG_MBEDTLS_AES_ROM_TABLES`        | `n`     | `n`   | `y` |
-+------------------------------------------------+---------+-------+-----+
++-------------------------------------------------+---------+-------+-----+
+| Option                                          | Default | Min   | Max |
++=================================================+=========+=======+=====+
+| :kconfig:`CONFIG_MBEDTLS_AES_ROM_TABLES`        | `n`     | `n`   | `y` |
++-------------------------------------------------+---------+-------+-----+
 
 .. note::
    This configuration is only available in :ref:`nrf_security_backends_orig_mbedtls`.
@@ -39,15 +39,15 @@ If the configuration :option:`CONFIG_MBEDTLS_AES_FEWER_TABLES` is set, then the 
 Fewer AES tables
 ****************
 
-The :option:`CONFIG_MBEDTLS_AES_FEWER_TABLES` Kconfig variable controls the size of the AES lookup tables in use.
+The :kconfig:`CONFIG_MBEDTLS_AES_FEWER_TABLES` Kconfig variable controls the size of the AES lookup tables in use.
 Enabling this omits about 75% of the AES tables in RAM or ROM.
 If the option is enabled, AES must perform more calculations, which impacts the overall performance.
 
-+------------------------------------------------+---------+-------+-----+
-| Option                                         | Default | Min   | Max |
-+================================================+=========+=======+=====+
-| :option:`CONFIG_MBEDTLS_AES_FEWER_TABLES`      | `n`     | `n`   | `y` |
-+------------------------------------------------+---------+-------+-----+
++-------------------------------------------------+---------+-------+-----+
+| Option                                          | Default | Min   | Max |
++=================================================+=========+=======+=====+
+| :kconfig:`CONFIG_MBEDTLS_AES_FEWER_TABLES`      | `n`     | `n`   | `y` |
++-------------------------------------------------+---------+-------+-----+
 
 .. note::
    This configuration is only available in :ref:`nrf_security_backends_orig_mbedtls`.
@@ -56,20 +56,20 @@ If the option is enabled, AES must perform more calculations, which impacts the 
 Multiple Precision Integers (MPI) / Bignum calculation
 ******************************************************
 
-The :option:`CONFIG_MBEDTLS_MPI_WINDOW_SIZE` Kconfig variable controls the window size used in Mbed TLS for MPI calculations.
+The :kconfig:`CONFIG_MBEDTLS_MPI_WINDOW_SIZE` Kconfig variable controls the window size used in Mbed TLS for MPI calculations.
 Reduce this value to reduce memory usage. Note that reducing this this value may have an impact on the performance.
 
-The :option:`CONFIG_MBEDTLS_MPI_MAX_SIZE` Kconfig variable controls the maximum size of MPIs that can be used for calculation.
+The :kconfig:`CONFIG_MBEDTLS_MPI_MAX_SIZE` Kconfig variable controls the maximum size of MPIs that can be used for calculation.
 Reduce this value only if you are sure that the system will not need larger sizes.
 
 
-+------------------------------------------------+---------+-------+------+
-| Option                                         | Default | Min   | Max  |
-+================================================+=========+=======+======+
-| :option:`CONFIG_MBEDTLS_MPI_WINDOW_SIZE`       | 6       | 1     | 6    |
-+------------------------------------------------+---------+-------+------+
-| :option:`CONFIG_MBEDTLS_MPI_MAX_SIZE`          | 1024    | 0     | 1024 |
-+------------------------------------------------+---------+-------+------+
++-------------------------------------------------+---------+-------+------+
+| Option                                          | Default | Min   | Max  |
++=================================================+=========+=======+======+
+| :kconfig:`CONFIG_MBEDTLS_MPI_WINDOW_SIZE`       | 6       | 1     | 6    |
++-------------------------------------------------+---------+-------+------+
+| :kconfig:`CONFIG_MBEDTLS_MPI_MAX_SIZE`          | 1024    | 0     | 1024 |
++-------------------------------------------------+---------+-------+------+
 
 .. note::
    This configuration is only available in cc310 backend and :ref:`nrf_security_backends_orig_mbedtls`.
@@ -78,29 +78,29 @@ Reduce this value only if you are sure that the system will not need larger size
 Elliptic Curves
 ***************
 
-The :option:`CONFIG_MBEDTLS_ECP_MAX_BITS` Kconfig variable controls the largest elliptic curve supported in the library.
+The :kconfig:`CONFIG_MBEDTLS_ECP_MAX_BITS` Kconfig variable controls the largest elliptic curve supported in the library.
 
 If the curves that are used are smaller than 521 bits, then this option can be reduced in order to save memory.
 See :ref:`nrf_security_backend_config_ecc_curves` for information on how to select the curves to use.
-For example, if `NIST secp384r1` is the only curve enabled, then :option:`CONFIG_MBEDTLS_ECP_MAX_BITS` can be reduced to 384 bits.
+For example, if `NIST secp384r1` is the only curve enabled, then :kconfig:`CONFIG_MBEDTLS_ECP_MAX_BITS` can be reduced to 384 bits.
 
-The :option:`CONFIG_MBEDTLS_ECP_WINDOW_SIZE` Kconfig variable controls the window size used for elliptic curve multiplication.
+The :kconfig:`CONFIG_MBEDTLS_ECP_WINDOW_SIZE` Kconfig variable controls the window size used for elliptic curve multiplication.
 This value can be reduced down to 2 to reduce memory usage.
 Keep in mind that reducing the value impacts the performance of the system.
 
-The :option:`CONFIG_MBEDTLS_ECP_FIXED_POINT_OPTIM` Kconfig variable controls ECP fixed point optimizations.
+The :kconfig:`CONFIG_MBEDTLS_ECP_FIXED_POINT_OPTIM` Kconfig variable controls ECP fixed point optimizations.
 If disabled, the system uses less memory, but performance of the system is reduced.
 
 
-+------------------------------------------------+---------+-------+-----+
-| Option                                         | Default | Min   | Max |
-+================================================+=========+=======+=====+
-| :option:`CONFIG_MBEDTLS_ECP_MAX_BITS`          | 521     | 0     | 521 |
-+------------------------------------------------+---------+-------+-----+
-| :option:`CONFIG_MBEDTLS_ECP_WINDOW_SIZE`       | 6       | 2     | 6   |
-+------------------------------------------------+---------+-------+-----+
-| :option:`CONFIG_MBEDTLS_ECP_FIXED_POINT_OPTIM` | `y`     | `n`   | `y` |
-+------------------------------------------------+---------+-------+-----+
++-------------------------------------------------+---------+-------+-----+
+| Option                                          | Default | Min   | Max |
++=================================================+=========+=======+=====+
+| :kconfig:`CONFIG_MBEDTLS_ECP_MAX_BITS`          | 521     | 0     | 521 |
++-------------------------------------------------+---------+-------+-----+
+| :kconfig:`CONFIG_MBEDTLS_ECP_WINDOW_SIZE`       | 6       | 2     | 6   |
++-------------------------------------------------+---------+-------+-----+
+| :kconfig:`CONFIG_MBEDTLS_ECP_FIXED_POINT_OPTIM` | `y`     | `n`   | `y` |
++-------------------------------------------------+---------+-------+-----+
 
 .. note::
    This configuration is only available in cc310 backend and :ref:`nrf_security_backends_orig_mbedtls`.
@@ -109,16 +109,16 @@ If disabled, the system uses less memory, but performance of the system is reduc
 SHA-256
 *******
 
-The :option:`CONFIG_MBEDTLS_SHA256_SMALLER` Kconfig variable can be used to select a SHA-256 implementation with smaller footprint.
+The :kconfig:`CONFIG_MBEDTLS_SHA256_SMALLER` Kconfig variable can be used to select a SHA-256 implementation with smaller footprint.
 Such configuration reduces SHA-256 calculation performance.
 
 For example, on a Cortex-M4, the size of :cpp:func:`mbedtls_sha256_process()` is reduced from ~2 KB to ~0.5 KB, however it also performs around 30% slower.
 
-+------------------------------------------------+---------+-------+-----+
-| Option                                         | Default | Min   | Max |
-+================================================+=========+=======+=====+
-| :option:`CONFIG_MBEDTLS_SHA256_SMALLER`        | `n`     | `n`   | `y` |
-+------------------------------------------------+---------+-------+-----+
++-------------------------------------------------+---------+-------+-----+
+| Option                                          | Default | Min   | Max |
++=================================================+=========+=======+=====+
+| :kconfig:`CONFIG_MBEDTLS_SHA256_SMALLER`        | `n`     | `n`   | `y` |
++-------------------------------------------------+---------+-------+-----+
 
 .. note::
    This configuration is only available in :ref:`nrf_security_backends_orig_mbedtls`.
@@ -126,7 +126,7 @@ For example, on a Cortex-M4, the size of :cpp:func:`mbedtls_sha256_process()` is
 SSL Configurations
 ******************
 
-The :option:`CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN` Kconfig variable can be used to specify the maximum size for incoming and outgoing Mbed TLS I/O buffers.
+The :kconfig:`CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN` Kconfig variable can be used to specify the maximum size for incoming and outgoing Mbed TLS I/O buffers.
 The default value is 16384 as specified in RFC5246, however if both sides are under your control, this value can safely be reduced under the following conditions:
 
 * Both sides support the max_fragment_length SSL extension, RFC8449.
@@ -135,18 +135,18 @@ The default value is 16384 as specified in RFC5246, however if both sides are un
 
 If one of those conditions is met, the buffer size can safely be reduced to a more appropriate value for memory constrained devices.
 
-The :option:`CONFIG_MBEDTLS_SSL_CIPHERSUITES` Kconfig variable is a custom list of cipher suites to support in SSL/TLS.
+The :kconfig:`CONFIG_MBEDTLS_SSL_CIPHERSUITES` Kconfig variable is a custom list of cipher suites to support in SSL/TLS.
 The cipher suites are provided as a comma-separated string, in order of preference.
 This list can only be used for restricting cipher suites available in the system.
 
 
-+------------------------------------------------+---------+-----------+-------+-------+
-| Option                                         | Type    | Default   | Min   | Max   |
-+================================================+=========+===========+=======+=======+
-| :option:`CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN`   | Integer | 16384     | 0     | 16384 |
-+------------------------------------------------+---------+-----------+-------+-------+
-| :option:`CONFIG_MBEDTLS_SSL_CIPHERSUITES`      | String  | `<empty>` |       |       |
-+------------------------------------------------+---------+-----------+-------+-------+
++-------------------------------------------------+---------+-----------+-------+-------+
+| Option                                          | Type    | Default   | Min   | Max   |
++=================================================+=========+===========+=======+=======+
+| :kconfig:`CONFIG_MBEDTLS_SSL_MAX_CONTENT_LEN`   | Integer | 16384     | 0     | 16384 |
++-------------------------------------------------+---------+-----------+-------+-------+
+| :kconfig:`CONFIG_MBEDTLS_SSL_CIPHERSUITES`      | String  | `<empty>` |       |       |
++-------------------------------------------------+---------+-----------+-------+-------+
 
 .. note::
-   The string in :option:`CONFIG_MBEDTLS_SSL_CIPHERSUITES` should not be quoted.
+   The string in :kconfig:`CONFIG_MBEDTLS_SSL_CIPHERSUITES` should not be quoted.

--- a/nrf_security/doc/backend_config.rst
+++ b/nrf_security/doc/backend_config.rst
@@ -36,19 +36,19 @@ If only a subset of the backends supports a given feature, this information is p
 AES configuration
 *****************
 
-AES core support can be enabled by setting the :option:`CONFIG_MBEDTLS_AES_C` Kconfig variable.
+AES core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_AES_C` Kconfig variable.
 Enabling AES core support enables AES ECB cipher mode and allows for the following ciphers to be configured: CTR, OFB, CFB, CBC, XTS, CMAC, CCM/CCM*, and GCM.
 
 Single backend
 ==============
 
-AES core support can be enabled by setting the :option:`CONFIG_MBEDTLS_AES_C` Kconfig variable.
+AES core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_AES_C` Kconfig variable.
 
-+--------------+-----------------------------------+
-| Cipher mode  | Configurations                    |
-+==============+===================================+
-| ECB          | :option:`CONFIG_MBEDTLS_AES_C`    |
-+--------------+-----------------------------------+
++--------------+------------------------------------+
+| Cipher mode  | Configurations                     |
++==============+====================================+
+| ECB          | :kconfig:`CONFIG_MBEDTLS_AES_C`    |
++--------------+------------------------------------+
 
 .. note::
    The :ref:`nrf_security_backends_cc3xx` is limited to key sizes of 128 bits on devices with Arm CryptoCell cc310.
@@ -56,16 +56,16 @@ AES core support can be enabled by setting the :option:`CONFIG_MBEDTLS_AES_C` Kc
 Multiple backends
 =================
 
-AES core support can be enabled by setting setting the :option:`CONFIG_MBEDTLS_AES_C` Kconfig variable, and one or more of the following Kconfig variables:
+AES core support can be enabled by setting setting the :kconfig:`CONFIG_MBEDTLS_AES_C` Kconfig variable, and one or more of the following Kconfig variables:
 
 +--------------+----------------+------------------------------------------------------------+
 | Cipher mode  | Support        | Configurations                                             |
 +==============+================+============================================================+
-| ECB          | Glue           | cc3xx: :option:`CONFIG_CC3XX_MBEDTLS_AES_C`                |
+| ECB          | Glue           | cc3xx: :kconfig:`CONFIG_CC3XX_MBEDTLS_AES_C`               |
 |              |                |                                                            |
-|              |                | nrf_oberon: :option:`CONFIG_OBERON_MBEDTLS_AES_C`          |
+|              |                | nrf_oberon: :kconfig:`CONFIG_OBERON_MBEDTLS_AES_C`         |
 |              |                |                                                            |
-|              |                | Original Mbed TLS: :option:`CONFIG_VANILLA_MBEDTLS_AES_C`  |
+|              |                | Original Mbed TLS: :kconfig:`CONFIG_VANILLA_MBEDTLS_AES_C` |
 +--------------+----------------+------------------------------------------------------------+
 
 .. note::
@@ -108,15 +108,15 @@ AES cipher modes can be enabled by setting one or more of the following Kconfig 
 +--------------+-----------------+---------------------------------------------+----------------------------------------+
 | Cipher mode  | Support         | Configurations                              | Note                                   |
 +==============+=================+=============================================+========================================+
-| CTR          | Glue            | :option:`CONFIG_MBEDTLS_CIPHER_MODE_CTR`    |                                        |
+| CTR          | Glue            | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_CTR`   |                                        |
 +--------------+-----------------+---------------------------------------------+----------------------------------------+
-| CBC          | Glue            | :option:`CONFIG_MBEDTLS_CIPHER_MODE_CBC`    |                                        |
+| CBC          | Glue            | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_CBC`   |                                        |
 +--------------+-----------------+---------------------------------------------+----------------------------------------+
-| CFB          |                 | :option:`CONFIG_MBEDTLS_CIPHER_MODE_CFB`    | Original Mbed TLS and nrf_oberon only  |
+| CFB          |                 | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_CFB`   | Original Mbed TLS and nrf_oberon only  |
 +--------------+-----------------+---------------------------------------------+----------------------------------------+
-| OFB          |                 | :option:`CONFIG_MBEDTLS_CIPHER_MODE_OFB`    | Original Mbed TLS and nrf_oberon only  |
+| OFB          |                 | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_OFB`   | Original Mbed TLS and nrf_oberon only  |
 +--------------+-----------------+---------------------------------------------+----------------------------------------+
-| XTS          |                 | :option:`CONFIG_MBEDTLS_CIPHER_MODE_XTS`    | Original Mbed TLS and nrf_oberon only  |
+| XTS          |                 | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_XTS`   | Original Mbed TLS and nrf_oberon only  |
 +--------------+-----------------+---------------------------------------------+----------------------------------------+
 
 .. note::
@@ -211,27 +211,27 @@ Cipher-based Message Authentication Code (CMAC) support can be enabled by settin
 Single backend
 ==============
 
-CMAC can be enabled by setting the :option:`CONFIG_MBEDTLS_CMAC_C` Kconfig variable.
+CMAC can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_CMAC_C` Kconfig variable.
 
 +--------------+-----------------------------------+
 | Algorithm    | Configurations                    |
 +==============+===================================+
-| CMAC         | :option:`CONFIG_MBEDTLS_CMAC_C`   |
+| CMAC         | :kconfig:`CONFIG_MBEDTLS_CMAC_C`  |
 +--------------+-----------------------------------+
 
 Multiple backends
 =================
 
-CMAC can be enabled by setting the :option:`CONFIG_MBEDTLS_CMAC_C` Kconfig variable, and one or more of the following Kconfig variables:
+CMAC can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_CMAC_C` Kconfig variable, and one or more of the following Kconfig variables:
 
 +--------------+-----------------------------+--------------------------------------------------------------------+
 | Algorithm    | Support                     | Configurations                                                     |
 +==============+=============================+====================================================================+
-| CMAC         | Choice                      | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_CMAC_C`                |
+| CMAC         | Choice                      | cc3xx: :kconfig:`CONFIG_CHOICE_CC3XX_MBEDTLS_CMAC_C`               |
 |              |                             |                                                                    |
-|              |                             | nrf_oberon: :option:`CONFIG_CHOICE_OBERON_MBEDTLS_CMAC_C`          |
+|              |                             | nrf_oberon: :kconfig:`CONFIG_CHOICE_OBERON_MBEDTLS_CMAC_C`         |
 |              |                             |                                                                    |
-|              |                             | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_CMAC_C`  |
+|              |                             | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_CMAC_C` |
 +--------------+-----------------------------+--------------------------------------------------------------------+
 
 .. note::
@@ -274,16 +274,16 @@ AEAD cipher mode support can be enabled by setting one or more of the following 
 +--------------+-----------------------------------------+-----------------------------------------+
 | AEAD cipher  | Configurations                          | Note                                    |
 +==============+=========================================+=========================================+
-| AES CCM/CCM* | :option:`CONFIG_MBEDTLS_CCM_C`          |                                         |
+| AES CCM/CCM* | :kconfig:`CONFIG_MBEDTLS_CCM_C`         |                                         |
 +--------------+-----------------------------------------+-----------------------------------------+
-| AES GCM      | :option:`CONFIG_MBEDTLS_GCM_C`          | Original Mbed TLS, or nrf_oberon,       |
+| AES GCM      | :kconfig:`CONFIG_MBEDTLS_GCM_C`         | Original Mbed TLS, or nrf_oberon,       |
 |              |                                         | or cc312                                |
 +--------------+-----------------------------------------+-----------------------------------------+
-| ChaCha20     | :option:`CONFIG_MBEDTLS_CHACHA20_C`     |                                         |
+| ChaCha20     | :kconfig:`CONFIG_MBEDTLS_CHACHA20_C`    |                                         |
 +--------------+-----------------------------------------+-----------------------------------------+
-| Poly1305     | :option:`CONFIG_MBEDTLS_POLY1305_C`     |                                         |
+| Poly1305     | :kconfig:`CONFIG_MBEDTLS_POLY1305_C`    |                                         |
 +--------------+-----------------------------------------+-----------------------------------------+
-| ChaCha-Poly  | :option:`CONFIG_MBEDTLS_CHACHAPOLY_C`   | Requires `Poly1305` and `ChaCha20`      |
+| ChaCha-Poly  | :kconfig:`CONFIG_MBEDTLS_CHACHAPOLY_C`  | Requires `Poly1305` and `ChaCha20`      |
 +--------------+-----------------------------------------+-----------------------------------------+
 
 .. note::
@@ -300,16 +300,16 @@ Multiple backend configurations for various AEAD cyphers are presented in the fo
 AES CCM/CCM*
 ------------
 
-AES CCM/CCM* can be enabled by setting the :option:`CONFIG_MBEDTLS_CCM_C` Kconfig variable, and one or more of the following Kconfig variables:
+AES CCM/CCM* can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_CCM_C` Kconfig variable, and one or more of the following Kconfig variables:
 
 +--------------+-----------------+-----------------------------------------------------------------+
 | AEAD cipher  | Support         | Configurations                                                  |
 +==============+=================+=================================================================+
-| AES CCM/CCM* | Glue            | cc3xx: :option:`CONFIG_CC3XX_MBEDTLS_CCM_C`                     |
+| AES CCM/CCM* | Glue            | cc3xx: :kconfig:`CONFIG_CC3XX_MBEDTLS_CCM_C`                    |
 |              |                 |                                                                 |
-|              |                 | nrf_oberon: :option:`CONFIG_OBERON_MBEDTLS_CCM_C`               |
+|              |                 | nrf_oberon: :kconfig:`CONFIG_OBERON_MBEDTLS_CCM_C`              |
 |              |                 |                                                                 |
-|              |                 | Original Mbed TLS: :option:`CONFIG_VANILLA_MBEDTLS_CCM_C`       |
+|              |                 | Original Mbed TLS: :kconfig:`CONFIG_VANILLA_MBEDTLS_CCM_C`      |
 +--------------+-----------------+-----------------------------------------------------------------+
 
 .. note::
@@ -321,12 +321,12 @@ AES CCM/CCM* can be enabled by setting the :option:`CONFIG_MBEDTLS_CCM_C` Kconfi
 AES GCM
 -------
 
-AES GCM can be enabled by setting the :option:`CONFIG_MBEDTLS_GCM_C` Kconfig variable.
+AES GCM can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_GCM_C` Kconfig variable.
 
 +--------------+-----------------------------------+--------------------------------------+
 | AEAD cipher  | Configurations                    | Note                                 |
 +==============+===================================+======================================+
-| AES GCM      | :option:`CONFIG_MBEDTLS_GCM_C`    | Original Mbed TLS or nrf_oberon only |
+| AES GCM      | :kconfig:`CONFIG_MBEDTLS_GCM_C`   | Original Mbed TLS or nrf_oberon only |
 +--------------+-----------------------------------+--------------------------------------+
 
 .. note::
@@ -335,16 +335,16 @@ AES GCM can be enabled by setting the :option:`CONFIG_MBEDTLS_GCM_C` Kconfig var
 ChaCha20
 --------
 
-ChaCha20 support can be enabled by setting the :option:`CONFIG_MBEDTLS_CHACHA20_C` Kconfig variable, and one of the following Kconfig variables:
+ChaCha20 support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_CHACHA20_C` Kconfig variable, and one of the following Kconfig variables:
 
 +--------------+-----------------+--------------------------------------------------------------------------+
 | AEAD cipher  | Support         | Configurations                                                           |
 +==============+=================+==========================================================================+
-| ChaCha20     | Choice          | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_CHACHA20_C`                  |
+| ChaCha20     | Choice          | cc3xx: :kconfig:`CONFIG_CHOICE_CC3XX_MBEDTLS_CHACHA20_C`                 |
 |              |                 |                                                                          |
-|              |                 | nrf_oberon: :option:`CONFIG_CHOICE_OBERON_MBEDTLS_CHACHA20_C`            |
+|              |                 | nrf_oberon: :kconfig:`CONFIG_CHOICE_OBERON_MBEDTLS_CHACHA20_C`           |
 |              |                 |                                                                          |
-|              |                 | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHA20_C`    |
+|              |                 | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHA20_C`   |
 +--------------+-----------------+--------------------------------------------------------------------------+
 
 .. note::
@@ -354,16 +354,16 @@ ChaCha20 support can be enabled by setting the :option:`CONFIG_MBEDTLS_CHACHA20_
 Poly1305
 --------
 
-Poly1305 can be enabled by setting the :option:`CONFIG_MBEDTLS_POLY1305_C` Kconfig variable and one of the following Kconfig variables:
+Poly1305 can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_POLY1305_C` Kconfig variable and one of the following Kconfig variables:
 
 +--------------+-----------------+-----------------------------------------------------------------------+
 | AEAD cipher  | Support         | Configurations                                                        |
 +==============+=================+=======================================================================+
-| Poly1305     | Choice          | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_POLY1305_C`               |
+| Poly1305     | Choice          | cc3xx: :kconfig:`CONFIG_CHOICE_CC3XX_MBEDTLS_POLY1305_C`              |
 |              |                 |                                                                       |
-|              |                 | nrf_oberon: :option:`CONFIG_CHOICE_OBERON_MBEDTLS_POLY1305_C`         |
+|              |                 | nrf_oberon: :kconfig:`CONFIG_CHOICE_OBERON_MBEDTLS_POLY1305_C`        |
 |              |                 |                                                                       |
-|              |                 | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_POLY1305_C` |
+|              |                 | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_POLY1305_C`|
 +--------------+-----------------+-----------------------------------------------------------------------+
 
 .. note::
@@ -374,16 +374,16 @@ Poly1305 can be enabled by setting the :option:`CONFIG_MBEDTLS_POLY1305_C` Kconf
 ChaCha-Poly
 -----------
 
-ChaCha-Poly can be enabled by setting the :option:`CONFIG_MBEDTLS_CHACHAPOLY_C` Kconfig variable, and one of the following Kconfig variables:
+ChaCha-Poly can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_CHACHAPOLY_C` Kconfig variable, and one of the following Kconfig variables:
 
 +--------------+-----------------+--------------------------------------------------------------------------+
 | AEAD cipher  | Support         | Configurations                                                           |
 +==============+=================+==========================================================================+
-| ChaCha-Poly  | Choice          | cc3xx: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHAPOLY_C`              |
+| ChaCha-Poly  | Choice          | cc3xx: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHAPOLY_C`             |
 |              |                 |                                                                          |
-|              |                 | nrf_oberon: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHAPOLY_C`         |
+|              |                 | nrf_oberon: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHAPOLY_C`        |
 |              |                 |                                                                          |
-|              |                 | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHAPOLY_C`  |	
+|              |                 | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_CHACHAPOLY_C` |	
 +--------------+-----------------+--------------------------------------------------------------------------+
 
 .. note::
@@ -452,26 +452,26 @@ Diffie-Hellman-Merkle (DHM) support can be enabled by setting Kconfig variables 
 Single backend
 ==============
 
-DHM can be enabled by setting the :option:`CONFIG_MBEDTLS_DHM_C` Kconfig variable.
+DHM can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_DHM_C` Kconfig variable.
 
 +--------------+--------------------------------------+
 | Algorithm    | Configurations                       |
 +==============+======================================+
-| DHM          | :option:`CONFIG_MBEDTLS_DHM_C`       |
+| DHM          | :kconfig:`CONFIG_MBEDTLS_DHM_C`      |
 +--------------+--------------------------------------+
 
 
 Multiple backends
 =================
 
-DHM can be enabled by setting the :option:`CONFIG_MBEDTLS_DHM_C` Kconfig variable, and one or more of the following Kconfig variables:
+DHM can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_DHM_C` Kconfig variable, and one or more of the following Kconfig variables:
 
 +--------------+--------------+--------------------------------------------------------------+
 | Algorithm    | Support      | Configurations                                               |
 +==============+==============+==============================================================+
-| DHM          | Glue         | cc3xx: :option:`CONFIG_CC3XX_MBEDTLS_DHM_C`                  |
+| DHM          | Glue         | cc3xx: :kconfig:`CONFIG_CC3XX_MBEDTLS_DHM_C`                 |
 |              |              |                                                              |
-|              |              | Original Mbed TLS: :option:`CONFIG_VANILLA_MBEDTLS_DHM_C`    |
+|              |              | Original Mbed TLS: :kconfig:`CONFIG_VANILLA_MBEDTLS_DHM_C`   |
 +--------------+--------------+--------------------------------------------------------------+
 
 Feature support
@@ -491,29 +491,29 @@ ECC configurations
 ******************
 
 Elliptic Curve Cryptography (ECC) configuration provides support for Elliptic Curve over GF(p).
-ECC core support can be enabled by setting the :option:`CONFIG_MBEDTLS_ECP_C` Kconfig variable.
-Enabling :option:`CONFIG_MBEDTLS_ECP_C` will activate configuration options that depend upon ECC, such as ECDH, ECDSA, ECJPAKE, and a selection of ECC curves to support in the system.
-If multiple backends are available, you can select which backend to use for :option:`CONFIG_MBEDTLS_ECP_C`.
+ECC core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_ECP_C` Kconfig variable.
+Enabling :kconfig:`CONFIG_MBEDTLS_ECP_C` will activate configuration options that depend upon ECC, such as ECDH, ECDSA, ECJPAKE, and a selection of ECC curves to support in the system.
+If multiple backends are available, you can select which backend to use for :kconfig:`CONFIG_MBEDTLS_ECP_C`.
 This backend will be used to provide support for ECDH, ECDSA, and/or ECJPAKE (if enabled).
 
 Single backend
 ==============
 
-ECC core support can be enabled by setting the :option:`CONFIG_MBEDTLS_ECP_C` Kconfig variable.
+ECC core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_ECP_C` Kconfig variable.
 
 Multiple backends
 =================
 
-ECC core support can be enabled by setting the :option:`CONFIG_MBEDTLS_ECP_C` Kconfig variable, and one of the following Kconfig variables:
+ECC core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_ECP_C` Kconfig variable, and one of the following Kconfig variables:
 
 +--------------+--------------+--------------------------------------------------------------------+
 | Algorithm    | Support      | Configurations                                                     |
 +==============+==============+====================================================================+
-| ECP          | Choice       | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_ECP_C`                 |
+| ECP          | Choice       | cc3xx: :kconfig:`CONFIG_CHOICE_CC3XX_MBEDTLS_ECP_C`                |
 |              |              |                                                                    |
-|              |              | nrf_oberon: :option:`CONFIG_CHOICE_OBERON_MBEDTLS_ECP_C`           |
+|              |              | nrf_oberon: :kconfig:`CONFIG_CHOICE_OBERON_MBEDTLS_ECP_C`          |
 |              |              |                                                                    |
-|              |              | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_ECP_C`   |
+|              |              | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_ECP_C`  |
 +--------------+--------------+--------------------------------------------------------------------+
 
 .. note::
@@ -577,12 +577,12 @@ Feature support
 ECDH configurations
 *******************
 
-Elliptic Curve Diffie-Hellman (ECDH) support can be enabled by setting the :option:`CONFIG_MBEDTLS_ECDH_C` Kconfig variable.
+Elliptic Curve Diffie-Hellman (ECDH) support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_ECDH_C` Kconfig variable.
 
 +--------------+--------------------------------------+
 | Algorithm    | Configurations                       |
 +==============+======================================+
-| ECDH         | :option:`CONFIG_MBEDTLS_ECDH_C`      |
+| ECDH         | :kconfig:`CONFIG_MBEDTLS_ECDH_C`     |
 +--------------+--------------------------------------+
 
 .. note::
@@ -648,12 +648,12 @@ Feature support
 ECDSA configurations
 ********************
 
-Elliptic Curve Digital Signature Algorithm (ECDSA) support can be enabled be configured by setting the :option:`CONFIG_MBEDTLS_ECDSA_C` Kconfig variable.
+Elliptic Curve Digital Signature Algorithm (ECDSA) support can be enabled be configured by setting the :kconfig:`CONFIG_MBEDTLS_ECDSA_C` Kconfig variable.
 
 +--------------+---------------------------------------+
 | Algorithm    | Configurations                        |
 +==============+=======================================+
-| ECDSA        | :option:`CONFIG_MBEDTLS_ECDSA_C`      |
+| ECDSA        | :kconfig:`CONFIG_MBEDTLS_ECDSA_C`     |
 +--------------+---------------------------------------+
 
 .. note::
@@ -719,12 +719,12 @@ Feature support
 ECJPAKE configurations
 **********************
 
-Elliptic Curve, Password Authenticated Key Exchange by Juggling (ECJPAKE) support can be enabled by setting the :option:`CONFIG_MBEDTLS_ECJPAKE_C` Kconfig variable.
+Elliptic Curve, Password Authenticated Key Exchange by Juggling (ECJPAKE) support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_ECJPAKE_C` Kconfig variable.
 
 +--------------+---------------------------------------+
 | Algorithm    | Configurations                        |
 +==============+=======================================+
-| ECJPAKE      | :option:`CONFIG_MBEDTLS_ECJPAKE_C`    |
+| ECJPAKE      | :kconfig:`CONFIG_MBEDTLS_ECJPAKE_C`   |
 +--------------+---------------------------------------+
 
 .. note::
@@ -758,31 +758,31 @@ The following table shows the curves that can be enabled.
 +-----------------------------+-----------------------------------------------------+--------------------------+
 | Curve                       | Configurations                                      | Note                     |
 +=============================+=====================================================+==========================+
-| NIST secp192r1              | :option:`CONFIG_MBEDTLS_ECP_DP_SECP192R1_ENABLED`   |                          |
+| NIST secp192r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP192R1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp224r1              | :option:`CONFIG_MBEDTLS_ECP_DP_SECP224R1_ENABLED`   |                          |
+| NIST secp224r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP224R1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp256r1              | :option:`CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED`   |                          |
+| NIST secp256r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp384r1              | :option:`CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED`   |                          |
+| NIST secp384r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp521r1              | :option:`CONFIG_MBEDTLS_ECP_DP_SECP521R1_ENABLED`   |                          |
+| NIST secp521r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP521R1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Koblitz secp192k1           | :option:`CONFIG_MBEDTLS_ECP_DP_SECP192K1_ENABLED`   |                          |
+| Koblitz secp192k1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP192K1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Koblitz secp224k1           | :option:`CONFIG_MBEDTLS_ECP_DP_SECP224K1_ENABLED`   |                          |
+| Koblitz secp224k1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP224K1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Koblitz secp256k1           | :option:`CONFIG_MBEDTLS_ECP_DP_SECP256K1_ENABLED`   |                          |
+| Koblitz secp256k1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP256K1_ENABLED`  |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Brainpool bp256r1           | :option:`CONFIG_MBEDTLS_ECP_DP_BP256R1_ENABLED`     | Original Mbed TLS only   |
+| Brainpool bp256r1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_BP256R1_ENABLED`    | Original Mbed TLS only   |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Brainpool bp384r1           | :option:`CONFIG_MBEDTLS_ECP_DP_BP384R1_ENABLED`     | Original Mbed TLS only   |
+| Brainpool bp384r1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_BP384R1_ENABLED`    | Original Mbed TLS only   |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Brainpool bp512r1           | :option:`CONFIG_MBEDTLS_ECP_DP_BP512R1_ENABLED`     | Original Mbed TLS only   |
+| Brainpool bp512r1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_BP512R1_ENABLED`    | Original Mbed TLS only   |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Curve25519                  | :option:`CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED`  |                          |
+| Curve25519                  | :kconfig:`CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED` |                          |
 +-----------------------------+-----------------------------------------------------+--------------------------+
-| Curve448                    | :option:`CONFIG_MBEDTLS_ECP_DP_CURVE448_ENABLED`    | Original Mbed TLS only   |
+| Curve448                    | :kconfig:`CONFIG_MBEDTLS_ECP_DP_CURVE448_ENABLED`   | Original Mbed TLS only   |
 +-----------------------------+-----------------------------------------------------+--------------------------+
 
 .. note::
@@ -798,12 +798,12 @@ Rivest-Shamir-Adleman (RSA) support can be enabled by setting Kconfig variables 
 Single backend
 ==============
 
-RSA support can be enabled by setting the :option:`CONFIG_MBEDTLS_RSA_C` Kconfig variable.
+RSA support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_RSA_C` Kconfig variable.
 
 +--------------+---------------------------------------+
 | Algorithm    | Configurations                        |
 +==============+=======================================+
-| RSA          | :option:`CONFIG_MBEDTLS_RSA_C`        |
+| RSA          | :kconfig:`CONFIG_MBEDTLS_RSA_C`       |
 +--------------+---------------------------------------+
 
 .. note::
@@ -812,14 +812,14 @@ RSA support can be enabled by setting the :option:`CONFIG_MBEDTLS_RSA_C` Kconfig
 Multiple backends
 =================
 
-RSA support can be enabled by setting the :option:`CONFIG_MBEDTLS_RSA_C` Kconfig variable, and one of the following Kconfig variables:
+RSA support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_RSA_C` Kconfig variable, and one of the following Kconfig variables:
 
 +--------------+-----------------+--------------------------------------------------------------------+
 | Algorithm    | Support         | Configurations                                                     |
 +==============+=================+====================================================================+
-| RSA          | Choice          | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_RSA_C`                 |
+| RSA          | Choice          | cc3xx: :kconfig:`CONFIG_CHOICE_CC3XX_MBEDTLS_RSA_C`                |
 |              |                 |                                                                    |
-|              |                 | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_RSA_C`   |
+|              |                 | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_RSA_C`  |
 +--------------+-----------------+--------------------------------------------------------------------+
 
 .. note::
@@ -851,11 +851,11 @@ SHA support can be enabled by setting Kconfig according to the following table:
 +--------------+--------------------+--------------------------------------+
 | Algorithm    | Support            | Backend selection                    |
 +==============+====================+======================================+
-| SHA-1        |                    | :option:`CONFIG_MBEDTLS_SHA1_C`      |
+| SHA-1        |                    | :kconfig:`CONFIG_MBEDTLS_SHA1_C`     |
 +--------------+--------------------+--------------------------------------+
-| SHA-256      |                    | :option:`CONFIG_MBEDTLS_SHA256_C`    |
+| SHA-256      |                    | :kconfig:`CONFIG_MBEDTLS_SHA256_C`   |
 +--------------+--------------------+--------------------------------------+
-| SHA-512      | Shared             | :option:`CONFIG_MBEDTLS_SHA512_C`    |
+| SHA-512      | Shared             | :kconfig:`CONFIG_MBEDTLS_SHA512_C`   |
 +--------------+--------------------+--------------------------------------+
 
 Multiple backends
@@ -866,16 +866,16 @@ Multiple backend configurations for Secure Hash algorithms are presented in the 
 SHA-1
 -----
 
-SHA-1 support can be enabled by setting the :option:`CONFIG_MBEDTLS_SHA1_C` Kconfig variable, and one of the following Kconfig variables:
+SHA-1 support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_SHA1_C` Kconfig variable, and one of the following Kconfig variables:
 
 +--------------+-----------------+--------------------------------------------------------------------+
 | Algorithm    | Support         | Backend selection                                                  |
 +==============+=================+====================================================================+
-| SHA-1        | Choice          | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_SHA1_C`                |
+| SHA-1        | Choice          | cc3xx: :kconfig:`CONFIG_CHOICE_CC3XX_MBEDTLS_SHA1_C`               |
 |              |                 |                                                                    |
-|              |                 | nrf_oberon: :option:`CONFIG_CHOICE_OBERON_MBEDTLS_SHA1_C`          |
+|              |                 | nrf_oberon: :kconfig:`CONFIG_CHOICE_OBERON_MBEDTLS_SHA1_C`         |
 |              |                 |                                                                    |
-|              |                 | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_SHA1_C`  |
+|              |                 | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_SHA1_C` |
 +--------------+-----------------+--------------------------------------------------------------------+
 
 .. note::
@@ -884,16 +884,16 @@ SHA-1 support can be enabled by setting the :option:`CONFIG_MBEDTLS_SHA1_C` Kcon
 SHA-256
 -------
 
-SHA-256 support can be enabled by setting the :option:`CONFIG_MBEDTLS_SHA256_C` Kconfig variable, and one of the following Kconfig variables:
+SHA-256 support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_SHA256_C` Kconfig variable, and one of the following Kconfig variables:
 
 +--------------+-----------------+-----------------------------------------------------------------------+
 | Algorithm    | Support         | Backend selection                                                     |
 +==============+=================+=======================================================================+
-| SHA-256      | Choice          | cc3xx: :option:`CONFIG_CHOICE_CC3XX_MBEDTLS_SHA256_C`                 |
+| SHA-256      | Choice          | cc3xx: :kconfig:`CONFIG_CHOICE_CC3XX_MBEDTLS_SHA256_C`                |
 |              |                 |                                                                       |
-|              |                 | nrf_oberon: :option:`CONFIG_CHOICE_OBERON_MBEDTLS_SHA256_C`           |
+|              |                 | nrf_oberon: :kconfig:`CONFIG_CHOICE_OBERON_MBEDTLS_SHA256_C`          |
 |              |                 |                                                                       |
-|              |                 | Original Mbed TLS: :option:`CONFIG_CHOICE_VANILLA_MBEDTLS_SHA256_C`   |
+|              |                 | Original Mbed TLS: :kconfig:`CONFIG_CHOICE_VANILLA_MBEDTLS_SHA256_C`  |
 +--------------+-----------------+-----------------------------------------------------------------------+
 
 .. note::
@@ -902,12 +902,12 @@ SHA-256 support can be enabled by setting the :option:`CONFIG_MBEDTLS_SHA256_C` 
 SHA-512
 -------
 
-SHA-256 support can be configured by setting the :option:`CONFIG_MBEDTLS_SHA512_C` Kconfig variable.
+SHA-256 support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_SHA512_C` Kconfig variable.
 
 +--------------+-----------------+-----------------------------------------------------------------+
 | Algorithm    | Support         | Backend selection                                               |
 +==============+=================+=================================================================+
-| SHA-512      | Shared          | :option:`CONFIG_MBEDTLS_SHA512_C`                               |
+| SHA-512      | Shared          | :kconfig:`CONFIG_MBEDTLS_SHA512_C`                              |
 +--------------+-----------------+-----------------------------------------------------------------+
 
 .. note::

--- a/nrf_security/doc/backends.rst
+++ b/nrf_security/doc/backends.rst
@@ -45,7 +45,7 @@ The Arm CryptoCell cc3xx backend is only available on the following devices:
 Enabling the Arm CryptoCell cc3xx backend
 =========================================
 
-The Arm CryptoCell cc3xx backend can be enabled by setting the :option:`CONFIG_CC3XX_BACKEND` Kconfig variable.
+The Arm CryptoCell cc3xx backend can be enabled by setting the :kconfig:`CONFIG_CC3XX_BACKEND` Kconfig variable.
 
 .. note:: This backend is only available in nRF52840 and nRF9160.
 
@@ -63,7 +63,7 @@ The nrf_oberon backend provides support for AES ciphers, SHA-1, SHA-256, and ECC
 Enabling the nrf_oberon backend
 ===============================
 
-To use the :ref:`nrf_oberon_readme` as a backend, set the :option:`CONFIG_OBERON_BACKEND` Kconfig variable to true.
+To use the :ref:`nrf_oberon_readme` as a backend, set the :kconfig:`CONFIG_OBERON_BACKEND` Kconfig variable to true.
 
 .. _nrf_security_backends_orig_mbedtls:
 
@@ -82,7 +82,7 @@ Similarly, you can use the original Mbed TLS backend to add support for features
 Enabling the original Mbed TLS backend
 ======================================
 
-To enable the original Mbed TLS backend, set the :option:`CONFIG_MBEDTLS_VANILLA_BACKEND` Kconfig variable to true.
+To enable the original Mbed TLS backend, set the :kconfig:`CONFIG_MBEDTLS_VANILLA_BACKEND` Kconfig variable to true.
 
 
 Using the nrf_cc3xx_mbedcrypto as backend
@@ -90,5 +90,5 @@ Using the nrf_cc3xx_mbedcrypto as backend
 
 To use the :ref:`nrf_cc3xx_mbedcrypto_readme` as a backend, the Arm CryptoCell cc310/cc312 hardware must be first initialized.
 
-The Arm CryptoCell cc3xx hardware is initialized in :file:`<NCS>/nrf/drivers/hw_cc310/hw_cc310.c` and is controlled with the :option:`CONFIG_HW_CC3XX` Kconfig variable.
+The Arm CryptoCell cc3xx hardware is initialized in :file:`<NCS>/nrf/drivers/hw_cc310/hw_cc310.c` and is controlled with the :kconfig:`CONFIG_HW_CC3XX` Kconfig variable.
 The Kconfig variable has a default value of 'y' when cc3xx is available in the SoC.

--- a/nrf_security/doc/configuration.rst
+++ b/nrf_security/doc/configuration.rst
@@ -4,19 +4,19 @@ Configuration
 #############
 
 Use Kconfig to configure the nrf_security module.
-To enable the module, set the :option:`CONFIG_NORDIC_SECURITY_BACKEND` Kconfig variable in the `Nordic Security` menu.
+To enable the module, set the :kconfig:`CONFIG_NORDIC_SECURITY_BACKEND` Kconfig variable in the `Nordic Security` menu.
 
 Setting this variable allows for additional Kconfig variables, depending on the number of features requested.
 These configurations are then used to generate an Mbed TLS configuration file used during compilation.
 
-It is possible to provide your own custom Mbed TLS configuration file by deselecting the :option:`CONFIG_GENERATE_MBEDTLS_CFG_FILE` Kconfig variable.
+It is possible to provide your own custom Mbed TLS configuration file by deselecting the :kconfig:`CONFIG_GENERATE_MBEDTLS_CFG_FILE` Kconfig variable.
 
 .. note::
-   Deselecting the :option:`CONFIG_GENERATE_MBEDTLS_CFG_FILE` Kconfig variable is not recommended.
+   Deselecting the :kconfig:`CONFIG_GENERATE_MBEDTLS_CFG_FILE` Kconfig variable is not recommended.
    If you decide to do so, see :ref:`nrf_security_tls_header`.
 
 Building with TF-M
 ******************
 
-If :option:`CONFIG_BUILD_WITH_TFM` is enabled together with :option:`CONFIG_NORDIC_SECURITY_BACKEND`, the TF-M secure image will enable the use of the hardware acceleration of Arm CryptoCell.
+If :kconfig:`CONFIG_BUILD_WITH_TFM` is enabled together with :kconfig:`CONFIG_NORDIC_SECURITY_BACKEND`, the TF-M secure image will enable the use of the hardware acceleration of Arm CryptoCell.
 In such case, the Kconfig configurations in the Nordic Security Backend control the features enabled through TF-M.

--- a/zboss/doc/zboss_configuration.rst
+++ b/zboss/doc/zboss_configuration.rst
@@ -24,13 +24,13 @@ OSIF implements a series of functions used by ZBOSS and is included in the |NCS|
 Configuration options
 *********************
 
-In the |NCS|, you can enable the ZBOSS library using the :option:`CONFIG_ZIGBEE` Kconfig option.
+In the |NCS|, you can enable the ZBOSS library using the :kconfig:`CONFIG_ZIGBEE` Kconfig option.
 Enabling this library is required when configuring the Zigbee protocol in the |NCS|, for example when testing the available :ref:`nrf:zigbee_samples`.
 
 To enable additional features in the ZBOSS libraries, you can use the following Kconfig options:
 
-* :option:`CONFIG_ZIGBEE_LIBRARY_NCP_DEV` - With this option enabled, the application links with an additional library, which implements NCP commands.
+* :kconfig:`CONFIG_ZIGBEE_LIBRARY_NCP_DEV` - With this option enabled, the application links with an additional library, which implements NCP commands.
   This option is enabled by default in the :ref:`Zigbee NCP sample <nrf:zigbee_ncp_sample>`.
   This option uses a production version of ZBOSS that has not been certified.
-* :option:`CONFIG_ZIGBEE_GP_CB` - With this option enabled, the application can support the Green Power Combo feature, which implements the basic set of Green Power Proxy and Green Power Sink functionalities within a single device.
+* :kconfig:`CONFIG_ZIGBEE_GP_CB` - With this option enabled, the application can support the Green Power Combo feature, which implements the basic set of Green Power Proxy and Green Power Sink functionalities within a single device.
   This option is added only for evaluation purposes and does not have a dedicated sample.


### PR DESCRIPTION
References to Kconfig options require usage of the :kconfig: role.