### PR TITLE
nrf_802154: ECB interrupt on ZLI priority.

### DIFF
--- a/nrf_802154/driver/src/nrf_802154_aes_ccm.c
+++ b/nrf_802154/driver/src/nrf_802154_aes_ccm.c
@@ -128,7 +128,7 @@ static void ecb_init(void)
 
     if (!m_initialized)
     {
-        nrf_802154_irq_init(ECB_IRQn, NRF_802154_ECB_PRIORITY, ecb_irq_handler);
+        nrf_802154_irq_init_zli(ECB_IRQn, NRF_802154_ECB_PRIORITY, ecb_irq_handler);
         m_initialized = true;
     }
 

--- a/nrf_802154/sl/include/platform/nrf_802154_irq.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_irq.h
@@ -83,6 +83,18 @@ typedef void (* nrf_802154_isr_t)();
 void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr);
 
 /**
+ * @brief Initializes a provided interrupt line as Zero Latency Interrupt (ZLI)
+ *
+ * @note This function does not enable the interrupt. In order to enable it,  additional call
+ *       to @ref nrf_802154_irq_enable is necessary.
+ *
+ * @param[in] irqn  IRQ line number.
+ * @param[in] prio  Priority of the IRQ.
+ * @param[in] isr   Pointer to ISR.
+ */
+void nrf_802154_irq_init_zli(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr);
+
+/**
  * @brief Enables an interrupt.
  *
  * @param[in] irqn  IRQ line number.


### PR DESCRIPTION
ECB interrupts could be delayed by arch_irq_lock. This resulted in a
possibility that on-the-fly encryption could fail and transmitted
frame contained zero bytes instead of proper ciphertext.

The fix is to put ECB priority as Zero Latency Interrupt (ZLI). Using such priority value proved, that the fix works.

I open this draft PR to discuss how to best introduce first "ability" to use ZLI on Zephyr ports and second "use this ability" to fix the bug.
Related commit in my fork of sdk-zephyr https://github.com/ankuns/sdk-zephyr/commit/a82adb44a4b999482262e32c827969ae8cf8db95
(I'm aware it should go upstream first).
And sdk-nrf branch with all this combined by west.yml https://github.com/ankuns/sdk-nrf/commits/KRKNWK-12770_fix1

The problem:
Radio driver itself should not need to know that there is such concept as ZLI. This is part of a platform port especially for Zephyr. The platform port and even end user should have a way to tweak this priority at their own discretion, and express that expected prio is ZLI. Until now code used just `NRF_802154_ECB_PRIORITY`. However such raw value is not enough to describe ZLI. Values passed as priorities to `nrf_802154_irq_init` should be platform-dependent, but the code calling `nrf_802154_irq_init` should be platform-independent.

Current ugly proposal introduces `nrf_802154_irq_init_zli`. It proven it works, howewer:
- It provides policy not mechanism, what is bad
- It introduces term "ZLI" to the platform-independent code, which is bad.

Proposals:
1. Let `prio` parameter be signed `void nrf_802154_irq_init(uint32_t irqn, int32_t prio, nrf_802154_isr_t isr);` The negative value will represent ZLI for Zephyr, or be equivalent to 0 priority if ZLI is not available. 
2. Let there be additional `flags` argument `void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr, uint32_t flags);` For Zephyr we could pass `IRQ_ZERO_LATENCY`, for other platforms we use this parameter in platform-dependent way (including ability to ignore). Then for NRF_802154_ECB_PRIORITY we could use macro NRF_802154_ECB_IRQ_FLAGS to carry required flags

```c
#define NRF_802154_ECB_IRQ_FLAGS IRQ_ZERO_LATENCY

nrf_802154_irq_init(ECB_IRQn, NRF_802154_ECB_PRIORITY, ecb_irq_handler, NRF_802154_ECB_IRQ_FLAGS);
```
The problem is that expansion of NRF_802154_ECB_IRQ_FLAGS should bring appropriate header bringing `IRQ_ZERO_LATENCY`

I look forward for your opinions. We can discuss f2f also, time is money.


