### PR TITLE
doc: nrf_security: Misc. doc improvements

### DIFF
--- a/crypto/doc/nrf_cc310_mbedcrypto.rst
+++ b/crypto/doc/nrf_cc310_mbedcrypto.rst
@@ -13,8 +13,8 @@ The library adds hardware support for selected cryptographic algorithms.
 
 Integration with Mbed TLS
 =========================
-The nrf_cc3xx_mbedcrypto library provides low-level integration towards selected versions of Mbed TLS deliverables.
-The APIs expressed in this library use the alternative implementation abstraction layer inside Mbed TLS for selected modules.
+The nrf_cc3xx_mbedcrypto library provides low-level integration with the Mbed TLS version provided in nRF Connect SDK.
+Some of the APIs expressed in this library use the Mbed TLS "alternative implementation" abstraction layer.
 
 .. note::
    It is not recommended to link to this library directly. Use the :ref:`nrf_security`.
@@ -27,8 +27,6 @@ The following tables show the supported cryptographic algorithms in the Arm Cryp
 
 .. note::
    If `no Mbed TLS support` is listed in limitations, it indicates that the hardware supports it, but it is not exposed in an API that works with Mbed TLS.
-   
-   If `mbedtls_extra only` is listed in limitations, it indicates that an API similar to recent versions of Mbed TLS is made available with the library.
 
 
 AES - Advanced Encryption Standard
@@ -55,11 +53,8 @@ AEAD - Authenticated Encryption with Associated Data
 +=======================+===============================+
 | CCM/CCM*              | 128-bit                       |
 +-----------------------+-------------------------------+
-| ChaCha-Poly           | 128-bit, mbedtls_extra only   |
+| ChaCha-Poly           | 128-bit                       |
 +-----------------------+-------------------------------+
-
-.. note::
-   APIs currently in mbedtls_extra, as well as APIs with no current HW TLS support, will be supported in upcoming releases of the nrf_cc3xx_mbedcrypto library.
 
 Diffie-Hellman-Merkel
 ---------------------
@@ -105,10 +100,10 @@ Edwards/Montgommery:
 
 Additional items in mbedtls_extra
 ---------------------------------
-The following is a list of features available in mbedtls_extra as non-standard Mbed TLS APIs:
+
+These mbedtls_extra algorithms are supported, but are not in the Mbed TLS API.
 
 * AES key wrap functions
-* ChaCha20 and Poly1305
 * ECIES
 * HKDF
 * SRP, up to 3072 bits
@@ -118,27 +113,23 @@ Using the library
 
 Providing platform specific calloc/free
 ---------------------------------------
-This library facilitates the same type of memory management as regular Mbed TLS deliverables.
-This includes using internal calls to calloc/free from the library code when memory is needed.
+Just like Mbed TLS, this library calls :c:func:`calloc` and :c:func:`free` for memory management.
 
-The following API must be used to change the default `calloc`/`free` function:
+The :c:func:`calloc` and :c:func:`free` functions can be changed with the following API:
 
 .. code-block:: c
     :caption: Setting custom calloc/free
 	
     int ret;
     
-    ret = mbedtls_platform_set_calloc_free(alloc_fn, free_fn);
+    ret = mbedtls_platform_set_calloc_free(calloc_fn, free_fn);
     if (ret != 0) {
             /* Failed to set the alternative calloc/free */
             return ret;
     }
 
-.. note::
-   This API must be called prior to calling :c:func:`mbedtls_platform_setup`.
-
-.. note::
-   The library will default to use clib calloc/free functions if the :c:func:`mbedtls_platform_set_calloc_free` is not used.
+This API must be called prior to calling :c:func:`mbedtls_platform_setup`.
+Otherwise, the library will default to use the clib functions :c:func:`calloc` and :c:func:`free`.
 
 
 Initializing the library
