### PR TITLE
Multiple same-type endpoints conflict resolved

### DIFF
--- a/zboss/development/include/ha/zb_ha_combined_interface.h
+++ b/zboss/development/include/ha/zb_ha_combined_interface.h
@@ -149,8 +149,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_COMBINED_INTERFACE_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                             \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                             \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
   {                                                                                                \
     ep_id,                                                                                         \
     ZB_AF_HA_PROFILE_ID,                                                                           \
@@ -179,7 +179,7 @@
       ZB_HA_COMBINED_INTERFACE_IN_CLUSTER_NUM, ZB_HA_COMBINED_INTERFACE_OUT_CLUSTER_NUM); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                        \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,                 \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,               \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,               \
                           0, NULL, /* No reporting ctx */                                 \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_configuration_tool.h
+++ b/zboss/development/include/ha/zb_ha_configuration_tool.h
@@ -152,8 +152,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                 \
 
 */
 #define ZB_ZCL_DECLARE_CONFIGURATION_TOOL_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                             \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                             \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
   {                                                                                                \
     ep_id,                                                                                         \
     ZB_AF_HA_PROFILE_ID,                                                                           \
@@ -183,7 +183,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                 \
       ZB_HA_CONFIGURATION_TOOL_IN_CLUSTER_NUM, ZB_HA_CONFIGURATION_TOOL_OUT_CLUSTER_NUM); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL, \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
                           0, NULL, /* No reporting ctx */               \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_custom_attr.h
+++ b/zboss/development/include/ha/zb_ha_custom_attr.h
@@ -168,14 +168,14 @@
 #define ZB_HA_DECLARE_CUSTOM_ATTR_EP(ep_name, ep_id, cluster_list)        \
   ZB_ZCL_DECLARE_CUSTOM_ATTR_SIMPLE_DESC(ep_name, ep_id,                  \
     ZB_HA_CUSTOM_ATTR_IN_CLUSTER_NUM, ZB_HA_CUSTOM_ATTR_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name, 20);  \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name, 20);  \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                    \
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,  \
                           ZB_ZCL_ARRAY_SIZE(ep_name, zb_af_endpoint_desc_t), \
-                          20, reporting_info## device_ctx_name, 0, NULL)
+                          20, reporting_info## ep_name, 0, NULL)
 
 
 #define ZB_HA_DECLARE_CUSTOM_ATTR_CTX(device_ctx, ep_name)              \

--- a/zboss/development/include/ha/zb_ha_custom_attr.h
+++ b/zboss/development/include/ha/zb_ha_custom_attr.h
@@ -139,8 +139,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_CUSTOM_ATTR_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num)     \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                          \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                          \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
   {                                                                                             \
     ep_id,                                                                                      \
     ZB_AF_HA_PROFILE_ID,                                                                        \
@@ -173,7 +173,7 @@
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,  \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,  \
                           ZB_ZCL_ARRAY_SIZE(ep_name, zb_af_endpoint_desc_t), \
                           20, reporting_info## device_ctx_name, 0, NULL)
 

--- a/zboss/development/include/ha/zb_ha_device_config.h
+++ b/zboss/development/include/ha/zb_ha_device_config.h
@@ -74,6 +74,13 @@ enum zb_ha_standard_devs_e
   /*! Range Extender */
   ZB_HA_RANGE_EXTENDER_DEVICE_ID      = 0x0008,
   /*! Mains Power Outlet */
+  /* Psychogenic MOD: 
+   * This may be standard:
+   * ZB_HA_MAINS_POWER_OUTLET_DEVICE_ID  = 0x0009,
+   * but real-world devices seem to recognize
+   * ZB_HA_MAINS_POWER_OUTLET_DEVICE_ID  = 0x010A,
+   * instead
+   * */
   ZB_HA_MAINS_POWER_OUTLET_DEVICE_ID  = 0x0009,
   /*! Door lock client */
   ZB_HA_DOOR_LOCK_DEVICE_ID           = 0x000A,

--- a/zboss/development/include/ha/zb_ha_dimmable_light.h
+++ b/zboss/development/include/ha/zb_ha_dimmable_light.h
@@ -157,8 +157,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
+  ZB_DECLARE_SIMPLE_DESC(ep_name, in_clust_num, out_clust_num);                                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
   {                                                                                            \
     ep_id,                                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                                       \
@@ -197,7 +197,7 @@
     0,                                                                          \
     NULL,                                                                       \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,     \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,     \
                           ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT,               \
                           reporting_info## device_ctx_name,                     \
                           ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT,                  \

--- a/zboss/development/include/ha/zb_ha_dimmable_light.h
+++ b/zboss/development/include/ha/zb_ha_dimmable_light.h
@@ -189,9 +189,9 @@
 #define ZB_HA_DECLARE_DIMMABLE_LIGHT_EP(ep_name, ep_id, cluster_list)           \
   ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id,                     \
     ZB_HA_DIMMABLE_LIGHT_IN_CLUSTER_NUM, ZB_HA_DIMMABLE_LIGHT_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,          \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,          \
                                      ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT);   \
-  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## device_ctx_name,      \
+  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## ep_name,      \
                                          ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT);  \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                       \
     0,                                                                          \
@@ -199,9 +199,9 @@
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,     \
                           ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT,               \
-                          reporting_info## device_ctx_name,                     \
+                          reporting_info## ep_name,                     \
                           ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT,                  \
-                          cvc_alarm_info## device_ctx_name)
+                          cvc_alarm_info## ep_name)
 
 /**
   @brief Declare application's device context for Dimmable Light device

--- a/zboss/development/include/ha/zb_ha_dimmer_switch.h
+++ b/zboss/development/include/ha/zb_ha_dimmer_switch.h
@@ -150,8 +150,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
 */
 #define ZB_ZCL_DECLARE_DIMMER_SWITCH_SIMPLE_DESC(                             \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -184,7 +184,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
                                                                                                 \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                     \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
                           0, NULL, /* No reporting ctx */                                       \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_door_lock.h
+++ b/zboss/development/include/ha/zb_ha_door_lock.h
@@ -191,7 +191,7 @@
 #define ZB_HA_DECLARE_DOOR_LOCK_EP(ep_name, ep_id, cluster_list)                \
       ZB_ZCL_DECLARE_DOOR_LOCK_SIMPLE_DESC(ep_name, ep_id,                      \
           ZB_HA_DOOR_LOCK_IN_CLUSTER_NUM, ZB_HA_DOOR_LOCK_OUT_CLUSTER_NUM);     \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,            \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,            \
                                          ZB_HA_DOOR_LOCK_REPORT_ATTR_COUNT);          \
       ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                         \
             0,                                                                        \
@@ -200,7 +200,7 @@
                               cluster_list,                                           \
                               (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_DOOR_LOCK_REPORT_ATTR_COUNT,                      \
-                              reporting_info## device_ctx_name,                       \
+                              reporting_info## ep_name,                       \
                               0, NULL)
 
 

--- a/zboss/development/include/ha/zb_ha_door_lock.h
+++ b/zboss/development/include/ha/zb_ha_door_lock.h
@@ -162,8 +162,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_DOOR_LOCK_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                  \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                  \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                     \
         ep_id,                                                              \
         ZB_AF_HA_PROFILE_ID,                                                \
@@ -198,7 +198,7 @@
             NULL,                                                                     \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_DOOR_LOCK_REPORT_ATTR_COUNT,                      \
                               reporting_info## device_ctx_name,                       \
                               0, NULL)

--- a/zboss/development/include/ha/zb_ha_door_lock_controller.h
+++ b/zboss/development/include/ha/zb_ha_door_lock_controller.h
@@ -163,8 +163,8 @@
 */
 #define ZB_ZCL_DECLARE_DOOR_LOCK_CONTROLLER_SIMPLE_DESC(                             \
     ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-        ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-        ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+        ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+        ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
         {                                                                            \
           ep_id,                                                                     \
           ZB_AF_HA_PROFILE_ID,                                                       \
@@ -195,7 +195,7 @@
           ZB_HA_DOOR_LOCK_CONTROLLER_IN_CLUSTER_NUM, ZB_HA_DOOR_LOCK_CONTROLLER_OUT_CLUSTER_NUM); \
       ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                            \
           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,                   \
-          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                                       \
+          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                                       \
           0, NULL, 0, NULL)
 
 /** @brief Declare Door Lock Controller device context.

--- a/zboss/development/include/ha/zb_ha_erl_device_interface.h
+++ b/zboss/development/include/ha/zb_ha_erl_device_interface.h
@@ -239,8 +239,8 @@
                                                      ep_id,                    \
                                                      in_clust_num,             \
                                                      out_clust_num)            \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
   {                                                                            \
     ep_id,                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                       \
@@ -288,7 +288,7 @@
                               NULL,                                                   \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_ERL_INTERFACE_DEV_REPORT_ATTR_COUNT,                 \
                               reporting_info##device_ctx_name,                        \
                               0, NULL)

--- a/zboss/development/include/ha/zb_ha_erl_gw_device.h
+++ b/zboss/development/include/ha/zb_ha_erl_gw_device.h
@@ -156,8 +156,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_ERL_GW_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
   {                                                                                           \
     ep_id,                                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                                      \
@@ -198,7 +198,7 @@
       NULL,                                                          \
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),        \
       cluster_list,                                                  \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               0, NULL, /* No reporting ctx */                         \
                               0, NULL)
 

--- a/zboss/development/include/ha/zb_ha_gp_dev.h
+++ b/zboss/development/include/ha/zb_ha_gp_dev.h
@@ -105,8 +105,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_GP_DEV_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                  \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =          \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                  \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =          \
   {                                                                     \
     ep_id,                                                              \
     ZB_AF_HA_PROFILE_ID,                                                \
@@ -135,7 +135,7 @@
                                      ZB_HA_GP_DEV_REPORT_ATTR_COUNT);           \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,              \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
                               ZB_HA_GP_DEV_REPORT_ATTR_COUNT,                   \
                               reporting_info## device_ctx_name, 0, NULL)
 

