### PR TITLE
crypto: Fixing miscellaneous doc warnings

### DIFF
--- a/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_derived_key.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_derived_key.h
@@ -112,7 +112,7 @@ int nrf_cc3xx_platform_derived_key_set_auth_info(nrf_cc3xx_platform_derived_key_
  *
  * @param[in,out]   ctx             Pointer to the derived key context.
  * @param[out]      output          Pointer to the output buffer.
- * @param[in]       output_size     The size of the output buffer in bytes.
+ * @param[in]       input_size      The size of the output buffer in bytes.
  * @param[in]       input           Pointer to the input buffer.
  *
  * @return NRF_CC3XX_PLATFORM_SUCCESS on success, otherwise a negative value.
@@ -129,7 +129,7 @@ int nrf_cc3xx_platform_derived_key_encrypt(nrf_cc3xx_platform_derived_key_ctx_t 
  *
  * @param[in,out]   ctx             Pointer to the derived key context.
  * @param[out]      output          Pointer to the output buffer.
- * @param[in]       output_size     The size of the output buffer in bytes.
+ * @param[in]       input_size      The size of the output buffer in bytes.
  * @param[in]       input           Pointer to the input buffer.
  *
  * @return NRF_CC3XX_PLATFORM_SUCCESS on success, otherwise a negative value.

--- a/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_hmac_drbg.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_hmac_drbg.h
@@ -214,7 +214,7 @@ int nrf_cc3xx_platform_hmac_drbg_get_with_add(nrf_cc3xx_platform_hmac_drbg_conte
  *
  * @param[in,out]   context     Pointer to structure holding the hmac_drbg context.
  * @param[out]      buffer      Pointer to buffer to hold PRNG data.
- * @param[in]       length      Length of PRNG to get in bytes.
+ * @param[in]       len         Length of PRNG to get in bytes.
  * @param[out]      olen        Actual number of bytes put into the buffer.
  *
  * @return 0 on success, otherwise a non-zero failure according to the API

--- a/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_kmu.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_kmu.h
@@ -168,6 +168,7 @@ int nrf_cc3xx_platform_kmu_write_key_slot(
  *          and pushable". Please see
  *          @ref NRF_CC3XX_PLATFORM_KMU_DEFAULT_PERMISSIONS.
  *
+ * @param[in]   slot_id     KMU slot ID for the new key.
  * @param[in]   key         Array with the 128 bit key to put in the KMU slot.
  *
  * @return NRF_CC3XX_PLATFORM_SUCCESS on success, otherwise a negative value.

--- a/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_derived_key.h
+++ b/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_derived_key.h
@@ -112,7 +112,7 @@ int nrf_cc3xx_platform_derived_key_set_auth_info(nrf_cc3xx_platform_derived_key_
  *
  * @param[in,out]   ctx             Pointer to the derived key context.
  * @param[out]      output          Pointer to the output buffer.
- * @param[in]       output_size     The size of the output buffer in bytes.
+ * @param[in]       input_size      The size of the output buffer in bytes.
  * @param[in]       input           Pointer to the input buffer.
  *
  * @return NRF_CC3XX_PLATFORM_SUCCESS on success, otherwise a negative value.
@@ -129,7 +129,7 @@ int nrf_cc3xx_platform_derived_key_encrypt(nrf_cc3xx_platform_derived_key_ctx_t 
  *
  * @param[in,out]   ctx             Pointer to the derived key context.
  * @param[out]      output          Pointer to the output buffer.
- * @param[in]       output_size     The size of the output buffer in bytes.
+ * @param[in]       input_size      The size of the output buffer in bytes.
  * @param[in]       input           Pointer to the input buffer.
  *
  * @return NRF_CC3XX_PLATFORM_SUCCESS on success, otherwise a negative value.

--- a/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_hmac_drbg.h
+++ b/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_hmac_drbg.h
@@ -214,7 +214,7 @@ int nrf_cc3xx_platform_hmac_drbg_get_with_add(nrf_cc3xx_platform_hmac_drbg_conte
  *
  * @param[in,out]   context     Pointer to structure holding the hmac_drbg context.
  * @param[out]      buffer      Pointer to buffer to hold PRNG data.
- * @param[in]       length      Length of PRNG to get in bytes.
+ * @param[in]       len         Length of PRNG to get in bytes.
  * @param[out]      olen        Actual number of bytes put into the buffer.
  *
  * @return 0 on success, otherwise a non-zero failure according to the API

--- a/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_kmu.h
+++ b/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_kmu.h
@@ -168,6 +168,7 @@ int nrf_cc3xx_platform_kmu_write_key_slot(
  *          and pushable". Please see
  *          @ref NRF_CC3XX_PLATFORM_KMU_DEFAULT_PERMISSIONS.
  *
+ * @param[in]   slot_id     KMU slot ID for the new key.
  * @param[in]   key         Array with the 128 bit key to put in the KMU slot.
  *
  * @return NRF_CC3XX_PLATFORM_SUCCESS on success, otherwise a negative value.

--- a/nrf_security/include/mbedcrypto_glue/backend_ccm.h
+++ b/nrf_security/include/mbedcrypto_glue/backend_ccm.h
@@ -31,7 +31,7 @@
  *          support the AES CCM cipher (mode, keysize etc). If the value is positive,
  *          then the backend with the highest value is selected (priority based).
  *
- * @param[in]   mode        AES CCM mode.
+ * @param[in]   cipher      Cipher ID.
  * @param[in]   keybits     Key size in bits for the AES functionality.
  *
  * @return 0 if the AES CCM functionality is not supported, otherwise a priority where higher is better.

--- a/nrf_security/include/mbedcrypto_glue/backend_cmac.h
+++ b/nrf_security/include/mbedcrypto_glue/backend_cmac.h
@@ -37,7 +37,7 @@
  *
  * @return 0 if the CMAC functionality is not supported, otherwise a priority where higher is better.
  */
-typedef int (*mbedtls_cipher_cmac_check_fn)(const mbedtls_cipher_info_t *cipher_info , const unsigned char *key, size_t keybits);
+typedef int (*mbedtls_cipher_cmac_check_fn)(const mbedtls_cipher_info_t *cipher_info, const unsigned char *key, size_t keybits);
 
 
 /**@brief Function pointer to do CMAC starts operation using given key
@@ -52,7 +52,7 @@ typedef int (*mbedtls_cipher_cmac_check_fn)(const mbedtls_cipher_info_t *cipher_
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_cipher_cmac_starts_fn)(mbedtls_cipher_context_t *ctx , const unsigned char *key, size_t keybits);
+typedef int (*mbedtls_cipher_cmac_starts_fn)(mbedtls_cipher_context_t *ctx, const unsigned char *key, size_t keybits);
 
 
 /**@brief Typedef for function pointer to do CMAC update operation given additional input
@@ -65,7 +65,7 @@ typedef int (*mbedtls_cipher_cmac_starts_fn)(mbedtls_cipher_context_t *ctx , con
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_cipher_cmac_update_fn)(mbedtls_cipher_context_t *ctx , const unsigned char *input, size_t ilen);
+typedef int (*mbedtls_cipher_cmac_update_fn)(mbedtls_cipher_context_t *ctx, const unsigned char *input, size_t ilen);
 
 
 /**@brief Typedef for function pointer to do CMAC finish operation.
@@ -77,7 +77,7 @@ typedef int (*mbedtls_cipher_cmac_update_fn)(mbedtls_cipher_context_t *ctx , con
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_cipher_cmac_finish_fn)(mbedtls_cipher_context_t *ctx , unsigned char *output);
+typedef int (*mbedtls_cipher_cmac_finish_fn)(mbedtls_cipher_context_t *ctx, unsigned char *output);
 
 
 /**@brief Typedef for function pointer to do CMAC reset operation
@@ -104,16 +104,16 @@ typedef void (*mbedtls_cipher_cmac_free_fn)(mbedtls_cipher_context_t *ctx);
  *
  * This function pointer has a signature equal to @c mbedtls_cipher_cmac.
  *
- * @param[in,out]   ctx     Pointer to context for the CMAC operation.
- * @param[in]       key     Pointer to array holding the key.
- * @param[in]       keybits Key size in bits.
- * @param[in]       input   Pointer to array holding additional input.
- * @param[in]       ilen    Length of additional input.
- * @param[out]      output  Output of the CMAC operation.
+ * @param[in]       cipher_info     Cipher info.
+ * @param[in]       key             Pointer to array holding the key.
+ * @param[in]       keybits         Key size in bits.
+ * @param[in]       input           Pointer to array holding additional input.
+ * @param[in]       ilen            Length of additional input.
+ * @param[out]      output          Output of the CMAC operation.
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_cipher_cmac_fn)(const mbedtls_cipher_info_t *cipher_info , const unsigned char *key, size_t keylen , const unsigned char *input, size_t ilen , unsigned char *output);
+typedef int (*mbedtls_cipher_cmac_fn)(const mbedtls_cipher_info_t *cipher_info, const unsigned char *key, size_t keybits, const unsigned char *input, size_t ilen , unsigned char *output);
 
 
 /**@brief Typedef for function to do AES PRF 128 operation in one single step
@@ -121,14 +121,14 @@ typedef int (*mbedtls_cipher_cmac_fn)(const mbedtls_cipher_info_t *cipher_info ,
  * This function pointer has a signature equal to @c mbedtls_aes_cmac_prf_128.
  *
  * @param[in]       key     Pointer to array holding the key.
- * @param[in]       key_len Key size in bytes.
+ * @param[in]       keybits Key size in bytes.
  * @param[in]       input   Pointer to array holding additional input.
  * @param[in]       in_len  Length of additional input.
  * @param[out]      output  Output of the CMAC operation.
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_aes_cmac_prf_128_fn)(const unsigned char *key, size_t key_len , const unsigned char *input, size_t in_len , unsigned char output[16]);
+typedef int (*mbedtls_aes_cmac_prf_128_fn)(const unsigned char *key, size_t keybits, const unsigned char *input, size_t in_len , unsigned char output[16]);
 
 
 /**@brief Typedef for structure type holding the CMAC calling interface for a backend

--- a/nrf_security/include/mbedcrypto_glue/backend_dhm.h
+++ b/nrf_security/include/mbedcrypto_glue/backend_dhm.h
@@ -157,7 +157,7 @@ typedef void (*mbedtls_dhm_free_fn)(mbedtls_dhm_context *ctx);
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_dhm_parse_dhm_fn)(mbedtls_dhm_context *dhm, const unsigned char *dhmin, size_t dhminlen);
+typedef int (*mbedtls_dhm_parse_dhm_fn)(mbedtls_dhm_context *ctx, const unsigned char *dhmin, size_t dhminlen);
 
 
 /**@brief Function pointer to parse DHM parameters from a file.
@@ -165,11 +165,11 @@ typedef int (*mbedtls_dhm_parse_dhm_fn)(mbedtls_dhm_context *dhm, const unsigned
  * @details This function pointer has a signature equal to @c mbedtls_dhm_parse_dhmfile.
  *
  * @param[in,out]       ctx         Pointer to the context for the operation.
- * param[in]            path        Path of the file to read DHM parameters from.
+ * @param[in]           path        Path of the file to read DHM parameters from.
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_dhm_parse_dhmfile_fn)(mbedtls_dhm_context *dhm, const char *path);
+typedef int (*mbedtls_dhm_parse_dhmfile_fn)(mbedtls_dhm_context *ctx, const char *path);
 
 
 /**@brief Structure type holding the CMAC calling interface for a backend.

--- a/nrf_security/include/mbedcrypto_glue/backend_ecdsa.h
+++ b/nrf_security/include/mbedcrypto_glue/backend_ecdsa.h
@@ -48,6 +48,7 @@ typedef int (*mbedtls_ecdsa_check_fn)(mbedtls_ecp_group *grp, mbedtls_ecp_group_
  * @param[in]       grp         Pointer to an ECP group.
  * @param[out]      r           Pointer to the MPI context to store the first part of the signature. Must be initialized.
  * @param[out]      s           Pointer to the MPI context to store the second part of the signature. Must be initialized.
+ * @param[out]      d           Pointer to the MPI context to the private key used for signing.
  * @param[in]       buf         Pointer to the buffer holding the hash to be signed.
  * @param[in]       blen        Length of the buffer to sign.
  * @param[in]       f_rng       RNG function.

--- a/nrf_security/include/mbedcrypto_glue/backend_rsa.h
+++ b/nrf_security/include/mbedcrypto_glue/backend_rsa.h
@@ -112,7 +112,7 @@ typedef int (*mbedtls_rsa_complete_fn)(mbedtls_rsa_context *ctx);
  * @param[out]          P           Pointer to an MPI to hold the first prime factor, or NULL if not to export.
  * @param[out]          Q           Pointer to an MPI to hold the second prime factor, or NULL if not to export.
  * @param[out]          D           Pointer to an MPI to hold the private exponent, or NULL if not to export.
- * @param[out]          Q           Pointer to an MPI to hold the public exponent, or NULL if not to export.
+ * @param[out]          E           Pointer to an MPI to hold the public exponent, or NULL if not to export.
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
@@ -227,7 +227,7 @@ typedef int (*mbedtls_rsa_check_privkey_fn)(const mbedtls_rsa_context *ctx);
  *
  * @return 0 if operation was successful, otherwise a negative value corresponding to the error.
  */
-typedef int (*mbedtls_rsa_check_pub_priv_fn)(const mbedtls_rsa_context *pub, const mbedtls_rsa_context *prv);
+typedef int (*mbedtls_rsa_check_pub_priv_fn)(const mbedtls_rsa_context *pub, const mbedtls_rsa_context *priv);
 
 
 /**@brief Function pointer to perform an RSA public key operation.
@@ -275,6 +275,7 @@ typedef int (*mbedtls_rsa_private_fn)(mbedtls_rsa_context *ctx, int (*f_rng)(voi
  * @param[in]       f_rng   RNG function.
  * @param[in,out]   p_rng   RNG context.
  * @param[in]       mode    Mode of operation.
+ * @param[in]       ilen    Input length
  * @param[in]       input   Pointer to the buffer holding the input.
  * @param[out]      output  Pointer to the buffer to hold the output.
  *

--- a/nrf_security/include/mbedtls/platform.h
+++ b/nrf_security/include/mbedtls/platform.h
@@ -48,14 +48,6 @@
 extern "C" {
 #endif
 
-/**
- * \name SECTION: Module settings
- *
- * The configuration options you can set for this module are in this section.
- * Either change them in config.h or define them on the compiler command line.
- * \{
- */
-
 /* The older Microsoft Windows common runtime provides non-conforming
  * implementations of some standard library functions, including snprintf
  * and vsnprintf. This affects MSVC and MinGW builds.
@@ -123,9 +115,6 @@ extern "C" {
 #include MBEDTLS_PLATFORM_STD_MEM_HDR
 #endif
 #endif /* MBEDTLS_PLATFORM_NO_STD_FUNCTIONS */
-
-
-/* \} name SECTION: Module settings */
 
 /*
  * The function pointers for calloc and free.


### PR DESCRIPTION
Fixing doxygen for:
- nrf_cc3xx_platform_derived_key APIs
- nrf_cc3xx_platform_hmac_drbg APIs
- nrf_cc3xx_platform_kmu APIs
- Glue layer: CCM, CMAC, DHM, ECDSA and RSA
- Removing section in platform.h

ref: NCSDK-11065
ref: NCSDK-12725

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>