### PR TITLE
mpsl: Set @rugeGerritsen as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,7 @@ doc/*                                     @b-gent
 /softdevice_controller/                   @joerchan @rugeGerritsen
 /nrf_modem/                               @rlubos @lemrey @evenl
 /crypto/                                  @frkv @tejlmand
-/mpsl/                                    @joerchan @carlopaparo
+/mpsl/                                    @joerchan @rugeGerritsen
 /nfc/                                     @anangl @grochu
 /nrf_802154/                              @czeslawmakarski
 /nrf_security/                            @frkv @tejlmand


### PR DESCRIPTION
Replaces @carlopaparo.

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>