--- a/zboss/development/include/ha/zb_ha_gp_dev.h
+++ b/zboss/development/include/ha/zb_ha_gp_dev.h
@@ -131,13 +131,13 @@
 #define ZB_HA_DECLARE_GP_DEV_EP(ep_name, ep_id, cluster_list)    \
   ZB_ZCL_DECLARE_GP_DEV_SIMPLE_DESC(ep_name, ep_id,                      \
       ZB_HA_GP_DEV_IN_CLUSTER_NUM, ZB_HA_GP_DEV_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,          \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,          \
                                      ZB_HA_GP_DEV_REPORT_ATTR_COUNT);           \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,              \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
                               (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
                               ZB_HA_GP_DEV_REPORT_ATTR_COUNT,                   \
-                              reporting_info## device_ctx_name, 0, NULL)
+                              reporting_info## ep_name, 0, NULL)
 
 
 #define ZB_HA_DECLARE_GP_DEV_CTX(device_ctx, ep_name)                                                   \

--- a/zboss/development/include/ha/zb_ha_ias_ancillary_control_equipment.h
+++ b/zboss/development/include/ha/zb_ha_ias_ancillary_control_equipment.h
@@ -185,7 +185,7 @@
           ep_id,                                                                    \
           ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_IN_CLUSTER_NUM,                     \
           ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_OUT_CLUSTER_NUM);                   \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,             \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,             \
           ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT);                    \
       ZB_AF_DECLARE_ENDPOINT_DESC(                                                     \
         ep_name,                                                                       \
@@ -198,7 +198,7 @@
                 zb_zcl_cluster_desc_t),                                             \
             cluster_list,                                                           \
         (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                              \
-        ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+        ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 /**
    @brief Declare application's device context for Ancillary Control Equipment

--- a/zboss/development/include/ha/zb_ha_ias_ancillary_control_equipment.h
+++ b/zboss/development/include/ha/zb_ha_ias_ancillary_control_equipment.h
@@ -154,8 +154,8 @@
  */
 #define ZB_HA_DECLARE_IAS_ANCILLARY_CONTROL_EQUIPMENT_SIMPLE_DESC(                 \
   ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                            \
         ep_id,                                                                     \
         ZB_AF_ZLL_PROFILE_ID,                                                      \
@@ -197,7 +197,7 @@
                 cluster_list,                                                       \
                 zb_zcl_cluster_desc_t),                                             \
             cluster_list,                                                           \
-        (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                              \
+        (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                              \
         ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 /**

--- a/zboss/development/include/ha/zb_ha_ias_control_indicating_equipment.h
+++ b/zboss/development/include/ha/zb_ha_ias_control_indicating_equipment.h
@@ -157,8 +157,8 @@
  */
 #define ZB_HA_DECLARE_IAS_CONTROL_INDICATING_EQUIPMENT_SIMPLE_DESC(                \
   ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                            \
         ep_id,                                                                     \
         ZB_AF_ZLL_PROFILE_ID,                                                      \
@@ -201,7 +201,7 @@
                 cluster_list,                                                       \
                 zb_zcl_cluster_desc_t),                                             \
             cluster_list,                                                           \
-            (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                           \
+            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                           \
             0, NULL, /* No reporting ctx */                                             \
             0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_ias_warning_device.h
+++ b/zboss/development/include/ha/zb_ha_ias_warning_device.h
@@ -166,8 +166,8 @@
  *  definitions, because these values are used to form simple descriptor type name.
  */
 #define ZB_HA_DECLARE_IAS_WARNING_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num)   \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);    \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)     \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);    \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)     \
             simple_desc_##ep_name =                           \
       {                                                       \
         ep_id,                                                \
@@ -211,7 +211,7 @@
                 cluster_list,                                  \
                 zb_zcl_cluster_desc_t),                        \
             cluster_list,                                      \
-        (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                      \
+        (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
         ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 #define ZB_HA_DECLARE_IAS_WARNING_CTX(device_ctx, ep_name)      \

--- a/zboss/development/include/ha/zb_ha_ias_warning_device.h
+++ b/zboss/development/include/ha/zb_ha_ias_warning_device.h
@@ -199,7 +199,7 @@
           ep_id,                                               \
           ZB_HA_IAS_WARNING_IN_CLUSTER_NUM,                    \
           ZB_HA_IAS_WARNING_OUT_CLUSTER_NUM);                  \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,     \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,     \
                                          ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT); \
       ZB_AF_DECLARE_ENDPOINT_DESC(                                             \
         ep_name,                                                               \
@@ -212,7 +212,7 @@
                 zb_zcl_cluster_desc_t),                        \
             cluster_list,                                      \
         (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
-        ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+        ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 #define ZB_HA_DECLARE_IAS_WARNING_CTX(device_ctx, ep_name)      \
   ZBOSS_DECLARE_DEVICE_CTX_1_EP(device_ctx, ep_name)

--- a/zboss/development/include/ha/zb_ha_ias_zone.h
+++ b/zboss/development/include/ha/zb_ha_ias_zone.h
@@ -196,7 +196,7 @@
           ep_id,                                                \
           ZB_HA_IAS_ZONE_IN_CLUSTER_NUM,                        \
           ZB_HA_IAS_ZONE_OUT_CLUSTER_NUM);                      \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,  \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,  \
                                      ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(                                          \
     ep_name,                                                            \
@@ -209,7 +209,7 @@
                 zb_zcl_cluster_desc_t),                         \
             cluster_list,                                       \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                   \
-    ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
+    ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT, reporting_info## ep_name, \
     0, NULL)
 
 /**

--- a/zboss/development/include/ha/zb_ha_ias_zone.h
+++ b/zboss/development/include/ha/zb_ha_ias_zone.h
@@ -163,8 +163,8 @@
  */
 #define ZB_HA_DECLARE_IAS_ZONE_SIMPLE_DESC(                     \
   ep_name, ep_id, in_clust_num, out_clust_num)                  \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);      \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)       \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);      \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)       \
             simple_desc_##ep_name =                             \
       {                                                         \
         ep_id,                                                  \
@@ -208,7 +208,7 @@
                 cluster_list,                                   \
                 zb_zcl_cluster_desc_t),                         \
             cluster_list,                                       \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                   \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                   \
     ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
     0, NULL)
 

--- a/zboss/development/include/ha/zb_ha_level_control_switch.h
+++ b/zboss/development/include/ha/zb_ha_level_control_switch.h
@@ -148,8 +148,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
 */
 #define ZB_ZCL_DECLARE_LEVEL_CONTROL_SWITCH_SIMPLE_DESC(                      \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -177,7 +177,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
       ZB_HA_LEVEL_CONTROL_SWITCH_IN_CLUSTER_NUM, ZB_HA_LEVEL_CONTROL_SWITCH_OUT_CLUSTER_NUM);   \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                              \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
                           0, NULL, /* No reporting ctx */                                       \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_level_controllable_output.h
+++ b/zboss/development/include/ha/zb_ha_level_controllable_output.h
@@ -173,8 +173,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
 */
 #define ZB_ZCL_DECLARE_LEVEL_CONTROLLABLE_OUTPUT_SIMPLE_DESC(                 \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -211,7 +211,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
                               0,                                        \
                               NULL,                                     \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,  \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                      \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_REPORT_ATTR_COUNT,                     \
                           reporting_info## device_ctx_name,                                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_CVC_ATTR_COUNT,                        \

--- a/zboss/development/include/ha/zb_ha_level_controllable_output.h
+++ b/zboss/development/include/ha/zb_ha_level_controllable_output.h
@@ -203,9 +203,9 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
    ep_id,                                                                                        \
    ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_IN_CLUSTER_NUM,                                               \
    ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_OUT_CLUSTER_NUM);                                             \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,                           \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,                           \
                                      ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_REPORT_ATTR_COUNT);         \
-  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## device_ctx_name,                       \
+  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## ep_name,                       \
                                          ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_CVC_ATTR_COUNT);        \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                               \
                               0,                                        \
@@ -213,9 +213,9 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,  \
                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_REPORT_ATTR_COUNT,                     \
-                          reporting_info## device_ctx_name,                                      \
+                          reporting_info## ep_name,                                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_CVC_ATTR_COUNT,                        \
-                          cvc_alarm_info## device_ctx_name)
+                          cvc_alarm_info## ep_name)
 
 /*!
   @brief Declare application's device context for Level Control Switch device

--- a/zboss/development/include/ha/zb_ha_mains_power_outlet.h
+++ b/zboss/development/include/ha/zb_ha_mains_power_outlet.h
@@ -191,14 +191,14 @@
 #define ZB_HA_DECLARE_MAINS_POWER_OUTLET_EP(ep_name, ep_id, cluster_list)                       \
   ZB_ZCL_DECLARE_MAINS_POWER_OUTLET_SIMPLE_DESC(ep_name, ep_id,                                 \
       ZB_HA_MAINS_POWER_OUTLET_IN_CLUSTER_NUM, ZB_HA_MAINS_POWER_OUTLET_OUT_CLUSTER_NUM);       \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,                    \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,                    \
                                      ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT);         \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                                 \
             0,                    \
             NULL,                                \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
             (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
-            ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+            ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 /** @brief Declare Mains Power Outlet device context.
     @param device_ctx - device context variable name.

--- a/zboss/development/include/ha/zb_ha_mains_power_outlet.h
+++ b/zboss/development/include/ha/zb_ha_mains_power_outlet.h
@@ -162,8 +162,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_MAINS_POWER_OUTLET_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                             \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                             \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
   {                                                                                                \
     ep_id,                                                                                         \
     ZB_AF_HA_PROFILE_ID,                                                                           \
@@ -197,7 +197,7 @@
             0,                    \
             NULL,                                \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-            (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                             \
+            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
             ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 /** @brief Declare Mains Power Outlet device context.

--- a/zboss/development/include/ha/zb_ha_on_off_output.h
+++ b/zboss/development/include/ha/zb_ha_on_off_output.h
@@ -194,7 +194,7 @@
           ep_id,                                                       \
           ZB_HA_ON_OFF_OUTPUT_IN_CLUSTER_NUM,                          \
           ZB_HA_ON_OFF_OUTPUT_OUT_CLUSTER_NUM);                        \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,           \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,           \
                                          ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT);     \
       ZB_AF_DECLARE_ENDPOINT_DESC(ep_name,                                           \
                               ep_id,                                    \
@@ -206,7 +206,7 @@
                 zb_zcl_cluster_desc_t),                                \
             cluster_list,                                              \
             (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
-            ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
+            ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT, reporting_info## ep_name, \
             0, NULL)
 
 /** @brief Declare On/Off Output device context.

--- a/zboss/development/include/ha/zb_ha_on_off_output.h
+++ b/zboss/development/include/ha/zb_ha_on_off_output.h
@@ -162,8 +162,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_ON_OFF_OUTPUT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                    \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name =            \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                    \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name =            \
       {                                                                                       \
         ep_id,                                                                                \
         ZB_AF_HA_PROFILE_ID,                                                                  \
@@ -205,7 +205,7 @@
                 cluster_list,                                          \
                 zb_zcl_cluster_desc_t),                                \
             cluster_list,                                              \
-            (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
             ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
             0, NULL)
 

--- a/zboss/development/include/ha/zb_ha_on_off_switch.h
+++ b/zboss/development/include/ha/zb_ha_on_off_switch.h
@@ -171,8 +171,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_ON_OFF_SWITCH_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
   {                                                                                           \
     ep_id,                                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                                      \
@@ -212,7 +212,7 @@
       NULL,                                                          \
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),        \
       cluster_list,                                                  \
-      (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+      (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
       0, NULL, /* No reporting ctx */           \
       0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_range_extender.h
