### PR TITLE
nrf_security: symbol rename script now passes settings through script

### DIFF
--- a/nrf_security/cmake/extensions.cmake
+++ b/nrf_security/cmake/extensions.cmake
@@ -649,15 +649,24 @@ function(nrf_security_target_embed_objects)
         ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${backend_name}.txt
       )
 
+      set(symbol_rename_include"\
+        set(CMAKE_OBJCOPY ${CMAKE_OBJCOPY})\n\
+        set(CMAKE_AR ${CMAKE_AR})\n\
+        set(OBJECTS $<TARGET_OBJECTS:${target}>)\n\
+        set(ARCHIVE $<TARGET_FILE:${SEC_LIBS_TARGET}>)\n\
+        set(RENAME ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${backend_name}.txt)\n\
+        set(OUT_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/${backend_name})\n"
+      )
+
+      file(GENERATE OUTPUT
+        ${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${target}_include.cmake
+	CONTENT "${symbol_rename_include}"
+      )
+
       add_custom_command(TARGET ${SEC_LIBS_TARGET}
         POST_BUILD
         COMMAND ${CMAKE_COMMAND}
-          -DCMAKE_OBJCOPY=${CMAKE_OBJCOPY}
-          -DCMAKE_AR=${CMAKE_AR}
-          -DOBJECTS="$<TARGET_OBJECTS:${target}>"
-          -DARCHIVE=$<TARGET_FILE:${SEC_LIBS_TARGET}>
-          -DRENAME="${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${backend_name}.txt"
-          -DOUT_FOLDER=${CMAKE_CURRENT_BINARY_DIR}/${backend_name}
+          -DINCLUDE=${CMAKE_CURRENT_BINARY_DIR}/symbol_rename_${target}_include.cmake
           -P ${NRF_SECURITY_ROOT}/cmake/symbol_rename_archive_script.cmake
       )
     else()

--- a/nrf_security/cmake/symbol_rename_archive_script.cmake
+++ b/nrf_security/cmake/symbol_rename_archive_script.cmake
@@ -15,6 +15,10 @@
 # Note: The OUTPUT is the same as input in the current version of the script.
 #       This will change in an upcoming refactoring
 #
+if(DEFINED INCLUDE)
+  include(${INCLUDE})
+endif()
+
 execute_process(
   COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_FOLDER}
 )


### PR DESCRIPTION
The symbol rename archive script used a generator expression to pass
all objects to the symbol_rename_archive_script.cmake among other
arguments.

When there are many objects in the library, then the command execution
string becomes very long.

On Windows, long execution commands are
wrapped inside a bat-file.

This might look like:
...\post-build.bat 7eb3ae9870a59d55

Resulting in SES-NE to try to execute the post-build.bat including the
following SHA as a single command, which fails.

This is fixed by generating a CMake file with required arguments to
symbol_rename_archive_script.cmake, and the pass this settings file as
argument to the script.

Fixes: NCSDK-10510

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>