### PR TITLE
nrf_802154: nrf_802154_irq_init signed prio to allow Zephyr's ZLI

### DIFF
--- a/nrf_802154/sl/include/platform/nrf_802154_irq.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_irq.h
@@ -79,8 +79,11 @@ typedef void (* nrf_802154_isr_t)();
  * @param[in] irqn  IRQ line number.
  * @param[in] prio  Priority of the IRQ.
  * @param[in] isr   Pointer to ISR.
+ *
+ * @note Interpretation of the value represented by @p prio is platform-dependent and defined by
+ *       the implementation.
  */
-void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr);
+void nrf_802154_irq_init(uint32_t irqn, int32_t prio, nrf_802154_isr_t isr);
 
 /**
  * @brief Enables an interrupt.

--- a/nrf_802154/sl/platform/irq/nrf_802154_irq_baremetal.c
+++ b/nrf_802154/sl/platform/irq/nrf_802154_irq_baremetal.c
@@ -13,7 +13,7 @@
 
 #include "nrf.h"
 
-void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr)
+void nrf_802154_irq_init(uint32_t irqn, int32_t prio, nrf_802154_isr_t isr)
 {
     /* This implementation assumes that:
      *   - a vector table entry related to IRQ line number irqn is provided by the caller
@@ -40,7 +40,7 @@ void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr)
      */
     (void)isr;
 
-    NVIC_SetPriority((IRQn_Type)irqn, prio);
+    NVIC_SetPriority((IRQn_Type)irqn, (uint32_t)prio);
     NVIC_ClearPendingIRQ((IRQn_Type)irqn);
 }
 


### PR DESCRIPTION
Negative `prio` are intended to allow ZLIs in zephyr platform
implementation.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>