+++ b/zboss/development/include/ha/zb_ha_range_extender.h
@@ -130,8 +130,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
   {                                                                                            \
     ep_id,                                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                                       \
@@ -158,7 +158,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
       ZB_HA_RANGE_EXTENDER_IN_CLUSTER_NUM, ZB_HA_RANGE_EXTENDER_OUT_CLUSTER_NUM);               \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                              \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                 \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                 \
                               0, NULL, /* No reporting ctx */                                   \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_scene_selector.h
+++ b/zboss/development/include/ha/zb_ha_scene_selector.h
@@ -145,8 +145,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SCENE_SELECTOR_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
   {                                                                                            \
     ep_id,                                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                                       \
@@ -175,7 +175,7 @@
       ZB_HA_SCENE_SELECTOR_IN_CLUSTER_NUM, ZB_HA_SCENE_SELECTOR_OUT_CLUSTER_NUM); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,         \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,   \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,   \
                               0, NULL, /* No reporting ctx */                     \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_shade.h
+++ b/zboss/development/include/ha/zb_ha_shade.h
@@ -183,8 +183,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SHADE_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =         \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =         \
   {                                                                                   \
     ep_id,                                                                            \
     ZB_AF_HA_PROFILE_ID,                                                              \
@@ -229,7 +229,7 @@
     NULL,                                                                 \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_SHADE_REPORT_ATTR_COUNT,                          \
                               reporting_info## device_ctx_name,                       \
                               ZB_HA_SHADE_CVC_ATTR_COUNT, cvc_alarm_info## device_ctx_name)

--- a/zboss/development/include/ha/zb_ha_shade.h
+++ b/zboss/development/include/ha/zb_ha_shade.h
@@ -220,9 +220,9 @@
     ep_id,                                                                \
     ZB_HA_SHADE_IN_CLUSTER_NUM,                                           \
     ZB_HA_SHADE_OUT_CLUSTER_NUM);                                         \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,                \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,                \
                                      ZB_HA_SHADE_REPORT_ATTR_COUNT);                  \
-  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## device_ctx_name,            \
+  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## ep_name,            \
                                          ZB_HA_SHADE_CVC_ATTR_COUNT);                 \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                             \
     0,                                                                    \
@@ -231,8 +231,8 @@
                               cluster_list,                                           \
                               (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_SHADE_REPORT_ATTR_COUNT,                          \
-                              reporting_info## device_ctx_name,                       \
-                              ZB_HA_SHADE_CVC_ATTR_COUNT, cvc_alarm_info## device_ctx_name)
+                              reporting_info## ep_name,                       \
+                              ZB_HA_SHADE_CVC_ATTR_COUNT, cvc_alarm_info## ep_name)
 
 
 /** @brief Declare Shade device context.

--- a/zboss/development/include/ha/zb_ha_shade_controller.h
+++ b/zboss/development/include/ha/zb_ha_shade_controller.h
@@ -154,8 +154,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SHADE_CONTROLLER_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =         \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =         \
   {                                                                                   \
     ep_id,                                                                            \
     ZB_AF_HA_PROFILE_ID,                                                              \
@@ -195,7 +195,7 @@
     NULL,                                                                   \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               0, NULL, /* No reporting ctx */                         \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_simple_sensor.h
+++ b/zboss/development/include/ha/zb_ha_simple_sensor.h
@@ -148,8 +148,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SIMPLE_SENSOR_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
   {                                                                                           \
     ep_id,                                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                                      \
@@ -180,7 +180,7 @@
                                      ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT);    \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL, \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
-                           (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,    \
+                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,    \
                            ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT,               \
                            reporting_info## device_ctx_name, 0, NULL)
 

--- a/zboss/development/include/ha/zb_ha_simple_sensor.h
+++ b/zboss/development/include/ha/zb_ha_simple_sensor.h
@@ -176,13 +176,13 @@
 #define ZB_HA_DECLARE_SIMPLE_SENSOR_EP(ep_name, ep_id, cluster_list)            \
   ZB_ZCL_DECLARE_SIMPLE_SENSOR_SIMPLE_DESC(ep_name, ep_id,                      \
       ZB_HA_SIMPLE_SENSOR_IN_CLUSTER_NUM, ZB_HA_SIMPLE_SENSOR_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,          \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info##ep_name,          \
                                      ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT);    \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL, \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
                            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,    \
                            ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT,               \
-                           reporting_info## device_ctx_name, 0, NULL)
+                           reporting_info##ep_name, 0, NULL)
 
 
 /** @brief Declare Simple Sensor device context.

--- a/zboss/development/include/ha/zb_ha_smart_plug.h
+++ b/zboss/development/include/ha/zb_ha_smart_plug.h
@@ -179,14 +179,14 @@
 #define ZB_HA_DECLARE_SMART_PLUG_EP(ep_name, ep_id, cluster_list)           \
   ZB_ZCL_DECLARE_SMART_PLUG_SIMPLE_DESC(ep_name, ep_id,                     \
     ZB_HA_SMART_PLUG_IN_CLUSTER_NUM, ZB_HA_SMART_PLUG_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,    \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,    \
                                      ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,        \
     0,                                                                          \
     NULL,                                                                       \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
-    ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+    ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 
 /*!

--- a/zboss/development/include/ha/zb_ha_smart_plug.h
+++ b/zboss/development/include/ha/zb_ha_smart_plug.h
@@ -150,8 +150,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SMART_PLUG_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                     \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =              \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                     \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =              \
   {                                                                                        \
     ep_id,                                                                                 \
     ZB_AF_HA_PROFILE_ID,                                                                   \
@@ -185,7 +185,7 @@
     0,                                                                          \
     NULL,                                                                       \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
     ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 

--- a/zboss/development/include/ha/zb_ha_temperature_sensor.h
+++ b/zboss/development/include/ha/zb_ha_temperature_sensor.h
@@ -146,8 +146,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_TEMPERATURE_SENSOR_TEMPERATURE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                          \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =   \
+  ZB_DECLARE_SIMPLE_DESC(ep_name, in_clust_num, out_clust_num);                          \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =   \
   {                                                                             \
     ep_id,                                                                      \
     ZB_AF_HA_PROFILE_ID,                                                        \
@@ -184,7 +184,7 @@
       NULL,                                                       \
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),     \
       cluster_list,                                               \
-      (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                           \
+      (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                           \
       ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 /** @brief Declare Temperature Sensor device context.

--- a/zboss/development/include/ha/zb_ha_temperature_sensor.h
+++ b/zboss/development/include/ha/zb_ha_temperature_sensor.h
@@ -176,7 +176,7 @@
       ep_id,                                                      \
       ZB_HA_TEMPERATURE_SENSOR_IN_CLUSTER_NUM,                    \
       ZB_HA_TEMPERATURE_SENSOR_OUT_CLUSTER_NUM);                  \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,            \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,            \
                                      ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id,                                              \
       ZB_AF_HA_PROFILE_ID,                                        \
@@ -185,7 +185,7 @@
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),     \
       cluster_list,                                               \
       (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                           \
-      ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+      ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 /** @brief Declare Temperature Sensor device context.
     @param device_ctx - device context variable name.

--- a/zboss/development/include/ha/zb_ha_test_device.h
+++ b/zboss/development/include/ha/zb_ha_test_device.h
@@ -121,8 +121,8 @@
  */
 #define ZB_HA_DECLARE_TEST_DEVICE_SIMPLE_DESC(                                     \
   ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                            \
         ep_id,                                                                     \
         ZB_AF_HA_PROFILE_ID,                                                       \
@@ -164,7 +164,7 @@
                 cluster_list,                                      \
                 zb_zcl_cluster_desc_t),                            \
             cluster_list,                                          \
-        (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,          \
+        (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,          \
                            0, NULL, /* No reporting ctx */              \
                            0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_thermostat.h
+++ b/zboss/development/include/ha/zb_ha_thermostat.h
@@ -247,14 +247,14 @@
 #define ZB_HA_DECLARE_THERMOSTAT_EP(ep_name, ep_id, cluster_list)         \
   ZB_ZCL_DECLARE_THERMOSTAT_SIMPLE_DESC(ep_name, ep_id,                   \
     ZB_HA_THERMOSTAT_IN_CLUSTER_NUM, ZB_HA_THERMOSTAT_OUT_CLUSTER_NUM);   \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,    \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,    \
                                      ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,        \
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
-    ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
+    ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT, reporting_info## ep_name, \
     0, NULL)
 
 

--- a/zboss/development/include/ha/zb_ha_thermostat.h
+++ b/zboss/development/include/ha/zb_ha_thermostat.h
@@ -217,8 +217,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_THERMOSTAT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                     \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =              \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                     \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =              \
   {                                                                                        \
     ep_id,                                                                                 \
     ZB_AF_HA_PROFILE_ID,                                                                   \
@@ -253,7 +253,7 @@
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
     ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
     0, NULL)
 

--- a/zboss/development/include/ha/zb_ha_window_covering.h
+++ b/zboss/development/include/ha/zb_ha_window_covering.h
@@ -189,14 +189,14 @@
 #define ZB_HA_DECLARE_WINDOW_COVERING_EP(ep_name, ep_id, cluster_list)            \
   ZB_ZCL_DECLARE_WINDOW_COVERING_SIMPLE_DESC(ep_name, ep_id,                      \
     ZB_HA_WINDOW_COVERING_IN_CLUSTER_NUM, ZB_HA_WINDOW_COVERING_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,            \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,            \
                                      ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT);    \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                \
             0,                    \
             NULL,                                \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,         \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
-    ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name,    \
+    ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT, reporting_info## ep_name,    \
     0, NULL) /* No CVC ctx */
 
 

--- a/zboss/development/include/ha/zb_ha_window_covering.h
+++ b/zboss/development/include/ha/zb_ha_window_covering.h
@@ -161,8 +161,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_WINDOW_COVERING_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                          \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                          \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
   {                                                                                             \
     ep_id,                                                                                      \
     ZB_AF_HA_PROFILE_ID,                                                                        \
@@ -195,7 +195,7 @@
             0,                    \
             NULL,                                \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,         \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                             \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
     ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name,    \
     0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/ha/zb_ha_window_covering_controller.h
+++ b/zboss/development/include/ha/zb_ha_window_covering_controller.h
@@ -151,8 +151,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                             \
 */
 #define ZB_ZCL_DECLARE_WINDOW_COVERING_CONTROLLER_SIMPLE_DESC(                \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -186,7 +186,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                             \
                           NULL,                                                   \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                           cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               0, NULL, /* No reporting ctx */                         \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/development/include/zboss_api_af.h
+++ b/zboss/development/include/zboss_api_af.h
@@ -217,10 +217,11 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
 
 /** @cond DOXYGEN_INTERNAL_DOC */
 #define CAT5(a, b, c, d, e) a##b##c##d##e
+#define CAT6(a, b, c, d, e,f) a##b##c##d##e##f
 /** @endcond */ /* DOXYGEN_INTERNAL_DOC */
 
 /** Generate simple descriptor type name */
-#define ZB_AF_SIMPLE_DESC_TYPE(in_num, out_num)  CAT5(zb_af_simple_desc_,in_num,_,out_num,_t)
+#define ZB_AF_SIMPLE_DESC_TYPE(epname, in_num, out_num)  CAT6(zb_af_simple_desc_,epname, in_num,_,out_num,_t)
 
 /**
    Declares Simple descriptor type
@@ -234,8 +235,9 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
    @endcode
  */
 
-#define ZB_DECLARE_SIMPLE_DESC(in_clusters_count, out_clusters_count)   \
-  typedef ZB_PACKED_PRE struct zb_af_simple_desc_ ## in_clusters_count ## _ ## out_clusters_count ## _s \
+#define ZB_DECLARE_SIMPLE_DESC(epname, in_clusters_count, out_clusters_count)   \
+/* #define HO_ ## in_clusters_count ## _ ## out_clusters_count 1 \ */ \
+  typedef ZB_PACKED_PRE struct zb_af_simple_desc_ ## epname ## in_clusters_count ## _ ## out_clusters_count ## _s \
   {                                                                                       \
     zb_uint8_t    endpoint;                 /* Endpoint */                                \
     zb_uint16_t   app_profile_id;           /* Application profile identifier */          \
@@ -247,7 +249,7 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
     /* Application input and output cluster list */                                       \
     zb_uint16_t   app_cluster_list[(in_clusters_count) + (out_clusters_count)];               \
   } ZB_PACKED_STRUCT                                                                      \
-  zb_af_simple_desc_ ## in_clusters_count ## _ ## out_clusters_count ## _t
+  zb_af_simple_desc_ ## epname ## in_clusters_count ## _ ## out_clusters_count ## _t 
 
 /** @} */ /* af_data_service */
 
@@ -256,9 +258,9 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
  * @{
  */
 /** General descriptor type */
-ZB_DECLARE_SIMPLE_DESC(1,1);
+ZB_DECLARE_SIMPLE_DESC(general, 1,1);
 /** ZDO descriptor type */
-ZB_DECLARE_SIMPLE_DESC(8,9);
+ZB_DECLARE_SIMPLE_DESC(general, 8,9);
 /** @} */ /* af_management_service */
 
 /**
@@ -350,7 +352,8 @@ typedef ZB_PACKED_PRE struct zb_af_endpoint_desc_s
   void* reserved_ptr; /*!< Unused parameter (reserved for future use) */
   zb_uint8_t cluster_count;       /*!< Number of supported clusters */
   struct zb_zcl_cluster_desc_s *cluster_desc_list;  /*!< Supported clusters list */
-  zb_af_simple_desc_1_1_t *simple_desc; /*!< Simple descriptor */
+  /* zb_af_simple_desc_general_1_1_t *simple_desc; */ /*!< Simple descriptor */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) * simple_desc;
 #if defined ZB_ENABLE_ZLL || defined DOXYGEN
   zb_uint8_t group_id_count;
 #endif /* defined ZB_ENABLE_ZLL || defined DOXYGEN */

--- a/zboss/development/include/zboss_api_zdo.h
+++ b/zboss/development/include/zboss_api_zdo.h
@@ -1429,7 +1429,7 @@ typedef zb_zdo_desc_resp_hdr_t            zb_zdo_user_desc_conf_hdr_t;
 typedef ZB_PACKED_PRE struct zb_zdo_simple_desc_resp_s
 {
   zb_zdo_simple_desc_resp_hdr_t hdr;  /*!< header for response */
-  zb_af_simple_desc_1_1_t simple_desc; /*!< Simple Descriptor */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) simple_desc; /*!< Simple Descriptor */
 } ZB_PACKED_STRUCT
 zb_zdo_simple_desc_resp_t;
 

--- a/zboss/development/include/zcl/zb_zcl_control4_networking.h
+++ b/zboss/development/include/zcl/zb_zcl_control4_networking.h
@@ -410,7 +410,7 @@ enum zb_zcl_control4_networking_cmd_e
     NULL,                                                            \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),          \
     cluster_list,                                                    \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                \
     0, NULL, 0, NULL)
 
 /**

--- a/zboss/development/src/include/zb_zdo.h
+++ b/zboss/development/src/include/zb_zdo.h
@@ -367,7 +367,7 @@ void zb_copy_power_desc(zb_af_node_power_desc_t *dst_desc, zb_af_node_power_desc
    @param dst_desc - destination descriptor
    @param src_desc - source descriptor
 */
