### PR TITLE
crypto: Add missing PSA driver supported algorithms for Oberon and CC3XX.

### DIFF
--- a/crypto/doc/nrf_cc310_mbedcrypto.rst
+++ b/crypto/doc/nrf_cc310_mbedcrypto.rst
@@ -131,6 +131,27 @@ The :c:func:`calloc` and :c:func:`free` functions can be changed with the follow
 This API must be called prior to calling :c:func:`mbedtls_platform_setup`.
 Otherwise, the library will default to use the clib functions :c:func:`calloc` and :c:func:`free`.
 
+PSA driver integration
+======================
+Starting from version 0.9.13, the nrf_oberon library contains a companion library that provides PSA driver integration for select features.
+This must be used with the :ref:`nrf_security`.
+
+Supported features
+------------------
+The supported features for the PSA driver companion library are:
+
+* AES CTR/CBC/ECB/CCM (192/256 bit keys are only supported by CryptoCell 312)
+* AES GCM (only supported by CryptoCell 312)
+* ChaCha20 and Poly1305 (256 bit keys only)
+* ECDSA (secp224r1, secp256r1 and secp384r1 only)
+* ECDH
+* RSA (PKCS1V15 with 1024 bits keys only)
+* HMAC
+* CMAC (192/256 bit keys are only supported by CryptoCell 312)
+* HKDF
+* SHA-1
+* SHA-224
+* SHA-256
 
 Initializing the library
 ------------------------

--- a/crypto/doc/nrf_oberon.rst
+++ b/crypto/doc/nrf_oberon.rst
@@ -45,12 +45,30 @@ The supported features for the Mbed TLS companion library are:
 * AES (all ciphers, all key sizes)
 * AES CCM
 * CMAC
-* ECDSA (secp256r1 only)
-* ECDH (secp256r1 only)
-* ECJPAKE (secp256r1 only)
+* ECDSA (secp224r1 and secp256r1 only)
+* ECDH (secp224r1 and secp256r1 only)
+* ECJPAKE (secp224r1 and secp256r1 only)
 * SHA-1
 * SHA-256
 
+
+PSA driver integration
+======================
+Starting from version 3.0.9, the nrf_oberon library contains a companion library that provides PSA driver integration for select features.
+This must be used with the :ref:`nrf_security`.
+
+Supported features
+------------------
+The supported features for the PSA driver companion library are:
+
+* AES CTR/CBC/ECB/CCM/GCM (all key sizes)
+* ChaCha20 and Poly1305 (256 bit keys)
+* ECDSA (secp224r1 and secp256r1 only)
+* ECDH (secp224r1 and secp256r1 only)
+* SHA-1
+* SHA-224
+* SHA-256
+* SHA-512
 
 nrf_oberon crypto library API
 =============================


### PR DESCRIPTION
This adds a list of supported algorithms for the CC3XX and Oberon PSA drivers.

Ref: NCSDK-12557
Ref: NCSDK-12563