### PR TITLE
nrf_security: Update mcuboot mbedcrypto config file

### DIFF
--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -56,8 +56,14 @@ else()
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS
       -DTFM_MBEDCRYPTO_CONFIG_PATH:STRING=${CONFIG_MBEDTLS_CFG_FILE}
-      -DMCUBOOT_MBEDCRYPTO_CONFIG_PATH=${CONFIG_MBEDTLS_CFG_FILE}
   )
+
+  if(CONFIG_TFM_BL2)
+    set_property(TARGET zephyr_property_target
+      APPEND PROPERTY TFM_CMAKE_OPTIONS
+        -DMCUBOOT_MBEDCRYPTO_CONFIG_PATHPATH:STRING=${CONFIG_MBEDTLS_CFG_FILE}
+    )
+  endif()
 
   if(CONFIG_MBEDTLS_ENABLE_HEAP)
     # The ENGINE_BUF_SIZE holds the dynamic allocation buffer for


### PR DESCRIPTION
Update mcuboot mbedcrypto config file name. This was always the name,
but commit message that added it uses the other name, probably changed
during code-review in trusted-firmware-m.

Don't set the config unless BL2 is enabled. Otherwise this will produce
a cmake warning when the config is not used.