@@ -165,7 +156,7 @@ You can initialize it by calling the :c:func:`mbedtls_platform_setup`/:c:func:`m
 RNG initialization memory management
 ------------------------------------
 
-The nrf_cc3xx_mbedcrypto library allocates a work buffer during RNG initialization using calloc/free.
+The nrf_cc3xx_mbedcrypto library allocates a work buffer during RNG initialization using :c:func:`calloc` and :c:func:`free`.
 The size of this work buffer is 6112 bytes.
 An alternative to allocating this on the heap is to provide a reference to a static variable inside the :c:type:`mbedtls_platform_context` structure type.
 
@@ -186,8 +177,10 @@ An alternative to allocating this on the heap is to provide a reference to a sta
 Usage restrictions
 ------------------
 
-On the nRF9160 SiP, the nrf_cc3xx_mbedcrypto library is restricted to only work in secure processing environment.
-The library uses mutexes to ensure single usage of hardware modules.
+The library can not be used in the non-secure domain of an application that uses ARM TrustZone.
+
+The hardware can only process one request at a time.
+Therefore, this library has used mutexes to make the library thread-safe.
 
 API documentation
 =================

--- a/nrf_security/README.rst
+++ b/nrf_security/README.rst
@@ -7,9 +7,8 @@ Nordic Security Module
 The Nordic Security Module (nrf_security) provides an integration between Mbed TLS and software libraries that provide hardware-accelerated cryptographic functionality on selected Nordic Semiconductor SoCs as well as alternate software-based implementations of the Mbed TLS APIs.
 This module includes an Mbed TLS glue layer to enable both hardware-accelerated and software-based Mbed TLS implementation at the same time.
 
-.. note::
-   The nrf_security module interfaces with the :ref:`nrf_cc3xx_mbedcrypto_readme`.
-   This library conforms to a specific version of Mbed TLS.
+The nrf_security module can interface with the :ref:`nrf_cc3xx_mbedcrypto_readme`.
+This library conforms to the specific revision of Mbed TLS that is supplied through the nRF Connect SDK.
 
 Prerequisites
 *************

--- a/nrf_security/doc/backend_config.rst
+++ b/nrf_security/doc/backend_config.rst
@@ -7,42 +7,33 @@ Backend configurations and supported features
    :local:
    :depth: 2
 
-This section covers the configurations available when one or more nrf_security backends are enabled.
-This includes linking directly to the backend library or utilizing the Mbed TLS glue layer.
+This section covers the configurations available when either linking directly to a backend library or when using the Mbed TLS glue layer.
 
 .. _nrf_security_backend_config_multiple:
 
 Configuring multiple backends
 *****************************
 
-Different backends can support different cryptographic algorithms.
-The configuration options listed in subsequent sections are either *Glue*, *Shared*, or *Choice*.
+Different backends support different cryptographic algorithms.
+The algorithms listed in subsequent sections are implemented either as *Glue* or *Choice*.
 
 Glue
-   The configuration options will list `Glue` for the cryptographic algorithms that can be enabled in multiple backends at the same time.
-Shared
-   For some cryptographic features, the implementation is only available in the :ref:`nrf_security_backends_orig_mbedtls`.
-   For convenience, this is made available in any backend, although the implementation will always use open-source code from the Arm Mbed TLS project.
+   Algorithms that can be enabled in multiple backends simultaneously.
 Choice
-   The configuration options will list `Choice` for the cryptographic algorithms that are supported by multiple backends, but only one of them can be enabled at the same time.
-   To enable the cryptographic algorithm, a `base` configuration must be enabled, and then the backend can be selected using a setting prefixed with ``CONFIG_CHOICE_``.
+   Algorithms that can not be enabled in multiple backends simultaneously.
+   To enable the algorithm, a `base` configuration must first be enabled, and then the backend is chosen using a Kconfig option prefixed with ``CONFIG_CHOICE_``.
+   If no backend is explicitly chosen it will be selected automatically with :ref:`nrf_security_backends_cc3xx` having precedence over :ref:`nrf_security_backends_oberon` and :ref:`nrf_security_backends_oberon` having precedence over :ref:`nrf_security_backends_orig_mbedtls`.
 
-If only a subset of the backends supports a given feature, this information is provided in the tables.
-
-.. note::
-   The first ordered item in the list of available choices is selected by default.
-
+It will be noted in the below tables when only some backends support a feature.
 
 AES configuration
 *****************
 
-AES core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_AES_C` Kconfig variable.
-Enabling AES core support enables AES ECB cipher mode and allows for the following ciphers to be configured: CTR, OFB, CFB, CBC, XTS, CMAC, CCM/CCM*, and GCM.
+The AES core is enabled with the Kconfig option :kconfig:`CONFIG_MBEDTLS_AES_C`.
+This enables AES ECB cipher mode and allows the ciphers and modes CTR, OFB, CFB, CBC, XTS, CMAC, CCM/CCM*, and GCM to be configured.
 
 Single backend
 ==============