-void zb_copy_simple_desc(zb_af_simple_desc_1_1_t* dst_desc, zb_af_simple_desc_1_1_t*src_desc);
+void zb_copy_simple_desc(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)* dst_desc, ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*src_desc);
 
 /**
    NWK_addr_req  primitive.
@@ -1209,7 +1209,7 @@ void zb_set_network_ed_role_legacy(zb_uint32_t channel_mask);
   @par
 
 */
-void zb_set_simple_descriptor(zb_af_simple_desc_1_1_t *simple_desc,
+void zb_set_simple_descriptor(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc,
                               zb_uint8_t  endpoint, zb_uint16_t app_profile_id,
                               zb_uint16_t app_device_id, zb_bitfield_t app_device_version,
                               zb_uint8_t app_input_cluster_count, zb_uint8_t app_output_cluster_count);
@@ -1225,7 +1225,7 @@ void zb_set_simple_descriptor(zb_af_simple_desc_1_1_t *simple_desc,
   @par
 
 */
-void zb_set_input_cluster_id(zb_af_simple_desc_1_1_t *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
+void zb_set_input_cluster_id(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
 
 /*! @brief Set output cluster item
     @param simple_desc - pointer to simple descriptor
@@ -1237,7 +1237,7 @@ void zb_set_input_cluster_id(zb_af_simple_desc_1_1_t *simple_desc, zb_uint8_t cl
   @par
 
 */
-void zb_set_output_cluster_id(zb_af_simple_desc_1_1_t *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
+void zb_set_output_cluster_id(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
 
 /**
   Set default descriptors values for FFD.
@@ -1265,7 +1265,7 @@ void zb_set_default_ed_descriptor_values(void);
   @par
 
  */
-zb_ret_t zb_add_simple_descriptor(zb_af_simple_desc_1_1_t *simple_desc);
+zb_ret_t zb_add_simple_descriptor(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc);
 
 /**
   Set node descriptor for FFD

--- a/zboss/development/src/include/zb_zdo_globals.h
+++ b/zboss/development/src/include/zb_zdo_globals.h
@@ -73,11 +73,11 @@ typedef struct zb_zdo_configuration_attributes_e
 
   zb_af_node_desc_t       node_desc;        /*!< Node Descriptors */
   zb_af_node_power_desc_t node_power_desc;  /*!< Node Power Descriptors */
-  zb_af_simple_desc_8_9_t zdo_simple_desc; /* TODO: remove it, ZDO simple descriptor is not needed - simple descriptors for EP >= 1 are used */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 8, 9) zdo_simple_desc; /* TODO: remove it, ZDO simple descriptor is not needed - simple descriptors for EP >= 1 are used */
   /* TODO: make real list support, if multiple EP are supported */
   /* TODO: each Zigbee device application declares a device context and a list of EPs. Each EP
      stores its simple descriptor => no need store it here, it is better to use that storage */
-  zb_af_simple_desc_1_1_t *simple_desc_list[ZB_MAX_EP_NUMBER];  /*!< Simple Descriptors table */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc_list[ZB_MAX_EP_NUMBER];  /*!< Simple Descriptors table */
   zb_uint8_t simple_desc_number;                                /*!< Number elements of Simple Descriptors table */
 
 #ifndef ZB_LITE_NO_END_DEVICE_BIND

--- a/zboss/production/include/ha/zb_ha_combined_interface.h
+++ b/zboss/production/include/ha/zb_ha_combined_interface.h
@@ -149,8 +149,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_COMBINED_INTERFACE_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                             \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                             \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
   {                                                                                                \
     ep_id,                                                                                         \
     ZB_AF_HA_PROFILE_ID,                                                                           \
@@ -179,7 +179,7 @@
       ZB_HA_COMBINED_INTERFACE_IN_CLUSTER_NUM, ZB_HA_COMBINED_INTERFACE_OUT_CLUSTER_NUM); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                        \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,                 \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,               \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,               \
                           0, NULL, /* No reporting ctx */                                 \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_configuration_tool.h
+++ b/zboss/production/include/ha/zb_ha_configuration_tool.h
@@ -152,8 +152,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                 \
 
 */
 #define ZB_ZCL_DECLARE_CONFIGURATION_TOOL_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                             \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                             \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
   {                                                                                                \
     ep_id,                                                                                         \
     ZB_AF_HA_PROFILE_ID,                                                                           \
@@ -183,7 +183,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                 \
       ZB_HA_CONFIGURATION_TOOL_IN_CLUSTER_NUM, ZB_HA_CONFIGURATION_TOOL_OUT_CLUSTER_NUM); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL, \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
                           0, NULL, /* No reporting ctx */               \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_custom_attr.h
+++ b/zboss/production/include/ha/zb_ha_custom_attr.h
@@ -168,14 +168,14 @@
 #define ZB_HA_DECLARE_CUSTOM_ATTR_EP(ep_name, ep_id, cluster_list)        \
   ZB_ZCL_DECLARE_CUSTOM_ATTR_SIMPLE_DESC(ep_name, ep_id,                  \
     ZB_HA_CUSTOM_ATTR_IN_CLUSTER_NUM, ZB_HA_CUSTOM_ATTR_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name, 20);  \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name, 20);  \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                    \
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,  \
                           ZB_ZCL_ARRAY_SIZE(ep_name, zb_af_endpoint_desc_t), \
-                          20, reporting_info## device_ctx_name, 0, NULL)
+                          20, reporting_info## ep_name, 0, NULL)
 
 
 #define ZB_HA_DECLARE_CUSTOM_ATTR_CTX(device_ctx, ep_name)              \

--- a/zboss/production/include/ha/zb_ha_custom_attr.h
+++ b/zboss/production/include/ha/zb_ha_custom_attr.h
@@ -139,8 +139,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_CUSTOM_ATTR_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num)     \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                          \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                          \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
   {                                                                                             \
     ep_id,                                                                                      \
     ZB_AF_HA_PROFILE_ID,                                                                        \
@@ -173,7 +173,7 @@
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,  \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,  \
                           ZB_ZCL_ARRAY_SIZE(ep_name, zb_af_endpoint_desc_t), \
                           20, reporting_info## device_ctx_name, 0, NULL)
 

--- a/zboss/production/include/ha/zb_ha_device_config.h
+++ b/zboss/production/include/ha/zb_ha_device_config.h
@@ -74,6 +74,13 @@ enum zb_ha_standard_devs_e
   /*! Range Extender */
   ZB_HA_RANGE_EXTENDER_DEVICE_ID      = 0x0008,
   /*! Mains Power Outlet */
+  /* Psychogenic MOD: 
+   * This may be standard:
+   * ZB_HA_MAINS_POWER_OUTLET_DEVICE_ID  = 0x0009,
+   * but real-world devices seem to recognize
+   * ZB_HA_MAINS_POWER_OUTLET_DEVICE_ID  = 0x010A,
+   * instead
+   * */
   ZB_HA_MAINS_POWER_OUTLET_DEVICE_ID  = 0x0009,
   /*! Door lock client */
   ZB_HA_DOOR_LOCK_DEVICE_ID           = 0x000A,

--- a/zboss/production/include/ha/zb_ha_dimmable_light.h
+++ b/zboss/production/include/ha/zb_ha_dimmable_light.h
@@ -157,8 +157,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
+  ZB_DECLARE_SIMPLE_DESC(ep_name, in_clust_num, out_clust_num);                                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
   {                                                                                            \
     ep_id,                                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                                       \
@@ -197,7 +197,7 @@
     0,                                                                          \
     NULL,                                                                       \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,     \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,     \
                           ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT,               \
                           reporting_info## device_ctx_name,                     \
                           ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT,                  \

--- a/zboss/production/include/ha/zb_ha_dimmable_light.h
+++ b/zboss/production/include/ha/zb_ha_dimmable_light.h
@@ -189,9 +189,9 @@
 #define ZB_HA_DECLARE_DIMMABLE_LIGHT_EP(ep_name, ep_id, cluster_list)           \
   ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id,                     \
     ZB_HA_DIMMABLE_LIGHT_IN_CLUSTER_NUM, ZB_HA_DIMMABLE_LIGHT_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,          \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,          \
                                      ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT);   \
-  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## device_ctx_name,      \
+  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## ep_name,      \
                                          ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT);  \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                       \
     0,                                                                          \
@@ -199,9 +199,9 @@
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,     \
                           ZB_HA_DIMMABLE_LIGHT_REPORT_ATTR_COUNT,               \
-                          reporting_info## device_ctx_name,                     \
+                          reporting_info## ep_name,                     \
                           ZB_HA_DIMMABLE_LIGHT_CVC_ATTR_COUNT,                  \
-                          cvc_alarm_info## device_ctx_name)
+                          cvc_alarm_info## ep_name)
 
 /**
   @brief Declare application's device context for Dimmable Light device

--- a/zboss/production/include/ha/zb_ha_dimmer_switch.h
+++ b/zboss/production/include/ha/zb_ha_dimmer_switch.h
@@ -150,8 +150,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
 */
 #define ZB_ZCL_DECLARE_DIMMER_SWITCH_SIMPLE_DESC(                             \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -184,7 +184,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
                                                                                                 \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                     \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
                           0, NULL, /* No reporting ctx */                                       \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_door_lock.h
+++ b/zboss/production/include/ha/zb_ha_door_lock.h
@@ -191,7 +191,7 @@
 #define ZB_HA_DECLARE_DOOR_LOCK_EP(ep_name, ep_id, cluster_list)                \
       ZB_ZCL_DECLARE_DOOR_LOCK_SIMPLE_DESC(ep_name, ep_id,                      \
           ZB_HA_DOOR_LOCK_IN_CLUSTER_NUM, ZB_HA_DOOR_LOCK_OUT_CLUSTER_NUM);     \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,            \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,            \
                                          ZB_HA_DOOR_LOCK_REPORT_ATTR_COUNT);          \
       ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                         \
             0,                                                                        \
@@ -200,7 +200,7 @@
                               cluster_list,                                           \
                               (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_DOOR_LOCK_REPORT_ATTR_COUNT,                      \
-                              reporting_info## device_ctx_name,                       \
+                              reporting_info## ep_name,                       \
                               0, NULL)
 
 

--- a/zboss/production/include/ha/zb_ha_door_lock.h
+++ b/zboss/production/include/ha/zb_ha_door_lock.h
@@ -162,8 +162,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_DOOR_LOCK_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                  \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                  \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                     \
         ep_id,                                                              \
         ZB_AF_HA_PROFILE_ID,                                                \
@@ -198,7 +198,7 @@
             NULL,                                                                     \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_DOOR_LOCK_REPORT_ATTR_COUNT,                      \
                               reporting_info## device_ctx_name,                       \
                               0, NULL)

--- a/zboss/production/include/ha/zb_ha_door_lock_controller.h
+++ b/zboss/production/include/ha/zb_ha_door_lock_controller.h
@@ -163,8 +163,8 @@
 */
 #define ZB_ZCL_DECLARE_DOOR_LOCK_CONTROLLER_SIMPLE_DESC(                             \
     ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-        ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-        ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+        ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+        ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
         {                                                                            \
           ep_id,                                                                     \
           ZB_AF_HA_PROFILE_ID,                                                       \
@@ -195,7 +195,7 @@
           ZB_HA_DOOR_LOCK_CONTROLLER_IN_CLUSTER_NUM, ZB_HA_DOOR_LOCK_CONTROLLER_OUT_CLUSTER_NUM); \
       ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                            \
           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,                   \
-          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                                       \
+          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                                       \
           0, NULL, 0, NULL)
 
 /** @brief Declare Door Lock Controller device context.

--- a/zboss/production/include/ha/zb_ha_erl_device_interface.h
+++ b/zboss/production/include/ha/zb_ha_erl_device_interface.h
@@ -239,8 +239,8 @@
                                                      ep_id,                    \
                                                      in_clust_num,             \
                                                      out_clust_num)            \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
   {                                                                            \
     ep_id,                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                       \
@@ -288,7 +288,7 @@
                               NULL,                                                   \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_ERL_INTERFACE_DEV_REPORT_ATTR_COUNT,                 \
                               reporting_info##device_ctx_name,                        \
                               0, NULL)

--- a/zboss/production/include/ha/zb_ha_erl_gw_device.h
+++ b/zboss/production/include/ha/zb_ha_erl_gw_device.h
@@ -156,8 +156,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_ERL_GW_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
   {                                                                                           \
     ep_id,                                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                                      \
@@ -198,7 +198,7 @@
       NULL,                                                          \
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),        \
       cluster_list,                                                  \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               0, NULL, /* No reporting ctx */                         \
                               0, NULL)
 

