### PR TITLE
doc: Version update for NCS 1.9.0

### DIFF
--- a/mpsl/CHANGELOG.rst
+++ b/mpsl/CHANGELOG.rst
@@ -7,17 +7,17 @@ Changelog
    :local:
    :depth: 2
 
-Main branch
-***********
+nRF Connect SDK v1.9.0
+**********************
 
-All the notable changes included in the main branch are documented in this section.
+All the notable changes included in the |NCS| v1.9.0 release are documented in this section.
 
 Added
 =====
 
-* Added a new header :file:`mpsl_dppi_protocol_api.h` which exposes DPPI channels that have a fixed configuration during the lifetime of a radio event (DRGN-16308).
-  This will facilitate debugging protocol implementations.
-  Currently these channels are only guaranteed to be applied correctly for Bluetooth.
+* Added a new header file :file:`mpsl_dppi_protocol_api.h` which exposes DPPI channels that have a fixed configuration during the lifetime of a radio event (DRGN-16308).
+  This will facilitate debugging of protocol implementations.
+  Currently these channels are guaranteed to be applied correctly for Bluetooth only.
 
 nRF Connect SDK v1.8.0
 **********************

--- a/nfc/CHANGELOG.rst
+++ b/nfc/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
-master
-******
+nRF Connect SDK v1.9.0
+**********************
 
 Added
 =====
@@ -22,14 +22,14 @@ Added
 Modified
 ========
 
-* The library returns specific errors codes from the :file:`nrf_nfc_errno.h` file instead of Zephyr error codes.
-* Removed unit tests dependencies from the header files :file:`nfc_t2t_lib.h` and :file:`nrf_t4t_lib.h`.
+* The library returns specific error codes from the :file:`nrf_nfc_errno.h` file instead of Zephyr error codes.
+* Removed unit test dependencies from the header files :file:`nfc_t2t_lib.h` and :file:`nrf_t4t_lib.h`.
 
 Bug fixes
 =========
 
- * Fixed handling R(NAK) frame after sending R(ACK) frame.
-   The Tag should respond with last transmitted R(ACK) frame.
+ * Fixed handling the R(NAK) frame after sending the R(ACK) frame.
+   The Tag should respond with the last transmitted R(ACK) frame.
  * Fixed the race condition that occurred when the S(WTX) frame was scheduled and the library tried to send a data chunk.
  * Fixed a possible memory overwrite in the :ref:`type_4_tag` library when the reader device sends an incorrect APDU Update command.
 

--- a/nrf_dm/doc/CHANGELOG.rst
+++ b/nrf_dm/doc/CHANGELOG.rst
@@ -9,10 +9,10 @@ Changelog
 
 All the notable changes to this project are documented in this file.
 
-Main branch
-***********
+nRF Connect SDK v1.9.0
+**********************
 
-All the notable changes added to the main branch are documented in this section.
+All the notable changes added to the |NCS| v1.9.0 release are documented in this section.
 
 Added
 =====

--- a/softdevice_controller/CHANGELOG.rst
+++ b/softdevice_controller/CHANGELOG.rst
@@ -9,10 +9,10 @@ Changelog
 
 All the notable changes to this project are documented in this file.
 
-Main branch
-***********
+nRF Connect SDK v1.9.0
+**********************
 
-All the notable changes included in the main branch are documented in this section.
+All the notable changes included in the |NCS| v1.9.0 release are documented in this section.
 
 Added
 =====

--- a/zboss/CHANGELOG.rst
+++ b/zboss/CHANGELOG.rst
@@ -9,10 +9,10 @@ Changelog
 
 All notable changes to this project in the |NCS| are documented in this file.
 
-Main branch
-***********
+nRF Connect SDK v1.9.0
+**********************
 
-All the notable changes included in the |NCS| main branch are documented in this section.
+All the notable changes included in the |NCS| v1.9.0 release are documented in this section.
 
 Added
 =====
@@ -27,7 +27,7 @@ Updated
 =======
 
 * Updated the ZBOSS stack to version ``3.11.1.0+5.1.1``.
-  For detailed information, see `ZBOSS stack release notes`_ for the main branch.
+  For detailed information, see `ZBOSS stack release notes`_ for the |NCS| v1.9.0.
 * Updated BDB to specification version ``3.0.1``.
 * Replaced ZB_IC_GET_TYPE_FROM_REC macro with ZB_IC_GET_TYPE_FROM_OPT.
 
@@ -54,7 +54,7 @@ Updated
 =======
 
 * Updated the ZBOSS stack to version ``3.9.0.1+4.1.0``.
-  For detailed information, see `ZBOSS stack release notes`_ for the main branch.
+  For detailed information, see `ZBOSS stack release notes`_ for the |NCS| v1.8.0.
 * Removed precompiled libraries for Zigbee Green Power Combo Basic functionality.
 
 Bug fixes


### PR DESCRIPTION
Changed main branch heading to nRF Connect SDK v1.9.0
NCSDK-13405

Signed-off-by: Mia Koen <mia.koen@nordicsemi.no>