### PR TITLE
gzll: Add a changelog

### DIFF
--- a/gzll/CHANGELOG.rst
+++ b/gzll/CHANGELOG.rst
@@ -1,0 +1,27 @@
+.. _gzll_changelog:
+
+Changelog
+#########
+
+.. contents::
+   :local:
+   :depth: 2
+
+All notable changes to this project are documented in this file.
+
+nRF Connect SDK v1.8.0
+**********************
+
+Initial release.
+
+Added
+=====
+
+* Added the :file:`libgzll.a` library variant, in both soft-float and hard-float builds, for the following nRF52 Series SoCs:
+
+  * nRF52810
+  * nRF52811
+  * nRF52820
+  * nRF52832
+  * nRF52833
+  * nRF52840

--- a/gzll/README.rst
+++ b/gzll/README.rst
@@ -12,4 +12,5 @@ See the :ref:`nrf:ug_gzll` user guide for information about how to use the libra
    :caption: Subpages:
 
    doc/integration_notes
+   CHANGELOG
    doc/api


### PR DESCRIPTION
Add a changelog file for GZLL.

The PR to check the documentation build is nrfconnect/sdk-nrf#6800.