--- a/zboss/production/include/ha/zb_ha_gp_dev.h
+++ b/zboss/production/include/ha/zb_ha_gp_dev.h
@@ -105,8 +105,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_GP_DEV_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                  \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =          \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                  \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =          \
   {                                                                     \
     ep_id,                                                              \
     ZB_AF_HA_PROFILE_ID,                                                \
@@ -135,7 +135,7 @@
                                      ZB_HA_GP_DEV_REPORT_ATTR_COUNT);           \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,              \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
                               ZB_HA_GP_DEV_REPORT_ATTR_COUNT,                   \
                               reporting_info## device_ctx_name, 0, NULL)
 

--- a/zboss/production/include/ha/zb_ha_gp_dev.h
+++ b/zboss/production/include/ha/zb_ha_gp_dev.h
@@ -131,13 +131,13 @@
 #define ZB_HA_DECLARE_GP_DEV_EP(ep_name, ep_id, cluster_list)    \
   ZB_ZCL_DECLARE_GP_DEV_SIMPLE_DESC(ep_name, ep_id,                      \
       ZB_HA_GP_DEV_IN_CLUSTER_NUM, ZB_HA_GP_DEV_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,          \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,          \
                                      ZB_HA_GP_DEV_REPORT_ATTR_COUNT);           \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,              \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
                               (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
                               ZB_HA_GP_DEV_REPORT_ATTR_COUNT,                   \
-                              reporting_info## device_ctx_name, 0, NULL)
+                              reporting_info## ep_name, 0, NULL)
 
 
 #define ZB_HA_DECLARE_GP_DEV_CTX(device_ctx, ep_name)                                                   \

--- a/zboss/production/include/ha/zb_ha_ias_ancillary_control_equipment.h
+++ b/zboss/production/include/ha/zb_ha_ias_ancillary_control_equipment.h
@@ -185,7 +185,7 @@
           ep_id,                                                                    \
           ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_IN_CLUSTER_NUM,                     \
           ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_OUT_CLUSTER_NUM);                   \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,             \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,             \
           ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT);                    \
       ZB_AF_DECLARE_ENDPOINT_DESC(                                                     \
         ep_name,                                                                       \
@@ -198,7 +198,7 @@
                 zb_zcl_cluster_desc_t),                                             \
             cluster_list,                                                           \
         (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                              \
-        ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+        ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 /**
    @brief Declare application's device context for Ancillary Control Equipment

--- a/zboss/production/include/ha/zb_ha_ias_ancillary_control_equipment.h
+++ b/zboss/production/include/ha/zb_ha_ias_ancillary_control_equipment.h
@@ -154,8 +154,8 @@
  */
 #define ZB_HA_DECLARE_IAS_ANCILLARY_CONTROL_EQUIPMENT_SIMPLE_DESC(                 \
   ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                            \
         ep_id,                                                                     \
         ZB_AF_ZLL_PROFILE_ID,                                                      \
@@ -197,7 +197,7 @@
                 cluster_list,                                                       \
                 zb_zcl_cluster_desc_t),                                             \
             cluster_list,                                                           \