-
-AES core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_AES_C` Kconfig variable.
 
 +--------------+------------------------------------+
 | Cipher mode  | Configurations                     |
@@ -56,8 +47,6 @@ AES core support can be enabled by setting the :kconfig:`CONFIG_MBEDTLS_AES_C` K
 Multiple backends
 =================
 
-AES core support can be enabled by setting setting the :kconfig:`CONFIG_MBEDTLS_AES_C` Kconfig variable, and one or more of the following Kconfig variables:
-
 +--------------+----------------+------------------------------------------------------------+
 | Cipher mode  | Support        | Configurations                                             |
 +==============+================+============================================================+
@@ -69,9 +58,8 @@ AES core support can be enabled by setting setting the :kconfig:`CONFIG_MBEDTLS_
 +--------------+----------------+------------------------------------------------------------+
 
 .. note::
-   * Enabling the :ref:`nrf_security_backends_oberon` replaces select internal APIs for AES block encrypt/decrypt and set key operations for encrypt/decrypt.
-   * If both nrf_oberon backend and :ref:`nrf_security_backends_orig_mbedtls` are enabled, the implementation from
-     nrf_oberon backend will provide support for AES ECB.
+   * The :ref:`nrf_security_backends_oberon` uses some functionality from Original Mbed TLS for AES operations.
+   * The :ref:`nrf_security_backends_oberon` has priority over the :ref:`nrf_security_backends_orig_mbedtls`.
 
 Feature support
 ===============
@@ -855,7 +843,7 @@ SHA support can be enabled by setting Kconfig according to the following table:
 +--------------+--------------------+--------------------------------------+
 | SHA-256      |                    | :kconfig:`CONFIG_MBEDTLS_SHA256_C`   |
 +--------------+--------------------+--------------------------------------+
-| SHA-512      | Shared             | :kconfig:`CONFIG_MBEDTLS_SHA512_C`   |
+| SHA-512      |                    | :kconfig:`CONFIG_MBEDTLS_SHA512_C`   |
 +--------------+--------------------+--------------------------------------+
 
 Multiple backends
@@ -907,7 +895,7 @@ SHA-256 support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_SHA512
 +--------------+-----------------+-----------------------------------------------------------------+
 | Algorithm    | Support         | Backend selection                                               |
 +==============+=================+=================================================================+
-| SHA-512      | Shared          | :kconfig:`CONFIG_MBEDTLS_SHA512_C`                              |
+| SHA-512      |                 | :kconfig:`CONFIG_MBEDTLS_SHA512_C`                              |
 +--------------+-----------------+-----------------------------------------------------------------+
 
 .. note::

--- a/nrf_security/doc/backends.rst
+++ b/nrf_security/doc/backends.rst
@@ -11,16 +11,12 @@ The nrf_security module supports multiple enabled backends at the same time.
 This mechanism is intended to extend the available feature set of hardware-accelerated cryptography or to provide alternative implementations of the Mbed TLS APIs.
 Enabling one or more backends adds more configuration options grouped into classes of cryptographic algorithms.
 
