### PR TITLE
nrf_802154: remove deprecated NRF_802154_IRQ_PRIORITY_ALLOWED

### DIFF
--- a/nrf_802154/driver/src/nrf_802154_aes_ccm.c
+++ b/nrf_802154/driver/src/nrf_802154_aes_ccm.c
@@ -122,10 +122,6 @@ static void ecb_irq_handler(void);
  */
 static void ecb_init(void)
 {
-#if !NRF_802154_IRQ_PRIORITY_ALLOWED(NRF_802154_ECB_PRIORITY)
-#error NRF_802154_ECB_PRIORITY value out of the allowed range.
-#endif
-
     if (!m_initialized)
     {
         nrf_802154_irq_init(ECB_IRQn, NRF_802154_ECB_PRIORITY, ecb_irq_handler);

--- a/nrf_802154/driver/src/nrf_802154_swi.c
+++ b/nrf_802154/driver/src/nrf_802154_swi.c
@@ -87,10 +87,6 @@ static void swi_irq_handler(void)
 
 void nrf_802154_swi_init(void)
 {
-#if !NRF_802154_IRQ_PRIORITY_ALLOWED(NRF_802154_SWI_PRIORITY)
-#error NRF_802154_SWI_PRIORITY value out of the allowed range.
-#endif
-
     static bool initialized = false;
 
     if (!initialized)

--- a/nrf_802154/driver/src/nrf_802154_trx.c
+++ b/nrf_802154/driver/src/nrf_802154_trx.c
@@ -279,10 +279,6 @@ static void cca_configuration_update(void)
 /** Initialize interrupts for radio peripheral. */
 static void irq_init(void)
 {
-#if !NRF_802154_IRQ_PRIORITY_ALLOWED(NRF_802154_IRQ_PRIORITY)
-#error NRF_802154_IRQ_PRIORITY value out of the allowed range.
-#endif
-
 #if NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
     nrf_802154_irq_init(RADIO_IRQn, NRF_802154_IRQ_PRIORITY, nrf_802154_radio_irq_handler);
 #endif

--- a/nrf_802154/sl/include/platform/nrf_802154_irq.h
+++ b/nrf_802154/sl/include/platform/nrf_802154_irq.h
@@ -46,12 +46,6 @@
 #include <stdint.h>
 
 /**
- * @brief Checks if the given IRQ priority is within the range implemented by the MCU.
- */
-#define NRF_802154_IRQ_PRIORITY_ALLOWED(priority) \
-    (((priority) >= 0) && ((priority) < (1U << (__NVIC_PRIO_BITS))))
-
-/**
  * @brief Function pointer used for IRQ handling.
  *
  * This type intentionally does not specify any parameters of the function.

--- a/nrf_802154/sl/platform/lp_timer/nrf_802154_lp_timer.c
+++ b/nrf_802154/sl/platform/lp_timer/nrf_802154_lp_timer.c
@@ -386,9 +386,6 @@ void nrf_802154_lp_timer_init(void)
     }
 
     // Setup RTC timer.
-#if !NRF_802154_IRQ_PRIORITY_ALLOWED(NRF_802154_SL_RTC_IRQ_PRIORITY)
-#error NRF_802154_SL_RTC_IRQ_PRIORITY value out of the allowed range.
-#endif
     nrf_802154_irq_init(NRF_802154_RTC_IRQN, NRF_802154_SL_RTC_IRQ_PRIORITY, rtc_irq_handler);
     nrf_802154_irq_enable(NRF_802154_RTC_IRQN);
 


### PR DESCRIPTION
`NRF_802154_IRQ_PRIORITY_ALLOWED` became deprecated when the `prio`
parameter of `nrf_802154_irq_init` is platform-dependent.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>