### PR TITLE
doc: nrf_security: Different configs on secure and non-secure

### DIFF
--- a/nrf_security/README.rst
+++ b/nrf_security/README.rst
@@ -27,4 +27,5 @@ manually configured with the CMake variable ``ARM_MBEDTLS_PATH``.
    doc/backend_config
    doc/adv_backend_config
    doc/mbed_tls_header
+   doc/different_tfm_config
    doc/api

--- a/nrf_security/doc/different_tfm_config.rst
+++ b/nrf_security/doc/different_tfm_config.rst
@@ -3,23 +3,20 @@
 Different configurations in SPE and NSPE
 ########################################
 
-Normally in a TF-M application with a NSPE image and a SPE image the
-NSPE will invoke the PSA Crypto APIs to do crypto. And the feature set
-of the PSA Crypto API will be configured through nrf_security. So
-there will be no crypto implementations in the NSPE.
+When a TF-M application has both an NSPE (Non-secure Processing Environment) image and an SPE (Secure Processing Environment) image, the NSPE usually invokes the PSA Cryptography APIs to perform cryptographic operations.
+In this case, you can configure the feature set of the PSA Cryptography API through the Nordic Security Module (nrf_security).
+As such, there are no cryptographic implementations in the NSPE.
 
-Therefore in a normal TF-M application there will be two instances of
-nrf_security, one in the NSPE that just contains an API for PSA
-Crypto. And one in the SPE which contains a cryptocell driver and
-possibly other backends as well. Yet they will both use the same
-configuration.
+Therefore, in a typical TF-M application, there are two instances of the Nordic Security Module:
 
-But, if an application needs to have some crypto features implemented
-in the NSPE nrf_security instance and other features implemented in
-the SPE nrf_security instance the following guide can be followed to
-configure each instance independently:
+* One instance in the NSPE that contains just an API for the PSA Cryptography.
+* One instance in the SPE that contains an ARM Cryptocell driver and possibly other backends.
 
-1. Build the application for a board with TF-M.
+Both instances would still use the same configuration.
+
+If you want to independently configure the two Nordic Security Module instances so that they can have different features, follow the steps below:
+
+1. Build the application for a development kit with TF-M:
 
    .. code-block:: console
 
@@ -27,14 +24,10 @@ configure each instance independently:
       cd $APP_DIR
       west build -b nrf9160dk_nrf9160_ns
 
-#. Enable nrf_security, if it is not enabled already, and configure
-   the crypto functionality and enabled backends as they should be
-   configured in the SPE. See :ref::`_nrf_security_backend_config` for
-   configuration of nrf_security.
+#. Enable the Nordic Security Module, if it is not enabled, and configure the cryptographic functionality and the necessary backends as needed by the SPE.
+   See :ref::`_nrf_security_backend_config` for details on the configuration of the Nordic Security Module.
 
-#. Copy the resulting configuration from the build directory to the
-   application source directory. This copy will be used to configure
-   the SPE nrf_security instance.
+#. Copy the resulting configuration files from the build directory to the application source directory:
 
    .. code-block:: console
 
@@ -42,21 +35,19 @@ configure each instance independently:
       mkdir -p $APP_DIR/secure/zephyr
       cp $APP_DIR/build/zephyr/include/generated/autoconf.h $APP_DIR/secure/zephyr/
 
-#. Modify the application build scripts such that the SPE nrf_security
-   instance uses these copied files to configure itself instead of
-   using the same configuration as the NSPE instance.
+   The build system can now use this copy to configure the SPE nrf_security instance.
+
+#. Modify the application build scripts to let the SPE nrf_security instance use these copied files to configure itself instead of using the same configuration as the NSPE instance:
 
    .. code-block:: console
 
       cat ~/ncs/nrf/samples/crypto/nrf_security_snippet.cmake >> $APP_DIR/CMakeLists.txt
 
-#. Rebuild.
+#. Rebuild the application:
 
    .. code-block:: console
 
       west build -b nrf9160dk_nrf9160_ns
 
-#. Now, any configuration of nrf_security through Kconfig will only
-   affect the NSPE instance. To configure the SPE instance either edit
-   the two copied files manually or re-generate a configuration with
-   Kconfig and copy the files again.
+After these steps, configuring the Nordic Security Module through Kconfig options would only affect the NSPE instance.
+To configure the SPE instance, either edit the copied files or re-generate a configuration with Kconfig and copy the files again.

--- a/nrf_security/doc/different_tfm_config.rst
+++ b/nrf_security/doc/different_tfm_config.rst
@@ -1,0 +1,62 @@
+.. _nrf_security_different_tfm_config:
+
+Different configurations in SPE and NSPE
+########################################
+
+Normally in a TF-M application with a NSPE image and a SPE image the
+NSPE will invoke the PSA Crypto APIs to do crypto. And the feature set
+of the PSA Crypto API will be configured through nrf_security. So
+there will be no crypto implementations in the NSPE.
+
+Therefore in a normal TF-M application there will be two instances of
+nrf_security, one in the NSPE that just contains an API for PSA
+Crypto. And one in the SPE which contains a cryptocell driver and
+possibly other backends as well. Yet they will both use the same
+configuration.
+
+But, if an application needs to have some crypto features implemented
+in the NSPE nrf_security instance and other features implemented in
+the SPE nrf_security instance the following guide can be followed to
+configure each instance independently:
+
+1. Build the application for a board with TF-M.
+
+   .. code-block:: console
+
+      export APP_DIR=~/ncs/nrf/samples/crypto/psa_tls
+      cd $APP_DIR
+      west build -b nrf9160dk_nrf9160_ns
+
+#. Enable nrf_security, if it is not enabled already, and configure
+   the crypto functionality and enabled backends as they should be
+   configured in the SPE. See :ref::`_nrf_security_backend_config` for
+   configuration of nrf_security.
+
+#. Copy the resulting configuration from the build directory to the
+   application source directory. This copy will be used to configure
+   the SPE nrf_security instance.
+
+   .. code-block:: console
+
+      cp $APP_DIR/build/zephyr/.config $APP_DIR/secure_zephyr.config
+      mkdir -p $APP_DIR/secure/zephyr
+      cp $APP_DIR/build/zephyr/include/generated/autoconf.h $APP_DIR/secure/zephyr/
+
+#. Modify the application build scripts such that the SPE nrf_security
+   instance uses these copied files to configure itself instead of
+   using the same configuration as the NSPE instance.
+
+   .. code-block:: console
+
+      cat ~/ncs/nrf/samples/crypto/nrf_security_snippet.cmake >> $APP_DIR/CMakeLists.txt
+
+#. Rebuild.
+
+   .. code-block:: console
+
+      west build -b nrf9160dk_nrf9160_ns
+
+#. Now, any configuration of nrf_security through Kconfig will only
+   affect the NSPE instance. To configure the SPE instance either edit
+   the two copied files manually or re-generate a configuration with
+   Kconfig and copy the files again.


### PR DESCRIPTION
Documented how to achieve different configuration of nrf_security on
the non-secure and secure side.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>