-Note that some cryptographic features are provided as an option regardless of the backend enabled.
-In such cases, the feature is compiled using open-source software from the original Arm Mbed TLS project.
-An example of this is `SHA-512`, which is only accessible using open-source software from the Arm Mbed TLS project.
-
 The configuration options added after enabling one or more backends will change based on the number of enabled backends.
 Some configuration options allow for adding support from multiple backends by utilizing the Mbed TLS glue layer, while other provide a selection between the enabled backends (as radio buttons).
 
 The nrf_security module supports the following backends:
 
-* Arm CryptoCell cc3xx (in nRF52840, nRF9160, and nRF5340)
+* Arm CryptoCell cc3xx
 * nrf_oberon binary library
 * Original Mbed TLS
 
@@ -47,15 +43,21 @@ Enabling the Arm CryptoCell cc3xx backend
 
 The Arm CryptoCell cc3xx backend can be enabled by setting the :kconfig:`CONFIG_CC3XX_BACKEND` Kconfig variable.
 
-.. note:: This backend is only available in nRF52840 and nRF9160.
 
+Using the Arm CryptoCell cc3xx backend
+======================================
+
+To use the :ref:`nrf_cc3xx_mbedcrypto_readme` as a backend, the Arm CryptoCell cc310/cc312 hardware must be first initialized.
+
+The Arm CryptoCell cc3xx hardware is initialized in :file:`<NCS>/nrf/drivers/hw_cc310/hw_cc310.c` and is controlled with the :kconfig:`CONFIG_HW_CC3XX` Kconfig variable.
+The Kconfig variable has a default value of 'y' when cc3xx is available in the SoC.
 
 .. _nrf_security_backends_oberon:
 
 nrf_oberon backend
 ******************
 
-The :ref:`nrf_oberon_readme` library is a binary library that provides select cryptographic algorithms optimized for use in nRF devices.
+The :ref:`nrf_oberon_readme` is distributed as a closed-source binary that provides select cryptographic algorithms optimized for use in nRF devices.
 This provides faster execution than the original Mbed TLS implementation.
 
 The nrf_oberon backend provides support for AES ciphers, SHA-1, SHA-256, and ECC (ECDH, ECDSA, and ECJPAKE) using NIST curve secp256r1.
@@ -83,12 +85,3 @@ Enabling the original Mbed TLS backend
 ======================================
 
 To enable the original Mbed TLS backend, set the :kconfig:`CONFIG_MBEDTLS_VANILLA_BACKEND` Kconfig variable to true.
-
-
-Using the nrf_cc3xx_mbedcrypto as backend
-*****************************************
-
-To use the :ref:`nrf_cc3xx_mbedcrypto_readme` as a backend, the Arm CryptoCell cc310/cc312 hardware must be first initialized.
-
-The Arm CryptoCell cc3xx hardware is initialized in :file:`<NCS>/nrf/drivers/hw_cc310/hw_cc310.c` and is controlled with the :kconfig:`CONFIG_HW_CC3XX` Kconfig variable.
-The Kconfig variable has a default value of 'y' when cc3xx is available in the SoC.

--- a/nrf_security/doc/configuration.rst
+++ b/nrf_security/doc/configuration.rst
@@ -3,20 +3,16 @@
 Configuration
 #############
 
-Use Kconfig to configure the nrf_security module.
-To enable the module, set the :kconfig:`CONFIG_NORDIC_SECURITY_BACKEND` Kconfig variable in the `Nordic Security` menu.
+The Nordic Security Module is enabled through Kconfig with the option :kconfig:`CONFIG_NORDIC_SECURITY_BACKEND` and additional configuration is usually done with Kconfig.
 
-Setting this variable allows for additional Kconfig variables, depending on the number of features requested.
 These configurations are then used to generate an Mbed TLS configuration file used during compilation.
 
