### PR TITLE
doc: update changelogs for NCS 1.7.0

### DIFF
--- a/crypto/nrf_cc310_mbedcrypto/CHANGELOG.rst
+++ b/crypto/nrf_cc310_mbedcrypto/CHANGELOG.rst
@@ -10,7 +10,7 @@ Changelog - nrf_cc3xx_mbedcrypto
 All notable changes to this project are documented in this file.
 
 nrf_cc3xx_mbedcrypto - 0.9.11
-****************************
+*****************************
 
 New version of the runtime library with the following bug fix:
 

--- a/mpsl/CHANGELOG.rst
+++ b/mpsl/CHANGELOG.rst
@@ -9,10 +9,10 @@ Changelog
 
 All the notable changes to this project are documented in this file.
 
-Master branch
-*************
+nRF Connect SDK v1.7.0
+**********************
 
-All the notable changes added to the master branch are documented in this section.
+All the notable changes included in the |NCS| v1.7.0 release are documented in this section.
 
 Added
 =====

--- a/nfc/CHANGELOG.rst
+++ b/nfc/CHANGELOG.rst
@@ -9,8 +9,10 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
-master
-******
+nRF Connect SDK v1.7.0
+**********************
+
+All the notable changes included in the |NCS| v1.7.0 release are documented in this section.
 
 Modified
 ========

--- a/nrf_802154/doc/CHANGELOG.rst
+++ b/nrf_802154/doc/CHANGELOG.rst
@@ -9,6 +9,37 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+nRF Connect SDK 1.7.0 - nRF 802.15.4 Radio Driver
+*************************************************
+
+Added
+=====
+
+* Adopted usage of the Zephyr temperature platform for the RSSI correction.
+* Support for the coexistence feature from :ref:`nrfxlib:mpsl`.
+* Support for nRF21540 FEM GPIO interface on nRF53 Series.
+
+Notable changes
+===============
+
+* Modified the 802.15.4 Radio Driver Transmit API.
+  It now allows specifying whether to encrypt or inject dynamic data into the outgoing frame, or do both.
+  The :c:type:`nrf_802154_transmitted_frame_props_t` type is used for this purpose.
+
+Bug fixes
+=========
+
+* Fixed an issue where it would not be possible to transmit frames with invalid Auxiliary Security Header if :kconfig:`CONFIG_NRF_802154_ENCRYPTION` was set to ``n``. (KRKNWK-11218)
+* Fix an issue with the IE Vendor OUI endianness. (KRKNWK-10633)
+* Fixed various bugs in the MAC Encryption layer. (KRKNWK-10646)
+
+Limitations
+===========
+
+* Application and device drivers (excluding those compliant with :ref:`nrfxlib:mpsl`) must not use IRQ priority higher than :c:macro:`NRF_802154_SWI_PRIORITY` and :c:macro:`NRF_802154_SL_RTC_IRQ_PRIORITY`.
+* Transmitting an 802.15.4 frame with improperly populated Auxiliary Security Header field might result in assert.
+  Make sure that you populate the Auxiliary Security Header field according to the IEEE Std 802.15.4-2015 specification, section 9.4.
+
 nRF Connect SDK 1.6.0 - nRF 802.15.4 Radio Driver
 *************************************************
 

--- a/softdevice_controller/CHANGELOG.rst
+++ b/softdevice_controller/CHANGELOG.rst
@@ -9,10 +9,10 @@ Changelog
 
 All the notable changes to this project are documented in this file.
 
-Master branch
-*************
+nRF Connect SDK v1.7.0
+**********************
 
-All the notable changes added to the master branch are documented in this section.
+All the notable changes included in the |NCS| v1.7.0 release are documented in this section.
 
 Added
 =====
@@ -28,6 +28,7 @@ Changes
 * The scanner is now scheduling cooperatively when the scan window is equal to the scan interval.
   This improves the performance in the case of Bluetooth Mesh applications (DRGN-13146).
 * Support for radio front-end module (FEM) in nRF53 Series, based on the :ref:`mpsl_fem` (DRGN-14908).
+* The application must now call the APIs prefixed with ``sdc_support_`` before calling :c:func:`sdc_cfg_set` (DRGN-15899).
 
 Bug fixes
 =========
@@ -39,11 +40,6 @@ Bug fixes
 * Fixed an issue where the ``mpsl_tx_power_channel_map_set()`` API would not work on peripheral-only or central-only configurations (DRGN-16091).
 * Fixed an issue where an assert may occur when legacy advertiser is used after "HCI LE Clear Advertising Sets" (DRGN-15993).
 * Fixed an issue where an assert could occur when in LLPM mode and the connection interval was more than 1 ms (DRGN-16079).
-
-Changes
-=======
-
-* The application must now call the APIs prefixed with ``sdc_support_` before calling :c:func:`sdc_cfg_set` (DRGN-15899).
 
 nRF Connect SDK v1.6.0
 **********************

--- a/zboss/CHANGELOG.rst
+++ b/zboss/CHANGELOG.rst
@@ -7,11 +7,12 @@ Changelog
    :local:
    :depth: 2
 
-All notable changes to this project in |NCS| are documented in this file.
+All notable changes to this project in the |NCS| are documented in this file.
 
+nRF Connect SDK v1.7.0
+**********************
 
-Master branch
-*************
+All the notable changes included in the |NCS| v1.7.0 release are documented in this section.
 
 Changes
 =======
@@ -19,7 +20,7 @@ Changes
 * Added API for reading active neighbor list.
 * Extended NCP protocol with vendor-specific commands set.
 * Updated the ZBOSS stack to version ``3.8.0.1+4.0.0``.
-  For detailed information, see `ZBOSS stack release notes`_ for the |NCS|'s Master branch.
+  For detailed information, see `ZBOSS stack release notes`_ for the |NCS| v1.7.0.
 
 nRF Connect SDK v1.6.0
 **********************


### PR DESCRIPTION
Changed master branch heading to nRF Connect SDK 1.7.0.
NCSDK-11022

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>