### PR TITLE
doc: fix fem support on 53 info

### DIFF
--- a/mpsl/doc/fem.rst
+++ b/mpsl/doc/fem.rst
@@ -12,9 +12,6 @@ This allows an increase of the transmitted power through a Power Amplifier (PA) 
 Any increase in power and sensitivity results in an increased communication range.
 The exact PA and LNA gains are dependent on the specific FEM used.
 
-.. note::
-   The front-end module feature is not supported on the nRF53 Series.
-
 Implementation
 **************
 
@@ -26,6 +23,9 @@ Two FEM implementations are provided:
 * Simple GPIO.
    It is a simplified version, made to be compatible with other front-end modules.
    It implements a 2-pin interface.
+
+.. note::
+   The nRF53 Series supports only the nRF21540 GPIO Front-End Module.
 
 Both implementations use PA and LNA pins for controlling the FEM.
 Additionally, the nRF21540 GPIO implementation uses the PDN pin for powering down the FEM internal circuits, to reduce energy consumption.


### PR DESCRIPTION
Removed note regarding fem not being supported on nRF53.

Signed-off-by: Francesco Servidio <francesco.servidio@nordicsemi.no>