### PR TITLE
cmake: Check for availability of softfp libararies

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -41,6 +41,18 @@ function(nrfxlib_calculate_lib_path lib_path)
   set(${lib_path} "lib/${arch_soc_dir}/${float_dir}${short_wchar}" PARENT_SCOPE)
 endfunction()
 
+function(nrfxlib_check_softfp_path lib_name)
+  if (CONFIG_FP_SOFTABI)
+    set(lib_full_path ${${lib_name}})
+    string(REGEX REPLACE "softfp-float" "soft-float" soft_path ${lib_full_path})
+
+    if(NOT EXISTS ${lib_full_path} AND EXISTS ${soft_path})
+      message("There is no softfp version for library ${lib_name}, using the soft-float version.")
+      set(${lib_name} ${soft_path} PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()
+
 function(get_mbedtls_dir ARM_MBEDTLS_PATH_ARG)
   if(EXISTS ${${ARM_MBEDTLS_PATH_ARG}})
   # Do nothing, just use the provided path

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Nordic Semiconductor
+# Copyright (c) 2021 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -12,15 +12,15 @@ add_library(nrfxlib_crypto INTERFACE)
 
 if (CONFIG_NRF_OBERON OR CONFIG_BUILD_WITH_TFM)
 
-  # The oberon library doesn't have a softfp version so we replace its path with the soft-float one
-  if (CONFIG_FP_SOFTABI)
-        string(REGEX REPLACE "softfp-float" "soft-float"  lib_path ${lib_path})
-  endif()
-
   set(OBERON_BASE ${CMAKE_CURRENT_SOURCE_DIR}/nrf_oberon)
   set(OBERON_VER 3.0.8)
+
   set(OBERON_LIB ${OBERON_BASE}/${lib_path}/liboberon_${OBERON_VER}.a)
+  nrfxlib_check_softfp_path(OBERON_LIB)
+
   set(OBERON_MBEDTLS_LIB ${OBERON_BASE}/${lib_path}/liboberon_mbedtls_${OBERON_VER}.a)
+  nrfxlib_check_softfp_path(OBERON_MBEDTLS_LIB)
+
   if(NOT EXISTS ${OBERON_LIB})
     message(WARNING "This combination of SoC and floating point ABI is not supported by the nrf_oberon lib."
                     "(${OBERON_LIB} doesn't exist.)")
@@ -74,6 +74,8 @@ if (CONFIG_NRF_CC310_BL)
   endif()
   set(CC310_BL_VER 0.9.12)
   set(CC310_BL_LIB ${CC310_BL_BASE}/${lib_path}/${CC310_FLAVOR}/libnrf_cc310_bl_${CC310_BL_VER}.a)
+  nrfxlib_check_softfp_path(CC310_BL_LIB)
+
   if(NOT EXISTS ${CC310_BL_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_cc310_bl lib."
                     "(${CC310_BL_LIB} doesn't exist.)")
@@ -96,6 +98,7 @@ if (CONFIG_NRF_CC3XX_PLATFORM)
   set(NRF_CC3XX_PLATFORM_LIB
     ${NRF_CC3XX_PLATFORM_BASE}/${lib_path}/${CC3XX_PLATFORM_FLAVOR}/libnrf_${CC3XX_ARCH}_platform_${NRF_CC3XX_PLATFORM_VER}.a
   )
+  nrfxlib_check_softfp_path(NRF_CC3XX_PLATFORM_LIB)
 
   if (NOT EXISTS ${NRF_CC3XX_PLATFORM_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_${CC3XX_ARCH}_platform lib."
@@ -138,6 +141,8 @@ if (CONFIG_CC3XX_BACKEND)
   set(NRF_CC3XX_LIB
     ${NRF_CC3XX_BASE}/${lib_path}/${CC3XX_FLAVOR}/libnrf_${CC3XX_ARCH}_mbedcrypto_${NRF_CC3XX_VER}.a
   )
+  nrfxlib_check_softfp_path(NRF_CC3XX_LIB)
+
   if(NOT EXISTS ${NRF_CC3XX_LIB})
     message(WARNING "This combination of SoC, floating point ABI, and interrupts settings is not supported by the nrf_${CC3XX_ARCH}_mbedcryto lib."
                     "(${NRF_CC3XX_LIB} doesn't exist.)")

--- a/mpsl/CMakeLists.txt
+++ b/mpsl/CMakeLists.txt
@@ -7,6 +7,7 @@
 nrfxlib_calculate_lib_path(lib_path)
 
 set(MPSL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+nrfxlib_check_softfp_path(MPSL_LIB_PATH)
 
 if(NOT EXISTS ${MPSL_LIB_PATH})
   message(WARNING "This combination of SoC and floating point ABI is not supported by the MPSL lib."

--- a/nfc/CMakeLists.txt
+++ b/nfc/CMakeLists.txt
@@ -7,6 +7,7 @@
 nrfxlib_calculate_lib_path(lib_path)
 
 set(NFC_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+nrfxlib_check_softfp_path(NFC_LIB_PATH)
 
 if(NOT EXISTS ${NFC_LIB_PATH})
   message(WARNING "This combination of SoC and floating point ABI is not supported by the nfc lib."

--- a/nrf_802154/sl/sl/CMakeLists.txt
+++ b/nrf_802154/sl/sl/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(nrf-802154-sl INTERFACE)
 nrfxlib_calculate_lib_path(lib_path SOC_MODE)
 
 set(NRF_802154_SL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+nrfxlib_check_softfp_path(NRF_802154_SL_LIB_PATH)
 
 if(NOT EXISTS ${NRF_802154_SL_LIB_PATH})
   message(WARNING "This combination of SoC and floating point ABI is not supported by the nrf_802154_sl lib."

--- a/nrf_modem/CMakeLists.txt
+++ b/nrf_modem/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CONFIG_NRF_MODEM_LINK_BINARY)
   nrfxlib_calculate_lib_path(lib_path)
 
   set(NRF_MODEM_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+  nrfxlib_check_softfp_path(NRF_MODEM_PATH)
 
   if(NOT EXISTS ${NRF_MODEM_PATH})
      message(ERROR " This combination of SoC and floating point ABI is not supported by libmodem"

--- a/softdevice_controller/CMakeLists.txt
+++ b/softdevice_controller/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CONFIG_BT_LL_SOFTDEVICE)
   nrfxlib_calculate_lib_path(lib_path)
 
   set(SOFTDEVICE_CONTROLLER_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
+  nrfxlib_check_softfp_path(SOFTDEVICE_CONTROLLER_LIB_PATH)
 
   if(NOT EXISTS ${SOFTDEVICE_CONTROLLER_LIB_PATH})
     message(WARNING "This combination of SoC and floating point ABI is not supported by the SoftDevice Controller lib."


### PR DESCRIPTION
-When FPU and the SOFTABI is enabled the cmake code
 tries to use the softfp version of libraries. Many
 libraries in nrfxlib do not have a softfp version but
 they do have a soft-float version which is compatible
 with the SOFTABI. This adds a CMake function which checks
 for the availability of a softfp library and if it is not
 available it is using the soft-float version instead.
-The libraries where this function is applied to are: crypto,
 mpsl, nfc, nrf_802154, nrf_modem and softdevice_controller

Ref: NCSDK-11600

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>