-It is possible to provide your own custom Mbed TLS configuration file by deselecting the :kconfig:`CONFIG_GENERATE_MBEDTLS_CFG_FILE` Kconfig variable.
+Although not recommended, it is possible to provide a custom Mbed TLS configuration file by disabling :kconfig:`CONFIG_GENERATE_MBEDTLS_CFG_FILE`.
+See :ref:`nrf_security_tls_header`.
 
-.. note::
-   Deselecting the :kconfig:`CONFIG_GENERATE_MBEDTLS_CFG_FILE` Kconfig variable is not recommended.
-   If you decide to do so, see :ref:`nrf_security_tls_header`.
 
 Building with TF-M
 ******************
 
 If :kconfig:`CONFIG_BUILD_WITH_TFM` is enabled together with :kconfig:`CONFIG_NORDIC_SECURITY_BACKEND`, the TF-M secure image will enable the use of the hardware acceleration of Arm CryptoCell.
-In such case, the Kconfig configurations in the Nordic Security Backend control the features enabled through TF-M.
+In this case, the Kconfig configurations in the Nordic Security Backend control the features enabled in TF-M.

--- a/nrf_security/doc/glue_layer.rst
+++ b/nrf_security/doc/glue_layer.rst
@@ -29,9 +29,9 @@ This function is called from the API which provides configuration changes that d
             return (keybits == 128) ? 3 : 0;
     }
 
-In this example, the AES CCM support in the backend will report priority level 3 if the key size is 128, or 0 if the key size is different.
-The :ref:`nrf_security_backends_cc3xx` does not support a larger key size.
-If the key size is larger than 128 bits, then another enabled backend is used.
+In this example, the AES CCM support in the backend will report priority level 3 if the key size is 128, or 0 if the key size is unsupported.
+Higher priority values are selected first.
+It reports this because :ref:`nrf_security_backends_cc3xx` only supports key size 128.
 
 .. note::
    The check function can be called from multiple APIs in the Mbed TLS glue layer.
@@ -53,8 +53,8 @@ The Mbed TLS glue layer is automatically enabled when two backends are enabled f
 
 Mbed TLS glue layer mechanisms
 ******************************
-The Mbed TLS glue layer relies on symbol renaming of known APIs in Mbed TLS to prevent collisions of identically named functions in multiple backends.
-The backend implementation is reached using a table of function pointers corresponding to the renamed symbols.
+The Mbed TLS glue layer will rename symbols to resolve the aliasing issues that occur from multiple enabled backends.
+The backend implementation is reached using a table of function pointers to the renamed symbols.
 
 .. code-block:: c
     :caption: Example: cc3xx backend ECDH function table
@@ -65,8 +65,8 @@ The backend implementation is reached using a table of function pointers corresp
             .compute_shared = mbedtls_ecdh_compute_shared,
     };
 
-:cpp:func:`mbedtls_ecdh_cc3xx_backend_funcs` points to Mbed TLS APIs in :ref:`nrf_cc3xx_mbedcrypto_readme` which is renamed if Mbed TLS glue layer is enabled.
+In this example :cpp:var:`mbedtls_ecdh_cc3xx_backend_funcs` points to APIs in :ref:`nrf_cc3xx_mbedcrypto_readme` which have been renamed.
 The function pointers `gen_public` and `compute_shared` have signatures equal to the corresponding Mbed TLS APIs.
 
 
-The complete list of APIs that can be renamed in the Mbed TLS glue layer can be found in :file:`nrfxlib/nrf_security/src/mbedcrypto_glue/symbol_rename.template.txt`
+The APIs that can be renamed are listed in :file:`nrfxlib/nrf_security/src/mbedcrypto_glue/symbol_rename.template.txt`


### PR DESCRIPTION
Miscellaneous doc improvements.

In some parts the language is superfluous, in a few cases it's
wrong/misleading, overall it is OK.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>