### PR TITLE
doc: add missing ToCs

### DIFF
--- a/nrf_security/doc/configuration.rst
+++ b/nrf_security/doc/configuration.rst
@@ -3,6 +3,10 @@
 Configuration
 #############
 
+.. contents::
+   :local:
+   :depth: 2
+
 The Nordic Security Module is enabled through Kconfig with the option :kconfig:`CONFIG_NORDIC_SECURITY_BACKEND` and additional configuration is usually done with Kconfig.
 
 These configurations are then used to generate an Mbed TLS configuration file used during compilation.

--- a/softdevice_controller/doc/bluetooth_coex_example_diagrams.rst
+++ b/softdevice_controller/doc/bluetooth_coex_example_diagrams.rst
@@ -1,9 +1,13 @@
 .. _bluetooth_coex_example_diagrams:
 
-Bluetooth External Radio Coexistence Examples
+Bluetooth External Radio Coexistence examples
 #############################################
 
-3-Wire Interface
+.. contents::
+   :local:
+   :depth: 2
+
+3-Wire interface
 ****************
 
 This section contains example timing diagrams for each supported Bluetooth® Low Energy Link Layer state.


### PR DESCRIPTION
Added missing ToC to BT External Radio Coexistence
examples and NSM Configuration documents.

Ref: NCSDK-13404

Signed-off-by: Pekka Niskanen <pekka.niskanen@nordicsemi.no>