### PR TITLE
doc: Remove latin from sdk-nrfxlib docs

### DIFF
--- a/nfc/CHANGELOG.rst
+++ b/nfc/CHANGELOG.rst
@@ -39,9 +39,9 @@ Added
 =====
 
 * Added support for non-secure firmware image to the NFC T2T and NFC T4T libraries.
-  A non-secure image can only be run on nRF devices that support Trusted Execution (e.g. nRF5340).
+  A non-secure image can only be run on nRF devices that support Trusted Execution (for example, nRF5340).
 * Added Frame Waiting Time (FWT) management logic to the NFC T4T library.
-  FWT is changed now according to the ISO-DEP timing requirements (e.g. WTX frame).
+  FWT is changed now according to the ISO-DEP timing requirements (for example, WTX frame).
 
 NFC 0.4.0
 *********

--- a/nrf_802154/doc/multiprotocol_support.rst
+++ b/nrf_802154/doc/multiprotocol_support.rst
@@ -12,7 +12,7 @@ It can be used to run several radio protocols simultaneously without the time-ex
 Switching between protocols requires only a reinitialization of the radio peripheral, since protocols may operate on different frequencies and/or modulations.
 Therefore, the time required for the switching is much shorter than in the switched multiprotocol method, where you need to completely shut down one protocol before enabling another.
 
-The driver can use the basic version of the Radio Arbiter via the open-source Service Layer, and the fully-featured one via the closed-source Service Layer.
+The driver can use the basic version of the Radio Arbiter through the open-source Service Layer, and the fully-featured one through the closed-source Service Layer.
 
 .. _rd_multiprotocol_support_implemented:
 

--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -65,7 +65,7 @@ nrf_modem 1.2.1
 ***************
 
 * Fixed an issue where :c:func:`nrf_getaddrinfo` would set a wrong errno when returning ``NRF_EAI_SYSTEM``.
-* Fixed an issue where the ``NRF_SO_TCP_SRV_SESSTIMEO``, ``NRF_SO_SILENCE_IP_ECHO_REPLY`` and ``NRF_SO_SILENCE_IPV6_ECHO_REPLY`` socket options returned an error when set via :c:func:`nrf_setsockopt`.
+* Fixed an issue where the ``NRF_SO_TCP_SRV_SESSTIMEO``, ``NRF_SO_SILENCE_IP_ECHO_REPLY`` and ``NRF_SO_SILENCE_IPV6_ECHO_REPLY`` socket options returned an error when set using :c:func:`nrf_setsockopt`.
 * Renamed the socket option ``NRF_SO_SILENCE_IP_ECHO_REPLY`` to ``NRF_SO_IP_ECHO_REPLY``.
 * Renamed the socket option ``NRF_SO_SILENCE_IPV6_ECHO_REPLY`` to ``NRF_SO_IPV6_ECHO_REPLY``.
 
@@ -267,7 +267,7 @@ bsdlib 0.5.0
 ************
 
 * bsd_irrecoverable_handler() has been removed.
-  The application no longer needs to implement it to receive errors during initialization, which are instead reported via bsd_init().
+  The application no longer needs to implement it to receive errors during initialization, which are instead reported through bsd_init().
 * bsd_shutdown() now returns an integer.
 * Added RAW socket support.
 * Added missing AGPS data models.

--- a/nrf_modem/doc/architecture.rst
+++ b/nrf_modem/doc/architecture.rst
@@ -10,7 +10,7 @@ Library architecture
 The Modem library is the application interface to the nRF9160 modem firmware, which contains a full IP and DTLS/TLS stack as well as GNSS.
 It provides the standard Socket APIs, to facilitate application development and additional APIs to manage the modem and perform full-modem firmware updates.
 
-The library implements a communication interface between the Application and Modem cores on the nRF9160 via the RPC protocol, using the Inter Processor Communication (IPC) peripheral and a shared region of RAM.
+The library implements a communication interface between the Application and Modem cores on the nRF9160 through the RPC protocol, using the Inter Processor Communication (IPC) peripheral and a shared region of RAM.
 
 The following figure shows a simplified Modem library architecture:
 
@@ -32,7 +32,7 @@ The shared memory area can be located anywhere within the first 128 kilobytes of
 
 The application can configure the size and location of these regions.
 The application is responsible for reserving the memory area by setting the values of these parameters before passing them onto the library.
-The library accepts these values as parameters to the :c:func:`nrf_modem_init` function via :c:enum:`nrf_modem_shmem_cfg`.
+The library accepts these values as parameters to the :c:func:`nrf_modem_init` function through :c:enum:`nrf_modem_shmem_cfg`.
 
 .. note::
    The size of the Control area is fixed.

--- a/nrf_modem/doc/ug_nrf_modem_porting_os.rst
+++ b/nrf_modem/doc/ug_nrf_modem_porting_os.rst
@@ -45,7 +45,7 @@ See :ref:`trace_output_function` for more information.
 * Initialize timers/threads.
 * Configure low priority Modem library scheduling IRQ (SoftIRQ).
 * Configure low priority trace scheduling IRQ (SoftIRQ).
-* Configure medium for trace (UART/SPI etc.).
+* Configure medium for trace (for example, UART or SPI).
 
 nrf_modem_os_timedwait
 ======================

--- a/nrf_rpc/README.rst
+++ b/nrf_rpc/README.rst
@@ -10,7 +10,7 @@ It is designed to be used with an underlying transport layer, for example `OpenA
 The nRF RPC library allows for calling a function on remote processors from a local processor, in both synchronous and asynchronous way.
 
 Depending on the transport layer, the remote processor is not limited to a single device.
-It can also be a separate device of any type (e.g. a PC), or another core on the same system.
+It can also be a separate device of any type (for example, a PC), or another core on the same system.
 
 The nRF RPC library simplifies the serialization of user APIs, such as a Bluetooth stack, and executing of functions implementing those APIs on a remote CPU.
 The library is operating system independent so it can be used with any operating system after porting the OS-dependent layers of the library.

--- a/nrf_rpc/doc/architecture.rst
+++ b/nrf_rpc/doc/architecture.rst
@@ -67,7 +67,7 @@ The following image presents sample command and response flows.
 
    nRF RPC simple command flow
 
-A thread waiting for a response can be reused to receive a new incoming command from the remote thread that the local thread is waiting for, e.g. when a callback is called synchronously.
+A thread waiting for a response can be reused to receive a new incoming command from the remote thread for which the local thread is waiting, for example, when a callback is called synchronously.
 The following diagram demonstrates this situation.
 
 .. figure:: img/cmd_recursive.svg

--- a/nrf_security/doc/mbed_tls_header.rst
+++ b/nrf_security/doc/mbed_tls_header.rst
@@ -16,5 +16,5 @@ When doing so, you must make sure that the system is working. First, use Kconfig
 .. note::
    When providing a custom Mbed TLS configuration header, it is important that the following criteria are still met:
 
-   * Entropy length of 144, i.e. ``#define MBEDTLS_ENTROPY_MAX_GATHER 144``
+   * Entropy length of 144, that is, ``#define MBEDTLS_ENTROPY_MAX_GATHER 144``
    * Force SHA256


### PR DESCRIPTION
NCSDK-12222
Remove Latin abbreviations from the
sdk-nrfxlib documents.

Signed-off-by: divya pillai <divya.pillai@nordicsemi.no>