### PR TITLE
crypto: Don't enable MD5 unless NET_TCP is enabled

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -1331,7 +1331,7 @@ menu "SHA   - Secure Hash Algorithm"
 
 config MBEDTLS_MD5_C
 	bool
-	default y
+	default y if NET_TCP
 	help
 	  MD5 hash functionality.
 	  MD5 is not recommended for general use as a secure hash algorithm.


### PR DESCRIPTION
Instead of always enabling MD5 we enable it only when NET_TCP is
enabled.

This saves us a significant amount of flash.

We could make additional savings by only enabling it in certain types
of TCP builds, but it is not clear which option to depend on.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>