-        (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                              \
+        (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                              \
         ZB_HA_IAS_ANCILLARY_CONTROL_EQUIPMENT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 /**

--- a/zboss/production/include/ha/zb_ha_ias_control_indicating_equipment.h
+++ b/zboss/production/include/ha/zb_ha_ias_control_indicating_equipment.h
@@ -157,8 +157,8 @@
  */
 #define ZB_HA_DECLARE_IAS_CONTROL_INDICATING_EQUIPMENT_SIMPLE_DESC(                \
   ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                            \
         ep_id,                                                                     \
         ZB_AF_ZLL_PROFILE_ID,                                                      \
@@ -201,7 +201,7 @@
                 cluster_list,                                                       \
                 zb_zcl_cluster_desc_t),                                             \
             cluster_list,                                                           \
-            (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                           \
+            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                           \
             0, NULL, /* No reporting ctx */                                             \
             0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_ias_warning_device.h
+++ b/zboss/production/include/ha/zb_ha_ias_warning_device.h
@@ -166,8 +166,8 @@
  *  definitions, because these values are used to form simple descriptor type name.
  */
 #define ZB_HA_DECLARE_IAS_WARNING_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num)   \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);    \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)     \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);    \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)     \
             simple_desc_##ep_name =                           \
       {                                                       \
         ep_id,                                                \
@@ -211,7 +211,7 @@
                 cluster_list,                                  \
                 zb_zcl_cluster_desc_t),                        \
             cluster_list,                                      \
-        (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                      \
+        (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
         ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 #define ZB_HA_DECLARE_IAS_WARNING_CTX(device_ctx, ep_name)      \

--- a/zboss/production/include/ha/zb_ha_ias_warning_device.h
+++ b/zboss/production/include/ha/zb_ha_ias_warning_device.h
@@ -199,7 +199,7 @@
           ep_id,                                               \
           ZB_HA_IAS_WARNING_IN_CLUSTER_NUM,                    \
           ZB_HA_IAS_WARNING_OUT_CLUSTER_NUM);                  \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,     \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,     \
                                          ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT); \
       ZB_AF_DECLARE_ENDPOINT_DESC(                                             \
         ep_name,                                                               \
@@ -212,7 +212,7 @@
                 zb_zcl_cluster_desc_t),                        \
             cluster_list,                                      \
         (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
-        ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+        ZB_HA_IAS_WARNING_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 #define ZB_HA_DECLARE_IAS_WARNING_CTX(device_ctx, ep_name)      \
   ZBOSS_DECLARE_DEVICE_CTX_1_EP(device_ctx, ep_name)

--- a/zboss/production/include/ha/zb_ha_ias_zone.h
+++ b/zboss/production/include/ha/zb_ha_ias_zone.h
@@ -196,7 +196,7 @@
           ep_id,                                                \
           ZB_HA_IAS_ZONE_IN_CLUSTER_NUM,                        \
           ZB_HA_IAS_ZONE_OUT_CLUSTER_NUM);                      \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,  \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,  \
                                      ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(                                          \
     ep_name,                                                            \
@@ -209,7 +209,7 @@
                 zb_zcl_cluster_desc_t),                         \
             cluster_list,                                       \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                   \
-    ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
+    ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT, reporting_info## ep_name, \
     0, NULL)
 
 /**

--- a/zboss/production/include/ha/zb_ha_ias_zone.h
+++ b/zboss/production/include/ha/zb_ha_ias_zone.h
@@ -163,8 +163,8 @@
  */
 #define ZB_HA_DECLARE_IAS_ZONE_SIMPLE_DESC(                     \
   ep_name, ep_id, in_clust_num, out_clust_num)                  \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);      \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)       \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);      \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)       \
             simple_desc_##ep_name =                             \
       {                                                         \
         ep_id,                                                  \
@@ -208,7 +208,7 @@
                 cluster_list,                                   \
                 zb_zcl_cluster_desc_t),                         \
             cluster_list,                                       \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                   \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                   \
     ZB_HA_IAS_ZONE_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
     0, NULL)
 

--- a/zboss/production/include/ha/zb_ha_level_control_switch.h
+++ b/zboss/production/include/ha/zb_ha_level_control_switch.h
@@ -148,8 +148,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
 */
 #define ZB_ZCL_DECLARE_LEVEL_CONTROL_SWITCH_SIMPLE_DESC(                      \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -177,7 +177,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
       ZB_HA_LEVEL_CONTROL_SWITCH_IN_CLUSTER_NUM, ZB_HA_LEVEL_CONTROL_SWITCH_OUT_CLUSTER_NUM);   \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                              \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
                           0, NULL, /* No reporting ctx */                                       \
                           0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_level_controllable_output.h
+++ b/zboss/production/include/ha/zb_ha_level_controllable_output.h
@@ -173,8 +173,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
 */
 #define ZB_ZCL_DECLARE_LEVEL_CONTROLLABLE_OUTPUT_SIMPLE_DESC(                 \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -211,7 +211,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
                               0,                                        \
                               NULL,                                     \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,  \
-                          (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                      \
+                          (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_REPORT_ATTR_COUNT,                     \
                           reporting_info## device_ctx_name,                                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_CVC_ATTR_COUNT,                        \

--- a/zboss/production/include/ha/zb_ha_level_controllable_output.h
+++ b/zboss/production/include/ha/zb_ha_level_controllable_output.h
@@ -203,9 +203,9 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
    ep_id,                                                                                        \
    ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_IN_CLUSTER_NUM,                                               \
    ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_OUT_CLUSTER_NUM);                                             \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,                           \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,                           \
                                      ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_REPORT_ATTR_COUNT);         \
-  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## device_ctx_name,                       \
+  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## ep_name,                       \
                                          ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_CVC_ATTR_COUNT);        \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                               \
                               0,                                        \
@@ -213,9 +213,9 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                    \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,  \
                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_REPORT_ATTR_COUNT,                     \
-                          reporting_info## device_ctx_name,                                      \
+                          reporting_info## ep_name,                                      \
                           ZB_HA_LEVEL_CONTROLLABLE_OUTPUT_CVC_ATTR_COUNT,                        \
-                          cvc_alarm_info## device_ctx_name)
+                          cvc_alarm_info## ep_name)
 
 /*!
   @brief Declare application's device context for Level Control Switch device

--- a/zboss/production/include/ha/zb_ha_mains_power_outlet.h
+++ b/zboss/production/include/ha/zb_ha_mains_power_outlet.h
@@ -191,14 +191,14 @@
 #define ZB_HA_DECLARE_MAINS_POWER_OUTLET_EP(ep_name, ep_id, cluster_list)                       \
   ZB_ZCL_DECLARE_MAINS_POWER_OUTLET_SIMPLE_DESC(ep_name, ep_id,                                 \
       ZB_HA_MAINS_POWER_OUTLET_IN_CLUSTER_NUM, ZB_HA_MAINS_POWER_OUTLET_OUT_CLUSTER_NUM);       \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,                    \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,                    \
                                      ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT);         \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                                 \
             0,                    \
             NULL,                                \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
             (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
-            ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+            ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 /** @brief Declare Mains Power Outlet device context.
     @param device_ctx - device context variable name.

--- a/zboss/production/include/ha/zb_ha_mains_power_outlet.h
+++ b/zboss/production/include/ha/zb_ha_mains_power_outlet.h
@@ -162,8 +162,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_MAINS_POWER_OUTLET_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                             \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                             \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                      \
   {                                                                                                \
     ep_id,                                                                                         \
     ZB_AF_HA_PROFILE_ID,                                                                           \
@@ -197,7 +197,7 @@
             0,                    \
             NULL,                                \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-            (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                             \
+            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
             ZB_HA_MAINS_POWER_OUTLET_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 /** @brief Declare Mains Power Outlet device context.

--- a/zboss/production/include/ha/zb_ha_on_off_output.h
+++ b/zboss/production/include/ha/zb_ha_on_off_output.h
@@ -194,7 +194,7 @@
           ep_id,                                                       \
           ZB_HA_ON_OFF_OUTPUT_IN_CLUSTER_NUM,                          \
           ZB_HA_ON_OFF_OUTPUT_OUT_CLUSTER_NUM);                        \
-      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,           \
+      ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,           \
                                          ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT);     \
       ZB_AF_DECLARE_ENDPOINT_DESC(ep_name,                                           \
                               ep_id,                                    \
@@ -206,7 +206,7 @@
                 zb_zcl_cluster_desc_t),                                \
             cluster_list,                                              \
             (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
-            ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
+            ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT, reporting_info## ep_name, \
             0, NULL)
 
 /** @brief Declare On/Off Output device context.

--- a/zboss/production/include/ha/zb_ha_on_off_output.h
+++ b/zboss/production/include/ha/zb_ha_on_off_output.h
@@ -162,8 +162,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_ON_OFF_OUTPUT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                    \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name =            \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                    \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name =            \
       {                                                                                       \
         ep_id,                                                                                \
         ZB_AF_HA_PROFILE_ID,                                                                  \
@@ -205,7 +205,7 @@
                 cluster_list,                                          \
                 zb_zcl_cluster_desc_t),                                \
             cluster_list,                                              \
-            (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
             ZB_HA_ON_OFF_OUTPUT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
             0, NULL)
 

--- a/zboss/production/include/ha/zb_ha_on_off_switch.h
+++ b/zboss/production/include/ha/zb_ha_on_off_switch.h
@@ -171,8 +171,8 @@
     definitions, because these values are used to form simple descriptor type name
 */
 #define ZB_ZCL_DECLARE_ON_OFF_SWITCH_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
   {                                                                                           \
     ep_id,                                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                                      \
@@ -212,7 +212,7 @@
       NULL,                                                          \
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),        \
       cluster_list,                                                  \
