### PR TITLE
openthread: allow to build from Thread 1.2 libraries

### DIFF
--- a/openthread/CMakeLists.txt
+++ b/openthread/CMakeLists.txt
@@ -67,8 +67,8 @@ if(CONFIG_OPENTHREAD_SOURCES)
   add_custom_target(install_openthread_libraries ${INSTALL_COMMANDS})
 endif()
 
-if (CONFIG_OPENTHREAD_LIBRARY_1_1)
-  openthread_calculate_lib_path("v1.1" OT_LIB_PATH)
+if (CONFIG_OPENTHREAD_NORDIC_LIBRARY)
+  openthread_calculate_lib_path("v${CONFIG_OPENTHREAD_THREAD_VERSION}" OT_LIB_PATH)
 
   if(NOT EXISTS ${OT_LIB_PATH})
     message(FATAL_ERROR

--- a/openthread/Kconfig
+++ b/openthread/Kconfig
@@ -19,11 +19,19 @@ choice OPENTHREAD_IMPLEMENTATION
 	  Select OpenThread to use for build. Custom OpenThread implementations
 	  can be added to the application Kconfig.
 
-config OPENTHREAD_LIBRARY_1_1
-	bool "OpenThread 1.1 from library"
+config OPENTHREAD_LIBRARY
+	bool "OpenThread from library"
 	select OPENTHREAD_NORDIC_LIBRARY
 	help
-	  Uses prebuilt library of openthread instead of building from sources.
+	  Build OpenThread from a prebuilt library instead of building from sources.
+	  CONFIG_OPENTHREAD_THREAD_VERSION determines which version of the library is to be used.
+
+config OPENTHREAD_LIBRARY_1_1
+	bool "(Legacy) OpenThread 1.1 from library"
+	depends on OPENTHREAD_THREAD_VERSION_1_1
+	select OPENTHREAD_NORDIC_LIBRARY
+	help
+	  Legacy option to use prebuilt OpenThread 1.1 library.
 
 endchoice
 


### PR DESCRIPTION
Rename `OPENTHREAD_LIBRARY_1_1` to `OPENTHREAD_LIBRARY` to make it
a more general configuration option allowing to select the proper
Thread library based on the `OPENTHREAD_THREAD_VERSION` configuration.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>