### PR TITLE
nrf_security: Fix crypto issues for TF-M

### DIFF
--- a/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -1678,6 +1678,12 @@ psa_status_t psa_driver_wrapper_hash_compute(
     size_t hash_size,
     size_t *hash_length)
 {
+#if defined(MBEDTLS_PSA_CRYPTO_SPM)
+    if (alg == PSA_ALG_SHA_1) {
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+#endif
+
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
 
     /* Try accelerators first */
@@ -1724,6 +1730,12 @@ psa_status_t psa_driver_wrapper_hash_setup(
     psa_algorithm_t alg )
 {
     psa_status_t status = PSA_ERROR_CORRUPTION_DETECTED;
+
+#if defined(MBEDTLS_PSA_CRYPTO_SPM)
+    if (alg == PSA_ALG_SHA_1) {
+        return PSA_ERROR_NOT_SUPPORTED;
+    }
+#endif
 
     /* Try setup on accelerators first */
 #if defined(PSA_CRYPTO_DRIVER_TEST)

--- a/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -237,6 +237,35 @@ psa_status_t psa_driver_wrapper_verify_message(
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #if defined(PSA_CRYPTO_DRIVER_OBERON)
+        {
+            /* Workaround NCSDK-13486
+             * oberon_verify_message does not support PSA_KEY_TYPE_CATEGORY_KEY_PAIR.
+             * Export a key that is PSA_KEY_TYPE_CATEGORY_PUBLIC_KEY instead.
+             */
+            psa_key_attributes_t attributes_copy = *attributes;
+            psa_key_type_t key_type = psa_get_key_type(&attributes_copy);
+
+            size_t exported_length = 0;
+            uint8_t exported[PSA_KEY_EXPORT_ECC_PUBLIC_KEY_MAX_SIZE(256)];
+
+            if (PSA_KEY_TYPE_IS_KEY_PAIR(key_type)) {
+                mbedtls_svc_key_id_t key = psa_get_key_id(&attributes_copy);
+
+                status = psa_export_public_key(key, exported, sizeof(exported),
+                                               &exported_length);
+                if (status != PSA_SUCCESS) {
+                    return status;
+                }
+
+                key_type &= ~PSA_KEY_TYPE_CATEGORY_FLAG_PAIR;
+                psa_set_key_type(&attributes_copy, key_type);
+
+                key_buffer_size = exported_length;
+                key_buffer = exported;
+
+                attributes = &attributes_copy;
+            }
+
             status = oberon_verify_message(
                         attributes,
                         key_buffer,
@@ -249,6 +278,7 @@ psa_status_t psa_driver_wrapper_verify_message(
             /* Declared with fallback == true */
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
+        }
 #endif /* PSA_CRYPTO_DRIVER_OBERON */
 #if defined(PSA_CRYPTO_DRIVER_TEST)
             status = mbedtls_test_transparent_signature_verify_message(


### PR DESCRIPTION
Fix crypto issues discovered by TF-M regression tests.

Disallow the SHA-1 algorithm when included by in the secure image.
TF-M expects these to not be usable.

TF-M regression tests:
```
'TFM_S_CRYPTO_TEST_1010'
  Description: 'Secure Unsupported Hash (SHA-1) interface'
'TFM_S_CRYPTO_TEST_1019'
  Description: 'Secure Unsupported HMAC (SHA-1) interface'
```
Add workaround for oberon_verify_message not supporting using
key attributes with key pair. Export a public-only key
before calling oberon_verify_message.

NCSDK-13486