-      (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name, \
+      (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name, \
       0, NULL, /* No reporting ctx */           \
       0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_range_extender.h
+++ b/zboss/production/include/ha/zb_ha_range_extender.h
@@ -130,8 +130,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_RANGE_EXTENDER_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
   {                                                                                            \
     ep_id,                                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                                       \
@@ -158,7 +158,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =               \
       ZB_HA_RANGE_EXTENDER_IN_CLUSTER_NUM, ZB_HA_RANGE_EXTENDER_OUT_CLUSTER_NUM);               \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                              \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                 \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                 \
                               0, NULL, /* No reporting ctx */                                   \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_scene_selector.h
+++ b/zboss/production/include/ha/zb_ha_scene_selector.h
@@ -145,8 +145,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SCENE_SELECTOR_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                         \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                         \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                  \
   {                                                                                            \
     ep_id,                                                                                     \
     ZB_AF_HA_PROFILE_ID,                                                                       \
@@ -175,7 +175,7 @@
       ZB_HA_SCENE_SELECTOR_IN_CLUSTER_NUM, ZB_HA_SCENE_SELECTOR_OUT_CLUSTER_NUM); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL,                \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,         \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,   \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,   \
                               0, NULL, /* No reporting ctx */                     \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_shade.h
+++ b/zboss/production/include/ha/zb_ha_shade.h
@@ -183,8 +183,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SHADE_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =         \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =         \
   {                                                                                   \
     ep_id,                                                                            \
     ZB_AF_HA_PROFILE_ID,                                                              \
@@ -229,7 +229,7 @@
     NULL,                                                                 \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_SHADE_REPORT_ATTR_COUNT,                          \
                               reporting_info## device_ctx_name,                       \
                               ZB_HA_SHADE_CVC_ATTR_COUNT, cvc_alarm_info## device_ctx_name)

--- a/zboss/production/include/ha/zb_ha_shade.h
+++ b/zboss/production/include/ha/zb_ha_shade.h
@@ -220,9 +220,9 @@
     ep_id,                                                                \
     ZB_HA_SHADE_IN_CLUSTER_NUM,                                           \
     ZB_HA_SHADE_OUT_CLUSTER_NUM);                                         \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,                \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,                \
                                      ZB_HA_SHADE_REPORT_ATTR_COUNT);                  \
-  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## device_ctx_name,            \
+  ZBOSS_DEVICE_DECLARE_LEVEL_CONTROL_CTX(cvc_alarm_info## ep_name,            \
                                          ZB_HA_SHADE_CVC_ATTR_COUNT);                 \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                             \
     0,                                                                    \
@@ -231,8 +231,8 @@
                               cluster_list,                                           \
                               (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               ZB_HA_SHADE_REPORT_ATTR_COUNT,                          \
-                              reporting_info## device_ctx_name,                       \
-                              ZB_HA_SHADE_CVC_ATTR_COUNT, cvc_alarm_info## device_ctx_name)
+                              reporting_info## ep_name,                       \
+                              ZB_HA_SHADE_CVC_ATTR_COUNT, cvc_alarm_info## ep_name)
 
 
 /** @brief Declare Shade device context.

--- a/zboss/production/include/ha/zb_ha_shade_controller.h
+++ b/zboss/production/include/ha/zb_ha_shade_controller.h
@@ -154,8 +154,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SHADE_CONTROLLER_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =         \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =         \
   {                                                                                   \
     ep_id,                                                                            \
     ZB_AF_HA_PROFILE_ID,                                                              \
@@ -195,7 +195,7 @@
     NULL,                                                                   \
                               ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                               cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               0, NULL, /* No reporting ctx */                         \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_simple_sensor.h
+++ b/zboss/production/include/ha/zb_ha_simple_sensor.h
@@ -148,8 +148,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SIMPLE_SENSOR_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                 \
   {                                                                                           \
     ep_id,                                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                                      \
@@ -180,7 +180,7 @@
                                      ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT);    \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL, \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
-                           (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,    \
+                           (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,    \
                            ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT,               \
                            reporting_info## device_ctx_name, 0, NULL)
 

--- a/zboss/production/include/ha/zb_ha_simple_sensor.h
+++ b/zboss/production/include/ha/zb_ha_simple_sensor.h
@@ -176,13 +176,13 @@
 #define ZB_HA_DECLARE_SIMPLE_SENSOR_EP(ep_name, ep_id, cluster_list)            \
   ZB_ZCL_DECLARE_SIMPLE_SENSOR_SIMPLE_DESC(ep_name, ep_id,                      \
       ZB_HA_SIMPLE_SENSOR_IN_CLUSTER_NUM, ZB_HA_SIMPLE_SENSOR_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,          \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info##ep_name,          \
                                      ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT);    \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID, 0, NULL, \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
                            (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,    \
                            ZB_HA_SIMPLE_SENSOR_REPORT_ATTR_COUNT,               \
-                           reporting_info## device_ctx_name, 0, NULL)
+                           reporting_info##ep_name, 0, NULL)
 
 
 /** @brief Declare Simple Sensor device context.

--- a/zboss/production/include/ha/zb_ha_smart_plug.h
+++ b/zboss/production/include/ha/zb_ha_smart_plug.h
@@ -179,14 +179,14 @@
 #define ZB_HA_DECLARE_SMART_PLUG_EP(ep_name, ep_id, cluster_list)           \
   ZB_ZCL_DECLARE_SMART_PLUG_SIMPLE_DESC(ep_name, ep_id,                     \
     ZB_HA_SMART_PLUG_IN_CLUSTER_NUM, ZB_HA_SMART_PLUG_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,    \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,    \
                                      ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,        \
     0,                                                                          \
     NULL,                                                                       \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
-    ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+    ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 
 /*!

--- a/zboss/production/include/ha/zb_ha_smart_plug.h
+++ b/zboss/production/include/ha/zb_ha_smart_plug.h
@@ -150,8 +150,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_SMART_PLUG_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                     \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =              \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                     \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =              \
   {                                                                                        \
     ep_id,                                                                                 \
     ZB_AF_HA_PROFILE_ID,                                                                   \
@@ -185,7 +185,7 @@
     0,                                                                          \
     NULL,                                                                       \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,       \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
     ZB_HA_SMART_PLUG_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 

--- a/zboss/production/include/ha/zb_ha_temperature_sensor.h
+++ b/zboss/production/include/ha/zb_ha_temperature_sensor.h
@@ -146,8 +146,8 @@
     @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_TEMPERATURE_SENSOR_TEMPERATURE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                          \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =   \
+  ZB_DECLARE_SIMPLE_DESC(ep_name, in_clust_num, out_clust_num);                          \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =   \
   {                                                                             \
     ep_id,                                                                      \
     ZB_AF_HA_PROFILE_ID,                                                        \
@@ -184,7 +184,7 @@
       NULL,                                                       \
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),     \
       cluster_list,                                               \
-      (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                           \
+      (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                           \
       ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
 
 /** @brief Declare Temperature Sensor device context.

--- a/zboss/production/include/ha/zb_ha_temperature_sensor.h
+++ b/zboss/production/include/ha/zb_ha_temperature_sensor.h
@@ -176,7 +176,7 @@
       ep_id,                                                      \
       ZB_HA_TEMPERATURE_SENSOR_IN_CLUSTER_NUM,                    \
       ZB_HA_TEMPERATURE_SENSOR_OUT_CLUSTER_NUM);                  \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,            \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,            \
                                      ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id,                                              \
       ZB_AF_HA_PROFILE_ID,                                        \
@@ -185,7 +185,7 @@
       ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),     \
       cluster_list,                                               \
       (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                           \
-      ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, 0, NULL)
+      ZB_HA_TEMPERATURE_SENSOR_REPORT_ATTR_COUNT, reporting_info## ep_name, 0, NULL)
 
 /** @brief Declare Temperature Sensor device context.
     @param device_ctx - device context variable name.

--- a/zboss/production/include/ha/zb_ha_test_device.h
+++ b/zboss/production/include/ha/zb_ha_test_device.h
@@ -121,8 +121,8 @@
  */
 #define ZB_HA_DECLARE_TEST_DEVICE_SIMPLE_DESC(                                     \
   ep_name, ep_id, in_clust_num, out_clust_num)                                     \
-      ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                         \
-      ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)  simple_desc_##ep_name = \
+      ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                         \
+      ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num)  simple_desc_##ep_name = \
       {                                                                            \
         ep_id,                                                                     \
         ZB_AF_HA_PROFILE_ID,                                                       \
@@ -164,7 +164,7 @@
                 cluster_list,                                      \
                 zb_zcl_cluster_desc_t),                            \
             cluster_list,                                          \
-        (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,          \
+        (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,          \
                            0, NULL, /* No reporting ctx */              \
                            0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_thermostat.h
+++ b/zboss/production/include/ha/zb_ha_thermostat.h
@@ -247,14 +247,14 @@
 #define ZB_HA_DECLARE_THERMOSTAT_EP(ep_name, ep_id, cluster_list)         \
   ZB_ZCL_DECLARE_THERMOSTAT_SIMPLE_DESC(ep_name, ep_id,                   \
     ZB_HA_THERMOSTAT_IN_CLUSTER_NUM, ZB_HA_THERMOSTAT_OUT_CLUSTER_NUM);   \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,    \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,    \
                                      ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT); \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,        \
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
-    ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
+    ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT, reporting_info## ep_name, \
     0, NULL)
 
 

--- a/zboss/production/include/ha/zb_ha_thermostat.h
+++ b/zboss/production/include/ha/zb_ha_thermostat.h
@@ -217,8 +217,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_THERMOSTAT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                     \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =              \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                     \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =              \
   {                                                                                        \
     ep_id,                                                                                 \
     ZB_AF_HA_PROFILE_ID,                                                                   \
@@ -253,7 +253,7 @@
     0,                                                                    \
     NULL,                                                                 \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list, \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                     \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                     \
     ZB_HA_THERMOSTAT_REPORT_ATTR_COUNT, reporting_info## device_ctx_name, \
     0, NULL)
 

--- a/zboss/production/include/ha/zb_ha_window_covering.h
+++ b/zboss/production/include/ha/zb_ha_window_covering.h
@@ -189,14 +189,14 @@
 #define ZB_HA_DECLARE_WINDOW_COVERING_EP(ep_name, ep_id, cluster_list)            \
   ZB_ZCL_DECLARE_WINDOW_COVERING_SIMPLE_DESC(ep_name, ep_id,                      \
     ZB_HA_WINDOW_COVERING_IN_CLUSTER_NUM, ZB_HA_WINDOW_COVERING_OUT_CLUSTER_NUM); \
-  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## device_ctx_name,            \
+  ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info## ep_name,            \
                                      ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT);    \
   ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                \
             0,                    \
             NULL,                                \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,         \
     (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
-    ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name,    \
+    ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT, reporting_info## ep_name,    \
     0, NULL) /* No CVC ctx */
 
 

--- a/zboss/production/include/ha/zb_ha_window_covering.h
+++ b/zboss/production/include/ha/zb_ha_window_covering.h
@@ -161,8 +161,8 @@
   @param out_clust_num - number of supported output clusters
 */
 #define ZB_ZCL_DECLARE_WINDOW_COVERING_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                          \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                                          \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name =                   \
   {                                                                                             \
     ep_id,                                                                                      \
     ZB_AF_HA_PROFILE_ID,                                                                        \
@@ -195,7 +195,7 @@
             0,                    \
             NULL,                                \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,         \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                             \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                             \
     ZB_HA_WINDOW_COVERING_REPORT_ATTR_COUNT, reporting_info## device_ctx_name,    \
     0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/ha/zb_ha_window_covering_controller.h
+++ b/zboss/production/include/ha/zb_ha_window_covering_controller.h
@@ -151,8 +151,8 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                             \
 */
 #define ZB_ZCL_DECLARE_WINDOW_COVERING_CONTROLLER_SIMPLE_DESC(                \
   ep_name, ep_id, in_clust_num, out_clust_num)                                \
-  ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                        \
-  ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num) simple_desc_##ep_name = \
+  ZB_DECLARE_SIMPLE_DESC(ep_name,in_clust_num, out_clust_num);                        \
+  ZB_AF_SIMPLE_DESC_TYPE(ep_name, in_clust_num, out_clust_num) simple_desc_##ep_name = \
   {                                                                           \
     ep_id,                                                                    \
     ZB_AF_HA_PROFILE_ID,                                                      \
@@ -186,7 +186,7 @@ zb_zcl_cluster_desc_t cluster_list_name[] =                             \
                           NULL,                                                   \
                           ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), \
                           cluster_list,                                           \
