### PR TITLE
zboss: addons: Fix implementation of ZBOSS addons

### DIFF
--- a/zboss/include/addons/zcl/zb_zcl_color_control_addons.h
+++ b/zboss/include/addons/zcl/zb_zcl_color_control_addons.h
@@ -108,7 +108,7 @@ typedef struct
   ZB_ZCL_PACKET_PUT_DATA8(ptr, (hue));                                                              \
   ZB_ZCL_PACKET_PUT_DATA8(ptr, (saturation));                                                       \
   ZB_ZCL_PACKET_PUT_DATA16_VAL(ptr, (transition_time));                                             \
-  ZB_ZCL_SEND_COMMAND_SHORT_WITHOUT_ACK((buffer), ptr, (zb_addr_u *)(&(addr), dst_addr_mode,        \
+  ZB_ZCL_SEND_COMMAND_SHORT_WITHOUT_ACK((buffer), ptr, addr, dst_addr_mode,                         \
                                 dst_ep, ep, prfl_id, ZB_ZCL_CLUSTER_ID_COLOR_CONTROL, cb, 0);       \
 }
 

--- a/zboss/include/addons/zcl/zb_zcl_identify_addons.h
+++ b/zboss/include/addons/zcl/zb_zcl_identify_addons.h
@@ -22,7 +22,7 @@
             ZB_ZCL_CMD_IDENTIFY_TRIGGER_EFFECT_ID);                                                 \
     ZB_ZCL_PACKET_PUT_DATA8(ptr, (effect_id));                                                      \
     ZB_ZCL_PACKET_PUT_DATA8(ptr, (effect_var));                                                     \
-  ZB_ZCL_SEND_COMMAND_SHORT_WITHOUT_ACK((buffer), ptr, (zb_addr_u *)(&(addr), dst_addr_mode,        \
+    ZB_ZCL_SEND_COMMAND_SHORT_WITHOUT_ACK((buffer), ptr, addr, dst_addr_mode,                       \
                                 dst_ep, ep, prof_id, ZB_ZCL_CLUSTER_ID_IDENTIFY, cb, 0);            \
 }
 

--- a/zboss/include/addons/zcl/zb_zcl_level_control_addons.h
+++ b/zboss/include/addons/zcl/zb_zcl_level_control_addons.h
@@ -40,7 +40,7 @@ typedef struct
   ZB_ZCL_PACKET_PUT_DATA8(ptr, (step_size));                            \
   ZB_ZCL_PACKET_PUT_DATA16_VAL(ptr, (transition_time));                 \
   ZB_ZCL_SEND_COMMAND_SHORT_WITHOUT_ACK((buffer), ptr,                  \
-                            (zb_addr_u *)(&(addr), dst_addr_mode,       \
+                            addr, dst_addr_mode,                        \
                             dst_ep, ep, prfl_id,                        \
                             ZB_ZCL_CLUSTER_ID_LEVEL_CONTROL, cb, 0);    \
 }

--- a/zboss/include/addons/zcl/zb_zcl_on_off_addons.h
+++ b/zboss/include/addons/zcl/zb_zcl_on_off_addons.h
@@ -28,7 +28,7 @@ typedef struct
   zb_uint8_t* ptr = ZB_ZCL_START_PACKET_REQ(buffer)                                     \
   ZB_ZCL_CONSTRUCT_SPECIFIC_COMMAND_REQ_FRAME_CONTROL(ptr, dis_default_resp)            \
   ZB_ZCL_CONSTRUCT_COMMAND_HEADER_REQ(ptr, ZB_ZCL_GET_SEQ_NUM(), command_id);           \
-  ZB_ZCL_SEND_COMMAND_SHORT_WITHOUT_ACK((buffer), ptr, (zb_addr_u *)(&(addr),           \
+  ZB_ZCL_SEND_COMMAND_SHORT_WITHOUT_ACK((buffer), ptr, addr,                            \
             dst_addr_mode, dst_ep, ep, prof_id, ZB_ZCL_CLUSTER_ID_ON_OFF, cb, 0);       \
 }
 


### PR DESCRIPTION
There is an API misuse in ZBOSS addons - the address should be passed as value, not a reference.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>