### PR TITLE
doc: gzll: Clarify library integration

### DIFF
--- a/gzll/README.rst
+++ b/gzll/README.rst
@@ -3,9 +3,9 @@
 Gazell Link Layer
 #################
 
-Gazell is a protocol for setting up a robust wireless link between a single Host and up to eight Devices in a star network topology.
-
 The Gazell Link Layer library is available as soft-float and hard-float builds for the nRF52 Series.
+
+See the :ref:`nrf:ug_gzll` user guide for information about how to use the libraries in the |NCS|.
 
 .. toctree::
    :maxdepth: 2

--- a/gzll/doc/integration_notes.rst
+++ b/gzll/doc/integration_notes.rst
@@ -7,11 +7,27 @@ Integration notes
    :local:
    :depth: 2
 
+To integrate the Gazell Link Layer library in your application, you need to:
+
+* Link in the GZLL library. See the :ref:`gzll_configuration` section.
+* Supply the glue code used by the library. See the :ref:`gzll_glue_layer` section.
+
 RTOS
 ****
 
 Gazell Link Layer API is not reentrant.
 It should be called by only a single thread in an RTOS.
+
+.. _gzll_configuration:
+
+Configuration
+*************
+
+In the |NCS|, you can enable the GZLL library using the :kconfig:`CONFIG_GZLL` Kconfig option.
+Look for the menu item "Enable Gazell Link Layer".
+The build system will link in the appropriate library for your nRF5 SoC.
+
+.. _gzll_glue_layer:
 
 Glue layer
 **********


### PR DESCRIPTION
- Add configuration details to integrate Gazell Link Layer library to a NCS application.
- Point to GZLL user guide for more information.
- Remove the duplicated introduction that is copied from GZLL user guide.

Beefing up the Gazell user guides for the NCS configuration details. Will submit another PR to the sdk-nrf repo.