-                              (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,       \
+                              (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,       \
                               0, NULL, /* No reporting ctx */                         \
                               0, NULL) /* No CVC ctx */
 

--- a/zboss/production/include/zboss_api_af.h
+++ b/zboss/production/include/zboss_api_af.h
@@ -217,10 +217,11 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
 
 /** @cond DOXYGEN_INTERNAL_DOC */
 #define CAT5(a, b, c, d, e) a##b##c##d##e
+#define CAT6(a, b, c, d, e,f) a##b##c##d##e##f
 /** @endcond */ /* DOXYGEN_INTERNAL_DOC */
 
 /** Generate simple descriptor type name */
-#define ZB_AF_SIMPLE_DESC_TYPE(in_num, out_num)  CAT5(zb_af_simple_desc_,in_num,_,out_num,_t)
+#define ZB_AF_SIMPLE_DESC_TYPE(epname, in_num, out_num)  CAT6(zb_af_simple_desc_,epname, in_num,_,out_num,_t)
 
 /**
    Declares Simple descriptor type
@@ -234,8 +235,9 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
    @endcode
  */
 
-#define ZB_DECLARE_SIMPLE_DESC(in_clusters_count, out_clusters_count)   \
-  typedef ZB_PACKED_PRE struct zb_af_simple_desc_ ## in_clusters_count ## _ ## out_clusters_count ## _s \
+#define ZB_DECLARE_SIMPLE_DESC(epname, in_clusters_count, out_clusters_count)   \
+/* #define HO_ ## in_clusters_count ## _ ## out_clusters_count 1 \ */ \
+  typedef ZB_PACKED_PRE struct zb_af_simple_desc_ ## epname ## in_clusters_count ## _ ## out_clusters_count ## _s \
   {                                                                                       \
     zb_uint8_t    endpoint;                 /* Endpoint */                                \
     zb_uint16_t   app_profile_id;           /* Application profile identifier */          \
@@ -247,7 +249,7 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
     /* Application input and output cluster list */                                       \
     zb_uint16_t   app_cluster_list[(in_clusters_count) + (out_clusters_count)];               \
   } ZB_PACKED_STRUCT                                                                      \
-  zb_af_simple_desc_ ## in_clusters_count ## _ ## out_clusters_count ## _t
+  zb_af_simple_desc_ ## epname ## in_clusters_count ## _ ## out_clusters_count ## _t 
 
 /** @} */ /* af_data_service */
 
@@ -256,9 +258,9 @@ typedef ZB_PACKED_PRE struct zb_af_node_power_desc_s
  * @{
  */
 /** General descriptor type */
-ZB_DECLARE_SIMPLE_DESC(1,1);
+ZB_DECLARE_SIMPLE_DESC(general, 1,1);
 /** ZDO descriptor type */
-ZB_DECLARE_SIMPLE_DESC(8,9);
+ZB_DECLARE_SIMPLE_DESC(general, 8,9);
 /** @} */ /* af_management_service */
 
 /**
@@ -350,7 +352,8 @@ typedef ZB_PACKED_PRE struct zb_af_endpoint_desc_s
   void* reserved_ptr; /*!< Unused parameter (reserved for future use) */
   zb_uint8_t cluster_count;       /*!< Number of supported clusters */
   struct zb_zcl_cluster_desc_s *cluster_desc_list;  /*!< Supported clusters list */
-  zb_af_simple_desc_1_1_t *simple_desc; /*!< Simple descriptor */
+  /* zb_af_simple_desc_general_1_1_t *simple_desc; */ /*!< Simple descriptor */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) * simple_desc;
 #if defined ZB_ENABLE_ZLL || defined DOXYGEN
   zb_uint8_t group_id_count;
 #endif /* defined ZB_ENABLE_ZLL || defined DOXYGEN */

--- a/zboss/production/include/zboss_api_zdo.h
+++ b/zboss/production/include/zboss_api_zdo.h
@@ -1429,7 +1429,7 @@ typedef zb_zdo_desc_resp_hdr_t            zb_zdo_user_desc_conf_hdr_t;
 typedef ZB_PACKED_PRE struct zb_zdo_simple_desc_resp_s
 {
   zb_zdo_simple_desc_resp_hdr_t hdr;  /*!< header for response */
-  zb_af_simple_desc_1_1_t simple_desc; /*!< Simple Descriptor */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) simple_desc; /*!< Simple Descriptor */
 } ZB_PACKED_STRUCT
 zb_zdo_simple_desc_resp_t;
 

--- a/zboss/production/include/zcl/zb_zcl_control4_networking.h
+++ b/zboss/production/include/zcl/zb_zcl_control4_networking.h
@@ -408,7 +408,7 @@ enum zb_zcl_control4_networking_cmd_e
     NULL,                                                            \
     ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t),          \
     cluster_list,                                                    \
-    (zb_af_simple_desc_1_1_t*)&simple_desc_##ep_name,                \
+    (ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*)&simple_desc_##ep_name,                \
     0, NULL, 0, NULL)
 
 /**

--- a/zboss/production/src/include/zb_zdo.h
+++ b/zboss/production/src/include/zb_zdo.h
@@ -367,7 +367,7 @@ void zb_copy_power_desc(zb_af_node_power_desc_t *dst_desc, zb_af_node_power_desc
    @param dst_desc - destination descriptor
    @param src_desc - source descriptor
 */
-void zb_copy_simple_desc(zb_af_simple_desc_1_1_t* dst_desc, zb_af_simple_desc_1_1_t*src_desc);
+void zb_copy_simple_desc(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)* dst_desc, ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1)*src_desc);
 
 /**
    NWK_addr_req  primitive.
@@ -1209,7 +1209,7 @@ void zb_set_network_ed_role_legacy(zb_uint32_t channel_mask);
   @par
 
 */
-void zb_set_simple_descriptor(zb_af_simple_desc_1_1_t *simple_desc,
+void zb_set_simple_descriptor(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc,
                               zb_uint8_t  endpoint, zb_uint16_t app_profile_id,
                               zb_uint16_t app_device_id, zb_bitfield_t app_device_version,
                               zb_uint8_t app_input_cluster_count, zb_uint8_t app_output_cluster_count);
@@ -1225,7 +1225,7 @@ void zb_set_simple_descriptor(zb_af_simple_desc_1_1_t *simple_desc,
   @par
 
 */
-void zb_set_input_cluster_id(zb_af_simple_desc_1_1_t *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
+void zb_set_input_cluster_id(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
 
 /*! @brief Set output cluster item
     @param simple_desc - pointer to simple descriptor
@@ -1237,7 +1237,7 @@ void zb_set_input_cluster_id(zb_af_simple_desc_1_1_t *simple_desc, zb_uint8_t cl
   @par
 
 */
-void zb_set_output_cluster_id(zb_af_simple_desc_1_1_t *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
+void zb_set_output_cluster_id(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc, zb_uint8_t cluster_number, zb_uint16_t cluster_id);
 
 /**
   Set default descriptors values for FFD.
@@ -1265,7 +1265,7 @@ void zb_set_default_ed_descriptor_values(void);
   @par
 
  */
-zb_ret_t zb_add_simple_descriptor(zb_af_simple_desc_1_1_t *simple_desc);
+zb_ret_t zb_add_simple_descriptor(ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc);
 
 /**
   Set node descriptor for FFD

--- a/zboss/production/src/include/zb_zdo_globals.h
+++ b/zboss/production/src/include/zb_zdo_globals.h
@@ -73,11 +73,11 @@ typedef struct zb_zdo_configuration_attributes_e
 
   zb_af_node_desc_t       node_desc;        /*!< Node Descriptors */
   zb_af_node_power_desc_t node_power_desc;  /*!< Node Power Descriptors */
-  zb_af_simple_desc_8_9_t zdo_simple_desc; /* TODO: remove it, ZDO simple descriptor is not needed - simple descriptors for EP >= 1 are used */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 8, 9) zdo_simple_desc; /* TODO: remove it, ZDO simple descriptor is not needed - simple descriptors for EP >= 1 are used */
   /* TODO: make real list support, if multiple EP are supported */
   /* TODO: each Zigbee device application declares a device context and a list of EPs. Each EP
      stores its simple descriptor => no need store it here, it is better to use that storage */
-  zb_af_simple_desc_1_1_t *simple_desc_list[ZB_MAX_EP_NUMBER];  /*!< Simple Descriptors table */
+  ZB_AF_SIMPLE_DESC_TYPE(general, 1, 1) *simple_desc_list[ZB_MAX_EP_NUMBER];  /*!< Simple Descriptors table */
   zb_uint8_t simple_desc_number;                                /*!< Number elements of Simple Descriptors table */
 
 #ifndef ZB_LITE_NO_END_DEVICE_BIND


### PR DESCRIPTION
Hi,
The Zboss implementation used with NCS won't let us create more than one endpoint of the same type.  For example, I can have a dimmable light and an outlet, but not two outlets.

This is because of the way ZB_DECLARE_SIMPLE_DESC and the resulting type depends only on the numbers of in/out clusters, and doesn't worry about if such a combination may have existed before.  

I detailed the problem and this fix at
https://devzone.nordicsemi.com/f/nordic-q-a/84787/zigbee-multiple-same-type-endpoints-conflict-and-proposed-fix
It is for the most part completely transparent to ZCL users and allows me to have a device with 2 outlets and 4 binary inputs without issue.  It'd be nice if this was the default.
