### PR TITLE
softdevice_controller: mpsl: Making debugversion compile work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,11 @@ if (CONFIG_NFC_T2T_NRFXLIB OR
 	add_subdirectory(nfc)
 endif()
 
-add_subdirectory_ifdef(CONFIG_MPSL                    mpsl)
 add_subdirectory_ifdef(CONFIG_NRF_MODEM               nrf_modem)
 add_subdirectory_ifdef(CONFIG_NRFXLIB_CRYPTO          crypto)
 add_subdirectory_ifdef(CONFIG_NRF_SECURITY            nrf_security)
 add_subdirectory_ifdef(CONFIG_BT                      softdevice_controller)
+add_subdirectory_ifdef(CONFIG_MPSL                    mpsl)
 add_subdirectory_ifdef(CONFIG_NET_L2_OPENTHREAD       openthread)
 add_subdirectory_ifdef(CONFIG_NRF_RPC                 nrf_rpc)
 add_subdirectory_ifdef(CONFIG_ZIGBEE                  zboss)


### PR DESCRIPTION
Moving mpsl under softdevice controller,
without this we get linker errors when linking with un-obfuscated softdevice-controller and mpsl libraries.

linker errors like:
"undefined reference to `mpsl_cx_granted_ops_get`

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>

Manifest PR https://github.com/nrfconnect/sdk-nrf/pull/10345