### PR TITLE
Upmerge 22-03-03

### DIFF
--- a/gzll/doc/integration_notes.rst
+++ b/gzll/doc/integration_notes.rst
@@ -23,7 +23,7 @@ It should be called by only a single thread in an RTOS.
 Configuration
 *************
 
-In the |NCS|, you can enable the GZLL library using the :kconfig:`CONFIG_GZLL` Kconfig option.
+In the |NCS|, you can enable the GZLL library using the :kconfig:option:`CONFIG_GZLL` Kconfig option.
 Look for the menu item "Enable Gazell Link Layer".
 The build system will link in the appropriate library for your nRF5 SoC.
 

--- a/nrf_802154/doc/CHANGELOG.rst
+++ b/nrf_802154/doc/CHANGELOG.rst
@@ -61,7 +61,7 @@ Notable changes
 Bug fixes
 =========
 
-* Fixed an issue where it would not be possible to transmit frames with invalid Auxiliary Security Header if :kconfig:`CONFIG_NRF_802154_ENCRYPTION` was set to ``n``. (KRKNWK-11218)
+* Fixed an issue where it would not be possible to transmit frames with invalid Auxiliary Security Header if :kconfig:option:`CONFIG_NRF_802154_ENCRYPTION` was set to ``n``. (KRKNWK-11218)
 * Fix an issue with the IE Vendor OUI endianness. (KRKNWK-10633)
 * Fixed various bugs in the MAC Encryption layer. (KRKNWK-10646)
 

--- a/nrf_security/doc/backend_config.rst
+++ b/nrf_security/doc/backend_config.rst
@@ -17,21 +17,21 @@ Configuring backends
 
 The legacy configuration does not allow multiple backends being enabled at the same time. 
 
-The choice of implementation is controlled by setting :kconfig:`CONFIG_CC3XX_BACKEND` for devices with the CryptoCell hardware peripheral, or :Kconfig:`CONFIG_OBERON_BACKEND`.
+The choice of implementation is controlled by setting :kconfig:option:`CONFIG_CC3XX_BACKEND` for devices with the CryptoCell hardware peripheral, or :kconfig:option:`CONFIG_OBERON_BACKEND`.
 
 .. _nrf_security_backends_cc3xx:
 
 cc3xx backend
 =============
 
-Setting the Kconfig option :kconfig:`CONFIG_CC3XX_BACKEND` enables legacy crypto support for hardware accelerated cryptography using :ref:`nrf_cc3xx_mbedcrypto_readme`
+Setting the Kconfig option :kconfig:option:`CONFIG_CC3XX_BACKEND` enables legacy crypto support for hardware accelerated cryptography using :ref:`nrf_cc3xx_mbedcrypto_readme`
 
 .. _nrf_security_backends_oberon:
 
 Oberon backend
 ==============
 
-Setting the Kconfig option :kconfig:`CONFIG_CC3XX_OBERON` enables legacy crypto support using :ref:`nrf_oberon_readme`
+Setting the Kconfig option :kconfig:option:`CONFIG_CC3XX_OBERON` enables legacy crypto support using :ref:`nrf_oberon_readme`
 
 
 .. _nrf_security_backends_orig_mbedtls:
@@ -46,7 +46,7 @@ The Original Mbed TLS backend is no longer available as a configuration option, 
 AES configuration
 *****************
 
-The AES core is enabled with the Kconfig option :kconfig:`CONFIG_MBEDTLS_AES_C`.
+The AES core is enabled with the Kconfig option :kconfig:option:`CONFIG_MBEDTLS_AES_C`.
 
 This enables AES ECB cipher mode and allows the ciphers and modes CTR, OFB, CFB, CBC, XTS, CMAC, CCM/CCM*, and GCM to be configured.
 
@@ -79,19 +79,19 @@ AES cipher configuration
 
 AES cipher modes can be configured by setting Kconfig variables in the following table:
 
-+--------------+---------------------------------------------+----------------------------------------+
-| Cipher mode  | Configurations                              | Note                                   |
-+==============+=============================================+========================================+
-| CTR          | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_CTR`   |                                        |
-+--------------+---------------------------------------------+----------------------------------------+
-| CBC          | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_CBC`   |                                        |
-+--------------+---------------------------------------------+----------------------------------------+
-| CFB          | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_CFB`   | nrf_oberon only                        |
-+--------------+---------------------------------------------+----------------------------------------+
-| OFB          | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_OFB`   | nrf_oberon only                        |
-+--------------+---------------------------------------------+----------------------------------------+
-| XTS          | :kconfig:`CONFIG_MBEDTLS_CIPHER_MODE_XTS`   | nrf_oberon only                        |
-+--------------+---------------------------------------------+----------------------------------------+
++--------------+----------------------------------------------------+----------------------------------------+
+| Cipher mode  | Configurations                                     | Note                                   |
++==============+====================================================+========================================+
+| CTR          | :kconfig:option:`CONFIG_MBEDTLS_CIPHER_MODE_CTR`   |                                        |
++--------------+----------------------------------------------------+----------------------------------------+
+| CBC          | :kconfig:option:`CONFIG_MBEDTLS_CIPHER_MODE_CBC`   |                                        |
++--------------+----------------------------------------------------+----------------------------------------+
+| CFB          | :kconfig:option:`CONFIG_MBEDTLS_CIPHER_MODE_CFB`   | nrf_oberon only                        |
++--------------+----------------------------------------------------+----------------------------------------+
+| OFB          | :kconfig:option:`CONFIG_MBEDTLS_CIPHER_MODE_OFB`   | nrf_oberon only                        |
++--------------+----------------------------------------------------+----------------------------------------+
+| XTS          | :kconfig:option:`CONFIG_MBEDTLS_CIPHER_MODE_XTS`   | nrf_oberon only                        |
++--------------+----------------------------------------------------+----------------------------------------+
 
 .. note::
    * AES cipher modes are dependent on enabling AES core support according to `AES configuration`_.
@@ -164,7 +164,7 @@ Feature support
 CMAC configuration
 ******************
 
-Cipher-based Message Authentication Code (CMAC) support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_CMAC_C` Kconfig variable.
+Cipher-based Message Authentication Code (CMAC) support can be configured by setting the :kconfig:option:`CONFIG_MBEDTLS_CMAC_C` Kconfig variable.
 
 Feature support
 ===============
@@ -193,19 +193,19 @@ AEAD configurations
 
 Authenticated Encryption with Associated Data (AEAD) can be configured by setting Kconfig variables in the following table:
 
-+--------------+-----------------------------------------+-----------------------------------------+
-| AEAD cipher  | Configurations                          | Note                                    |
-+==============+=========================================+=========================================+
-| AES CCM/CCM* | :kconfig:`CONFIG_MBEDTLS_CCM_C`         |                                         |
-+--------------+-----------------------------------------+-----------------------------------------+
-| AES GCM      | :kconfig:`CONFIG_MBEDTLS_GCM_C`         | nrf_oberon or cc312                     |
-+--------------+-----------------------------------------+-----------------------------------------+
-| ChaCha20     | :kconfig:`CONFIG_MBEDTLS_CHACHA20_C`    |                                         |
-+--------------+-----------------------------------------+-----------------------------------------+
-| Poly1305     | :kconfig:`CONFIG_MBEDTLS_POLY1305_C`    |                                         |
-+--------------+-----------------------------------------+-----------------------------------------+
-| ChaCha-Poly  | :kconfig:`CONFIG_MBEDTLS_CHACHAPOLY_C`  | Requires `Poly1305` and `ChaCha20`      |
-+--------------+-----------------------------------------+-----------------------------------------+
++--------------+------------------------------------------------+-----------------------------------------+
+| AEAD cipher  | Configurations                                 | Note                                    |
++==============+================================================+=========================================+
+| AES CCM/CCM* | :kconfig:option:`CONFIG_MBEDTLS_CCM_C`         |                                         |
++--------------+------------------------------------------------+-----------------------------------------+
+| AES GCM      | :kconfig:option:`CONFIG_MBEDTLS_GCM_C`         | nrf_oberon or cc312                     |
++--------------+------------------------------------------------+-----------------------------------------+
+| ChaCha20     | :kconfig:option:`CONFIG_MBEDTLS_CHACHA20_C`    |                                         |
++--------------+------------------------------------------------+-----------------------------------------+
+| Poly1305     | :kconfig:option:`CONFIG_MBEDTLS_POLY1305_C`    |                                         |
++--------------+------------------------------------------------+-----------------------------------------+
+| ChaCha-Poly  | :kconfig:option:`CONFIG_MBEDTLS_CHACHAPOLY_C`  | Requires `Poly1305` and `ChaCha20`      |
++--------------+------------------------------------------------+-----------------------------------------+
 
 .. note::
    * AEAD AES cipher modes are dependent on enabling AES core support according to `AES configuration`_.
@@ -262,7 +262,7 @@ Feature support
 DHM configurations
 ******************
 
-Diffie-Hellman-Merkle (DHM) support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_DHM_C` Kconfig variable.
+Diffie-Hellman-Merkle (DHM) support can be configured by setting the :kconfig:option:`CONFIG_MBEDTLS_DHM_C` Kconfig variable.
 
 Feature support
 ===============
@@ -283,9 +283,9 @@ ECC configurations
 
 Elliptic Curve Cryptography (ECC) configuration provides support for Elliptic Curve over GF(p).
 
-ECC core support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_ECP_C` Kconfig variable.
+ECC core support can be configured by setting the :kconfig:option:`CONFIG_MBEDTLS_ECP_C` Kconfig variable.
 
-Enabling :kconfig:`CONFIG_MBEDTLS_ECP_C` will activate configuration options that depend upon ECC, such as ECDH, ECDSA, ECJPAKE, and a selection of ECC curves to support in the system.
+Enabling :kconfig:option:`CONFIG_MBEDTLS_ECP_C` will activate configuration options that depend upon ECC, such as ECDH, ECDSA, ECJPAKE, and a selection of ECC curves to support in the system.
 
 Feature support
 ===============
@@ -321,13 +321,13 @@ Feature support
 ECDH configurations
 *******************
 
-Elliptic Curve Diffie-Hellman (ECDH) support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_ECDH_C` Kconfig variable.
+Elliptic Curve Diffie-Hellman (ECDH) support can be configured by setting the :kconfig:option:`CONFIG_MBEDTLS_ECDH_C` Kconfig variable.
 
-+--------------+--------------------------------------+
-| Algorithm    | Configurations                       |
-+==============+======================================+
-| ECDH         | :kconfig:`CONFIG_MBEDTLS_ECDH_C`     |
-+--------------+--------------------------------------+
++--------------+---------------------------------------------+
+| Algorithm    | Configurations                              |
++==============+=============================================+
+| ECDH         | :kconfig:option:`CONFIG_MBEDTLS_ECDH_C`     |
++--------------+---------------------------------------------+
 
 .. note::
    * ECDH support depends upon `ECC Configurations`_ being enabled.
@@ -368,13 +368,13 @@ Feature support
 ECDSA configurations
 ********************
 
-Elliptic Curve Digital Signature Algorithm (ECDSA) support can be configured be configured by setting the :kconfig:`CONFIG_MBEDTLS_ECDSA_C` Kconfig variable.
+Elliptic Curve Digital Signature Algorithm (ECDSA) support can be configured be configured by setting the :kconfig:option:`CONFIG_MBEDTLS_ECDSA_C` Kconfig variable.
 
-+--------------+---------------------------------------+
-| Algorithm    | Configurations                        |
-+==============+=======================================+
-| ECDSA        | :kconfig:`CONFIG_MBEDTLS_ECDSA_C`     |
-+--------------+---------------------------------------+
++--------------+----------------------------------------------+
+| Algorithm    | Configurations                               |
++==============+==============================================+
+| ECDSA        | :kconfig:option:`CONFIG_MBEDTLS_ECDSA_C`     |
++--------------+----------------------------------------------+
 
 .. note::
    * ECDSA support depends upon `ECC Configurations`_ being enabled.
@@ -415,13 +415,13 @@ Feature support
 ECJPAKE configurations
 **********************
 
-Elliptic Curve, Password Authenticated Key Exchange by Juggling (ECJPAKE) support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_ECJPAKE_C` Kconfig variable.
+Elliptic Curve, Password Authenticated Key Exchange by Juggling (ECJPAKE) support can be configured by setting the :kconfig:option:`CONFIG_MBEDTLS_ECJPAKE_C` Kconfig variable.
 
-+--------------+---------------------------------------+
-| Algorithm    | Configurations                        |
-+==============+=======================================+
-| ECJPAKE      | :kconfig:`CONFIG_MBEDTLS_ECJPAKE_C`   |
-+--------------+---------------------------------------+
++--------------+----------------------------------------------+
+| Algorithm    | Configurations                               |
++==============+==============================================+
+| ECJPAKE      | :kconfig:option:`CONFIG_MBEDTLS_ECJPAKE_C`   |
++--------------+----------------------------------------------+
 
 .. note::
    ECJPAKE support depends upon `ECC Configurations`_ being enabled.
@@ -447,27 +447,27 @@ It is possible to configure the curves that should be supported in the system de
 
 The following table shows the curves that can be enabled.
 
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| Curve                       | Configurations                                      | Note                     |
-+=============================+=====================================================+==========================+
-| NIST secp192r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP192R1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp224r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP224R1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp256r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp384r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| NIST secp521r1              | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP521R1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| Koblitz secp192k1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP192K1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| Koblitz secp224k1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP224K1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| Koblitz secp256k1           | :kconfig:`CONFIG_MBEDTLS_ECP_DP_SECP256K1_ENABLED`  |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
-| Curve25519                  | :kconfig:`CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED` |                          |
-+-----------------------------+-----------------------------------------------------+--------------------------+
++-----------------------------+------------------------------------------------------------+--------------------------+
+| Curve                       | Configurations                                             | Note                     |
++=============================+============================================================+==========================+
+| NIST secp192r1              | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP192R1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| NIST secp224r1              | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP224R1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| NIST secp256r1              | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| NIST secp384r1              | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| NIST secp521r1              | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP521R1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| Koblitz secp192k1           | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP192K1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| Koblitz secp224k1           | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP224K1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| Koblitz secp256k1           | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_SECP256K1_ENABLED`  |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
+| Curve25519                  | :kconfig:option:`CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED` |                          |
++-----------------------------+------------------------------------------------------------+--------------------------+
 
 .. note::
    * The :ref:`nrf_oberon_readme` only supports ECC curve secp224r1 and secp256r1.
@@ -477,7 +477,7 @@ The following table shows the curves that can be enabled.
 RSA configurations
 ******************
 
-Rivest-Shamir-Adleman (RSA) support can be configured by setting the :kconfig:`CONFIG_MBEDTLS_RSA_C` Kconfig variable.
+Rivest-Shamir-Adleman (RSA) support can be configured by setting the :kconfig:option:`CONFIG_MBEDTLS_RSA_C` Kconfig variable.
 
 Feature support
 ===============
@@ -498,19 +498,19 @@ Secure Hash configurations
 
 The Secure Hash algorithms can be configured by setting Kconfig variables in the following table:
 
-+--------------+--------------------+--------------------------------------+
-| Algorithm    | Support            | Backend selection                    |
-+==============+====================+======================================+
-| SHA-1        |                    | :kconfig:`CONFIG_MBEDTLS_SHA1_C`     |
-+--------------+--------------------+--------------------------------------+
-| SHA-224      |                    | :kconfig:`CONFIG_MBEDTLS_SHA224_C`   |
-+--------------+--------------------+--------------------------------------+
-| SHA-256      |                    | :kconfig:`CONFIG_MBEDTLS_SHA256_C`   |
-+--------------+--------------------+--------------------------------------+
-| SHA-384      |                    | :kconfig:`CONFIG_MBEDTLS_SHA384_C`   |
-+--------------+--------------------+--------------------------------------+
-| SHA-512      |                    | :kconfig:`CONFIG_MBEDTLS_SHA512_C`   |
-+--------------+--------------------+--------------------------------------+
++--------------+--------------------+---------------------------------------------+
+| Algorithm    | Support            | Backend selection                           |
++==============+====================+=============================================+
+| SHA-1        |                    | :kconfig:option:`CONFIG_MBEDTLS_SHA1_C`     |
++--------------+--------------------+---------------------------------------------+
+| SHA-224      |                    | :kconfig:option:`CONFIG_MBEDTLS_SHA224_C`   |
++--------------+--------------------+---------------------------------------------+
+| SHA-256      |                    | :kconfig:option:`CONFIG_MBEDTLS_SHA256_C`   |
++--------------+--------------------+---------------------------------------------+
+| SHA-384      |                    | :kconfig:option:`CONFIG_MBEDTLS_SHA384_C`   |
++--------------+--------------------+---------------------------------------------+
+| SHA-512      |                    | :kconfig:option:`CONFIG_MBEDTLS_SHA512_C`   |
++--------------+--------------------+---------------------------------------------+
 
 Feature support
 ===============

--- a/nrf_security/doc/configuration.rst
+++ b/nrf_security/doc/configuration.rst
@@ -12,7 +12,7 @@ You can enable the Nordic Security Module using `PSA driver support`_ or with `L
 PSA driver support
 ******************
 
-To enable Nordic Security Module with the PSA driver support, set the :kconfig:`CONFIG_NRF_SECURITY` Kconfig option along with additional configuration options, as described in :ref:`nrf_security_driver_config`.
+To enable Nordic Security Module with the PSA driver support, set the :kconfig:option:`CONFIG_NRF_SECURITY` Kconfig option along with additional configuration options, as described in :ref:`nrf_security_driver_config`.
 
 The PSA driver support requires using PSA Crypto APIs.
 
@@ -30,11 +30,11 @@ Custom Mbed TLS configuration files
 
 The Nordic Security Module (nrf_security) Kconfig options are used to generate an Mbed TLS configuration file.
 
-Although not recommended, it is possible to provide a custom Mbed TLS configuration file by disabling :kconfig:`CONFIG_GENERATE_MBEDTLS_CFG_FILE`.
+Although not recommended, it is possible to provide a custom Mbed TLS configuration file by disabling :kconfig:option:`CONFIG_GENERATE_MBEDTLS_CFG_FILE`.
 See :ref:`nrf_security_tls_header`.
 
 Building with TF-M
 ******************
 
-If :kconfig:`CONFIG_BUILD_WITH_TFM` is enabled together with :kconfig:`CONFIG_NRF_SECURITY`, the TF-M secure image will enable the use of the hardware acceleration of Arm CryptoCell.
+If :kconfig:option:`CONFIG_BUILD_WITH_TFM` is enabled together with :kconfig:option:`CONFIG_NRF_SECURITY`, the TF-M secure image will enable the use of the hardware acceleration of Arm CryptoCell.
 In this case, the Kconfig configurations in the Nordic Security Module control the features enabled in TF-M.

--- a/nrf_security/doc/driver_config.rst
+++ b/nrf_security/doc/driver_config.rst
@@ -18,13 +18,13 @@ Multiple PSA drivers can be enabled at the same time, with added support for fin
 
 To enable a PSA driver, set the configurations according to the following table:
 
-+---------------+-------------------------------------------+------------------------------------------------+
-| PSA driver    | Configuration option                      | Notes                                          |
-+================+==========================================+================================================+
-| nrf_cc3xx     | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_CC3XX` | Only on nRF52840, nRF9160, and nRF5340 devices |
-+---------------+-------------------------------------------+------------------------------------------------+
-| nrf_oberon    | :kconfig:`CONFIG_PSA_RYPTO_DRIVER_OBERON` |                                                |
-+---------------+-------------------------------------------+------------------------------------------------+
++---------------+--------------------------------------------------+------------------------------------------------+
+| PSA driver    | Configuration option                             | Notes                                          |
++===============+==================================================+================================================+
+| nrf_cc3xx     | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_CC3XX` | Only on nRF52840, nRF9160, and nRF5340 devices |
++---------------+--------------------------------------------------+------------------------------------------------+
+| nrf_oberon    | :kconfig:option:`CONFIG_PSA_RYPTO_DRIVER_OBERON` |                                                |
++---------------+--------------------------------------------------+------------------------------------------------+
 
 If multiple drivers are enabled, the first ordered item in this table takes precedence for an enabled cryptographic feature, unless the driver does not enable or support it.
 
@@ -37,23 +37,23 @@ AES cipher configuration
 
 AES cipher modes can be enabled by setting one or more of the following Kconfig options:
 
-+----------------+-----------------------------------------------+
-| Cipher mode    | Configuration option                          |
-+================+===============================================+
-| ECB_NO_PADDING | :kconfig:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING` |
-+----------------+-----------------------------------------------+
-| CBC_NO_PADDING | :kconfig:`CONFIG_PSA_WANT_ALG_CBC_NO_PADDING` |
-+----------------+-----------------------------------------------+
-| CBC_PKCS7      | :kconfig:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`      |
-+----------------+-----------------------------------------------+
-| CFB            | :kconfig:`CONFIG_PSA_WANT_ALG_CFB`            |
-+----------------+-----------------------------------------------+
-| CTR            | :kconfig:`CONFIG_PSA_WANT_ALG_CTR`            |
-+----------------+-----------------------------------------------+
-| OFB            | :kconfig:`CONFIG_PSA_WANT_ALG_OFB`            |
-+----------------+-----------------------------------------------+
-| XTS            | :kconfig:`CONFIG_PSA_WANT_ALG_XTS`            |
-+----------------+-----------------------------------------------+
++----------------+------------------------------------------------------+
+| Cipher mode    | Configuration option                                 |
++================+======================================================+
+| ECB_NO_PADDING | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECB_NO_PADDING` |
++----------------+------------------------------------------------------+
+| CBC_NO_PADDING | :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_NO_PADDING` |
++----------------+------------------------------------------------------+
+| CBC_PKCS7      | :kconfig:option:`CONFIG_PSA_WANT_ALG_CBC_PKCS7`      |
++----------------+------------------------------------------------------+
+| CFB            | :kconfig:option:`CONFIG_PSA_WANT_ALG_CFB`            |
++----------------+------------------------------------------------------+
+| CTR            | :kconfig:option:`CONFIG_PSA_WANT_ALG_CTR`            |
++----------------+------------------------------------------------------+
+| OFB            | :kconfig:option:`CONFIG_PSA_WANT_ALG_OFB`            |
++----------------+------------------------------------------------------+
+| XTS            | :kconfig:option:`CONFIG_PSA_WANT_ALG_XTS`            |
++----------------+------------------------------------------------------+
 
 
 AES cipher driver configuration
@@ -61,23 +61,23 @@ AES cipher driver configuration
 
 You can use the Kconfig options from the following table for fine-grained control over which drivers provide AES cipher support:
 
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
-| Cipher mode    | nrf_cc3xx driver support                                     | nrf_oberon driver support                                     |
-+================+==============================================================+===============================================================+
-| ECB_NO_PADDING | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_CC3XX` | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_OBERON` |
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
-| CBC_NO_PADDING | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_CC3XX` | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_OBERON` |
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
-| CBC_PKCS7      | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_PKCS7_CC3XX`      | Not supported                                                 |
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
-| CFB            | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CFB_CC3XX`            | Not supported                                                 |
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
-| CTR            | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_CC3XX`            | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_OBERON`            |
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
-| OFB            | Not supported                                                | Not supported                                                 |
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
-| XTS            | Not supported                                                | Not supported                                                 |
-+----------------+--------------------------------------------------------------+---------------------------------------------------------------+
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| Cipher mode    | nrf_cc3xx driver support                                            | nrf_oberon driver support                                            |
++================+=====================================================================+======================================================================+
+| ECB_NO_PADDING | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECB_NO_PADDING_OBERON` |
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CBC_NO_PADDING | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_NO_PADDING_OBERON` |
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CBC_PKCS7      | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CBC_PKCS7_CC3XX`      | Not supported                                                        |
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CFB            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CFB_CC3XX`            | Not supported                                                        |
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| CTR            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_CC3XX`            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CTR_OBERON`            |
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| OFB            | Not supported                                                       | Not supported                                                        |
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
+| XTS            | Not supported                                                       | Not supported                                                        |
++----------------+---------------------------------------------------------------------+----------------------------------------------------------------------+
 
 .. note::
    * If an AES cipher mode is enabled and no PSA driver enables or supports it, then :ref:`nrf_security_drivers_builtin` support is enabled and used.
@@ -89,26 +89,26 @@ MAC configuration
 
 You can enable MAC support by setting one or more Kconfig options in the following table:
 
-+----------------+-------------------------------------+
-| MAC cipher     | Configuration option                |
-+================+=====================================+
-| ECB_NO_PADDING | :kconfig:`CONFIG_PSA_WANT_ALG_CMAC` |
-+----------------+-------------------------------------+
-| CBC_NO_PADDING | :kconfig:`CONFIG_PSA_WANT_ALG_HMAC` |
-+----------------+-------------------------------------+
++----------------+--------------------------------------------+
+| MAC cipher     | Configuration option                       |
++================+============================================+
+| ECB_NO_PADDING | :kconfig:option:`CONFIG_PSA_WANT_ALG_CMAC` |
++----------------+--------------------------------------------+
+| CBC_NO_PADDING | :kconfig:option:`CONFIG_PSA_WANT_ALG_HMAC` |
++----------------+--------------------------------------------+
 
 MAC driver configurations
 =========================
 
 You can use the Kconfig options in the following table for fine-grained control over which drivers provide AEAD support:
 
-+----------------+----------------------------------------------------+----------------------------+
-| MAC cipher     | nrf_cc3xx driver support                           | nrf_oberon driver support  |
-+================+====================================================+============================+
-| ECB_NO_PADDING | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CMAC_CC3XX` | Not supported              |
-+----------------+----------------+-----------------------------------+----------------------------+
-| CBC_NO_PADDING | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_HMAC_CC3XX` | Not supported              |
-+----------------+----------------+-----------------------------------+----------------------------+
++----------------+-----------------------------------------------------------+----------------------------+
+| MAC cipher     | nrf_cc3xx driver support                                  | nrf_oberon driver support  |
++================+===========================================================+============================+
+| ECB_NO_PADDING | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CMAC_CC3XX` | Not supported              |
++----------------+----------------+------------------------------------------+----------------------------+
+| CBC_NO_PADDING | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_HMAC_CC3XX` | Not supported              |
++----------------+----------------+------------------------------------------+----------------------------+
 
 .. note::
    * If a MAC algorithm is enabled and no PSA driver enables or supports it, then :ref:`nrf_security_drivers_builtin` support is enabled and used.
@@ -121,15 +121,15 @@ AEAD configurations
 
 You can enable Authenticated Encryption with Associated Data (AEAD) by setting one or more Kconfig options in the following table:
 
-+----------------+--------------------------------------------------+
-| AEAD cipher    | Configuration option                             |
-+================+==================================================+
-| AES CCM        | :kconfig:`CONFIG_PSA_WANT_ALG_CCM`               |
-+----------------+--------------------------------------------------+
-| AES GCM        | :kconfig:`CONFIG_PSA_WANT_ALG_GCM`               |
-+----------------+--------------------------------------------------+
-| ChaCha/Poly    | :kconfig:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305` |
-+----------------+--------------------------------------------------+
++----------------+---------------------------------------------------------+
+| AEAD cipher    | Configuration option                                    |
++================+=========================================================+
+| AES CCM        | :kconfig:option:`CONFIG_PSA_WANT_ALG_CCM`               |
++----------------+---------------------------------------------------------+
+| AES GCM        | :kconfig:option:`CONFIG_PSA_WANT_ALG_GCM`               |
++----------------+---------------------------------------------------------+
+| ChaCha/Poly    | :kconfig:option:`CONFIG_PSA_WANT_ALG_CHACHA20_POLY1305` |
++----------------+---------------------------------------------------------+
 
 
 AEAD driver configurations
@@ -137,15 +137,15 @@ AEAD driver configurations
 
 You can use the Kconfig options in the following table for fine-grained control over which drivers provide AEAD support:
 
-+----------------+-----------------------------------------------------------------+------------------------------------------------------------------+
-| AEAD cipher    | nrf_cc3xx driver support                                        | nrf_oberon driver support                                        |
-+================+=================================================================+==================================================================+
-| AES CCM        | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_CC3XX`               | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_OBERON`               |
-+----------------+-----------------------------------------------------------------+------------------------------------------------------------------+
-| AES GCM        | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_CC3XX`               | Not Supported                                                    |
-+----------------+-----------------------------------------------------------------+------------------------------------------------------------------+
-| ChaCha/Poly    | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_CC3XX` | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_OBERON` |
-+----------------+-----------------------------------------------------------------+------------------------------------------------------------------+
++----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
+| AEAD cipher    | nrf_cc3xx driver support                                               | nrf_oberon driver support                                               |
++================+========================================================================+=========================================================================+
+| AES CCM        | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CCM_OBERON`               |
++----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
+| AES GCM        | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_GCM_CC3XX`               | Not Supported                                                           |
++----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
+| ChaCha/Poly    | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_CHACHA20_POLY1305_OBERON` |
++----------------+------------------------------------------------------------------------+-------------------------------------------------------------------------+
 
 .. note::
    * If an AEAD algorithm is enabled and no PSA driver enables or supports it, then :ref:`nrf_security_drivers_builtin` support is enabled and used.
@@ -158,15 +158,15 @@ ECC configurations
 
 You can enable Elliptic Curve Cryptography (ECC) by setting one or more Kconfig options in the following table:
 
-+-----------------------+----------------------------------------------------+
-| ECC algorithm         | Configuration option                               |
-+=======================+====================================================+
-| ECDH                  | :kconfig:`CONFIG_PSA_WANT_ALG_ECDH`                |
-+----------------+-----------------------------------------------------------+
-| ECDSA                 | :kconfig:`CONFIG_PSA_WANT_ALG_ECDSA`               |
-+-----------------------+----------------------------------------------------+
-| ECDSA (deterministic) | :kconfig:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA` |
-+-----------------------+----------------------------------------------------+
++-----------------------+-----------------------------------------------------------+
+| ECC algorithm         | Configuration option                                      |
++=======================+===========================================================+
+| ECDH                  | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDH`                |
++-----------------------+-----------------------------------------------------------+
+| ECDSA                 | :kconfig:option:`CONFIG_PSA_WANT_ALG_ECDSA`               |
++-----------------------+-----------------------------------------------------------+
+| ECDSA (deterministic) | :kconfig:option:`CONFIG_PSA_WANT_ALG_DETERMINISTIC_ECDSA` |
++-----------------------+-----------------------------------------------------------+
 
 The ECC algorithm support is dependent on one or more Kconfig options enabling curve support according to `ECC curve configurations`_.
 
@@ -176,15 +176,15 @@ ECC driver configurations
 
 You can use the Kconfig options in the following table for fine-grained control over which drivers provide ECC support:
 
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| ECC algorithm         | nrf_cc3xx driver support                                          | nrf_oberon driver support                                          |
-+=======================+===================================================================+====================================================================+
-| ECDH                  | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDH_CC3XX`                | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDSA_OBERON`               |
-+----------------+--------------------------------------------------------------------------+--------------------------------------------------------------------+
-| ECDSA                 | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDSA_CC3XX`               | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDSA_OBERON`               |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| ECDSA (deterministic) | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_DETERMINISTIC_ECDSA_CC3XX` | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_DETERMINISTIC_ECDSA_OBERON` |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| ECC algorithm         | nrf_cc3xx driver support                                                 | nrf_oberon driver support                                                 |
++=======================+==========================================================================+===========================================================================+
+| ECDH                  | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDH_CC3XX`                | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDSA_OBERON`               |
++-----------------------+---------------------------------------------------------------------------------+--------------------------------------------------------------------+
+| ECDSA                 | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDSA_CC3XX`               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_ECDSA_OBERON`               |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| ECDSA (deterministic) | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_DETERMINISTIC_ECDSA_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_DETERMINISTIC_ECDSA_OBERON` |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
 
 .. note::
    * If an ECC algorithm is enabled and no PSA driver enables or supports it, then :ref:`nrf_security_drivers_builtin` support is enabled and used.
@@ -196,33 +196,33 @@ ECC curve configurations
 
 You can configure elliptic curve support by setting one or more Kconfig options in the following table:
 
-+-----------------------+----------------------------------------------------+
-| ECC curve type        | Configuration option                               |
-+=======================+====================================================+
-| Brainpool256r1        | :kconfig:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_256`  |
-+-----------------------+----------------------------------------------------+
-| Brainpool384r1        | :kconfig:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_384`  |
-+-----------------------+----------------------------------------------------+
-| Brainpool512r1        | :kconfig:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512`  |
-+-----------------------+----------------------------------------------------+
-| Curve25519            | :kconfig:`CONFIG_PSA_WANT_ECC_MONTGOMERY_255`      |
-+-----------------------+----------------------------------------------------+
-| Curve448              | :kconfig:`CONFIG_PSA_WANT_ECC_MONTGOMERY_448`      |
-+-----------------------+----------------------------------------------------+
-| secp192k1             | :kconfig:`CONFIG_PSA_WANT_ECC_SECP_K1_192`         |
-+-----------------------+----------------------------------------------------+
-| secp256k1             | :kconfig:`CONFIG_PSA_WANT_ECC_SECP_K1_256`         |
-+-----------------------+----------------------------------------------------+
-| secp192r1             | :kconfig:`CONFIG_PSA_WANT_ECC_SECP_R1_192`         |
-+-----------------------+----------------------------------------------------+
-| secp224r1             | :kconfig:`CONFIG_PSA_WANT_ECC_SECP_R1_224`         |
-+-----------------------+----------------------------------------------------+
-| secp256r1             | :kconfig:`CONFIG_PSA_WANT_ECC_SECP_R1_256`         |
-+-----------------------+----------------------------------------------------+
-| secp384r1             | :kconfig:`CONFIG_PSA_WANT_ECC_SECP_R1_384`         |
-+-----------------------+----------------------------------------------------+
-| secp521r1             | :kconfig:`CONFIG_PSA_WANT_ECC_SECP_R1_521`         |
-+-----------------------+----------------------------------------------------+
++-----------------------+-----------------------------------------------------------+
+| ECC curve type        | Configuration option                                      |
++=======================+===========================================================+
+| Brainpool256r1        | :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_256`  |
++-----------------------+-----------------------------------------------------------+
+| Brainpool384r1        | :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_384`  |
++-----------------------+-----------------------------------------------------------+
+| Brainpool512r1        | :kconfig:option:`CONFIG_PSA_WANT_ECC_BRAINPOOL_P_R1_512`  |
++-----------------------+-----------------------------------------------------------+
+| Curve25519            | :kconfig:option:`CONFIG_PSA_WANT_ECC_MONTGOMERY_255`      |
++-----------------------+-----------------------------------------------------------+
+| Curve448              | :kconfig:option:`CONFIG_PSA_WANT_ECC_MONTGOMERY_448`      |
++-----------------------+-----------------------------------------------------------+
+| secp192k1             | :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_K1_192`         |
++-----------------------+-----------------------------------------------------------+
+| secp256k1             | :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_K1_256`         |
++-----------------------+-----------------------------------------------------------+
+| secp192r1             | :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_192`         |
++-----------------------+-----------------------------------------------------------+
+| secp224r1             | :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_224`         |
++-----------------------+-----------------------------------------------------------+
+| secp256r1             | :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_256`         |
++-----------------------+-----------------------------------------------------------+
+| secp384r1             | :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_384`         |
++-----------------------+-----------------------------------------------------------+
+| secp521r1             | :kconfig:option:`CONFIG_PSA_WANT_ECC_SECP_R1_521`         |
++-----------------------+-----------------------------------------------------------+
 
 
 ECC curve driver configurations
@@ -230,33 +230,33 @@ ECC curve driver configurations
 
 You can sue the Kconfig options in the following table for fine-grained control over which drivers provide elliptic curve support:
 
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| ECC curve type        | nrf_cc3xx driver support                                          | nrf_oberon driver support                                          |
-+=======================+===================================================================+====================================================================+
-| Brainpool256r1        | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_BRAINPOOL_P_R1_256_CC3XX`  | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| Brainpool384r1        | Not supported                                                     | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| Brainpool512r1        | Not supported                                                     | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| Curve25519            | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_MONTGOMERY_255_CC3XX`      | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_MONTGOMERY_255_OBERON`      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| Curve448              | Not supported                                                     | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| secp192k1             | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_K1_192_CC3XX`         | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| secp256k1             | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_K1_256_CC3XX`         | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| secp192r1             | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_192_CC3XX`         | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| secp224r1             | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_224_CC3XX`         | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_224_OBERON`         |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| secp256r1             | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_256_CC3XX`         | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_256_OBERON`         |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| secp384r1             | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_384_CC3XX`         | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
-| secp521r1             | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_521_CC3XX`         | Not supported                                                      |
-+-----------------------+-------------------------------------------------------------------+--------------------------------------------------------------------+
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| ECC curve type        | nrf_cc3xx driver support                                                 | nrf_oberon driver support                                                 |
++=======================+==========================================================================+===========================================================================+
+| Brainpool256r1        | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_BRAINPOOL_P_R1_256_CC3XX`  | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| Brainpool384r1        | Not supported                                                            | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| Brainpool512r1        | Not supported                                                            | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| Curve25519            | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_MONTGOMERY_255_CC3XX`      | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_MONTGOMERY_255_OBERON`      |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| Curve448              | Not supported                                                            | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| secp192k1             | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_K1_192_CC3XX`         | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| secp256k1             | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_K1_256_CC3XX`         | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| secp192r1             | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_192_CC3XX`         | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| secp224r1             | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_224_CC3XX`         | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_224_OBERON`         |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| secp256r1             | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_256_CC3XX`         | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_256_OBERON`         |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| secp384r1             | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_384_CC3XX`         | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
+| secp521r1             | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ECC_SECP_R1_521_CC3XX`         | Not supported                                                             |
++-----------------------+--------------------------------------------------------------------------+---------------------------------------------------------------------------+
 
 
 RSA configurations
@@ -264,17 +264,17 @@ RSA configurations
 
 You can enable Rivest-Shamir-Adleman (RSA) support by setting one or more Kconfig options in the following table:
 
-+-----------------------+---------------------------------------------------+
-| RSA algorithms        | Configuration option                              |
-+=======================+===================================================+
-| RSA OAEP              | :kconfig:`CONFIG_PSA_WANT_ALG_RSA_OAEP`           |
-+-----------------------+---------------------------------------------------+
-| RSA PKCS#1 v1.5 crypt | :kconfig:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_CRYPT` |
-+-----------------------+---------------------------------------------------+
-| RSA PKCS#1 v1.5 sign  | :kconfig:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`  |
-+-----------------------+---------------------------------------------------+
-| RSA PSS               | :kconfig:`CONFIG_PSA_WANT_ALG_RSA_PSS`            |
-+-----------------------+---------------------------------------------------+
++-----------------------+----------------------------------------------------------+
+| RSA algorithms        | Configuration option                                     |
++=======================+==========================================================+
+| RSA OAEP              | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_OAEP`           |
++-----------------------+----------------------------------------------------------+
+| RSA PKCS#1 v1.5 crypt | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_CRYPT` |
++-----------------------+----------------------------------------------------------+
+| RSA PKCS#1 v1.5 sign  | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PKCS1V15_SIGN`  |
++-----------------------+----------------------------------------------------------+
+| RSA PSS               | :kconfig:option:`CONFIG_PSA_WANT_ALG_RSA_PSS`            |
++-----------------------+----------------------------------------------------------+
 
 
 RSA driver configurations
@@ -282,17 +282,17 @@ RSA driver configurations
 
 You can use the Kconfig options in the following table for fine-grained control over which drivers provide RSA support:
 
-+-----------------------+-------------------------------------------------------------------+----------------------------+
-| RSA algorithms        | nrf_cc3xx driver support                                          | nrf_oberon driver support  |
-+=======================+===================================================================+============================+
-| RSA OAEP              | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_OAEP_CC3XX`            | Not supported              |
-+-----------------------+-------------------------------------------------------------------+----------------------------+
-| RSA PKCS#1 v1.5 crypt | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_CRYPT_CC3XX`  | Not supported              |
-+-----------------------+-------------------------------------------------------------------+----------------------------+
-| RSA PKCS#1 v1.5 sign  | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_SIGN_CC3XX`   | Not supported              |
-+-----------------------+-------------------------------------------------------------------+----------------------------+
-| RSA PSS               | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_PSS_CC3XX`             | Not supported              |
-+-----------------------+-------------------------------------------------------------------+----------------------------+
++-----------------------+--------------------------------------------------------------------------+----------------------------+
+| RSA algorithms        | nrf_cc3xx driver support                                                 | nrf_oberon driver support  |
++=======================+==========================================================================+============================+
+| RSA OAEP              | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_OAEP_CC3XX`            | Not supported              |
++-----------------------+--------------------------------------------------------------------------+----------------------------+
+| RSA PKCS#1 v1.5 crypt | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_CRYPT_CC3XX`  | Not supported              |
++-----------------------+--------------------------------------------------------------------------+----------------------------+
+| RSA PKCS#1 v1.5 sign  | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_PKCS1V15_SIGN_CC3XX`   | Not supported              |
++-----------------------+--------------------------------------------------------------------------+----------------------------+
+| RSA PSS               | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_RSA_PSS_CC3XX`             | Not supported              |
++-----------------------+--------------------------------------------------------------------------+----------------------------+
 
 .. note::
    * If an RSA algorithm is enabled and no PSA driver enables or supports it, then :ref:`nrf_security_drivers_builtin` support is enabled and used.
@@ -304,19 +304,19 @@ Secure Hash configurations
 
 You can configure the Secure Hash algorithms by setting one or more Kconfig options according to the following table:
 
-+-----------------------+----------------------------------------+
-| Hash algorithm        | Configuration optio                    |
-+=======================+========================================+
-| SHA-1                 | :kconfig:`CONFIG_PSA_WANT_ALG_SHA_1`   |
-+-----------------------+----------------------------------------+
-| SHA-224               | :kconfig:`CONFIG_PSA_WANT_ALG_SHA_224` |
-+-----------------------+----------------------------------------+
-| SHA-256               | :kconfig:`CONFIG_PSA_WANT_ALG_SHA_256` |
-+-----------------------+----------------------------------------+
-| SHA-384               | :kconfig:`CONFIG_PSA_WANT_ALG_SHA_384` |
-+-----------------------+----------------------------------------+
-| SHA-512               | :kconfig:`CONFIG_PSA_WANT_ALG_SHA_512` |
-+-----------------------+----------------------------------------+
++-----------------------+-----------------------------------------------+
+| Hash algorithm        | Configuration optio                           |
++=======================+===============================================+
+| SHA-1                 | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_1`   |
++-----------------------+-----------------------------------------------+
+| SHA-224               | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_224` |
++-----------------------+-----------------------------------------------+
+| SHA-256               | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_256` |
++-----------------------+-----------------------------------------------+
+| SHA-384               | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_384` |
++-----------------------+-----------------------------------------------+
+| SHA-512               | :kconfig:option:`CONFIG_PSA_WANT_ALG_SHA_512` |
++-----------------------+-----------------------------------------------+
 
 
 Secure Hash driver configurations
@@ -324,19 +324,19 @@ Secure Hash driver configurations
 
 You can use the PSA driver-specific configurations provided in this table for fine-grained control over which drivers provide the Secure Hash algorithm.
 
-+-----------------------+--------------------------------------------------------+--------------------------------------------------------+
-| Hash algorithm        |  nrf_cc3xx driver support                              | nrf_oberon driver support                              |
-+=======================+========================================================+========================================================+
-| SHA-1                 |  :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_1_CC3XX`   | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_1_OBERON`   |
-+-----------------------+--------------------------------------------------------+--------------------------------------------------------+
-| SHA-224               |  :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_224_CC3XX` | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_224_OBERON` |
-+-----------------------+--------------------------------------------------------+--------------------------------------------------------+
-| SHA-256               |  :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_256_CC3XX` | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_256_OBERON` |
-+-----------------------+--------------------------------------------------------+--------------------------------------------------------+
-| SHA-384               |  Not supported                                         | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_384_OBERON` |
-+-----------------------+--------------------------------------------------------+--------------------------------------------------------+
-| SHA-512               |  Not supported                                         | :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_512_OBERON` |
-+-----------------------+--------------------------------------------------------+--------------------------------------------------------+
++-----------------------+---------------------------------------------------------------+---------------------------------------------------------------+
+| Hash algorithm        |  nrf_cc3xx driver support                                     | nrf_oberon driver support                                     |
++=======================+===============================================================+===============================================================+
+| SHA-1                 |  :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_1_CC3XX`   | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_1_OBERON`   |
++-----------------------+---------------------------------------------------------------+---------------------------------------------------------------+
+| SHA-224               |  :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_224_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_224_OBERON` |
++-----------------------+---------------------------------------------------------------+---------------------------------------------------------------+
+| SHA-256               |  :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_256_CC3XX` | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_256_OBERON` |
++-----------------------+---------------------------------------------------------------+---------------------------------------------------------------+
+| SHA-384               |  Not supported                                                | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_384_OBERON` |
++-----------------------+---------------------------------------------------------------+---------------------------------------------------------------+
+| SHA-512               |  Not supported                                                | :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_ALG_SHA_512_OBERON` |
++-----------------------+---------------------------------------------------------------+---------------------------------------------------------------+
 
 .. note::
    * If Secure Hash algorithm is enabled and no PSA driver enables or supports it, then :ref:`nrf_security_drivers_builtin` support is enabled and used.

--- a/nrf_security/doc/drivers.rst
+++ b/nrf_security/doc/drivers.rst
@@ -43,7 +43,7 @@ The Arm CryptoCell cc3xx driver is only available on the following devices:
 Enabling the Arm CryptoCell cc3xx driver
 ========================================
 
-The Arm CryptoCell cc3xx driver can be enabled by setting the :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_CC3XX` Kconfig option.
+The Arm CryptoCell cc3xx driver can be enabled by setting the :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_CC3XX` Kconfig option.
 
 
 Using the Arm CryptoCell cc3xx driver
@@ -51,7 +51,7 @@ Using the Arm CryptoCell cc3xx driver
 
 To use the :ref:`nrf_cc3xx_mbedcrypto_readme` PSA driver, the Arm CryptoCell cc310/cc312 hardware must be first initialized.
 
-The Arm CryptoCell cc3xx hardware is initialized in the :file:`hw_cc310.c` file, located under :file:`nrf/drivers/hw_cc310/`, and is controlled with the :kconfig:`CONFIG_HW_CC3XX` Kconfig option.
+The Arm CryptoCell cc3xx hardware is initialized in the :file:`hw_cc310.c` file, located under :file:`nrf/drivers/hw_cc310/`, and is controlled with the :kconfig:option:`CONFIG_HW_CC3XX` Kconfig option.
 The Kconfig option has a default value of 'y' when cc3xx is available in the SoC.
 
 .. _nrf_security_drivers_oberon:
@@ -67,7 +67,7 @@ The nrf_oberon driver provides support for AES ciphers, SHA-1, SHA-256, SHA-384,
 Enabling the nrf_oberon driver
 ==============================
 
-The :ref:`nrf_oberon_readme` PSA driver can be enabled by setting the :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_OBERON` Kconfig option.
+The :ref:`nrf_oberon_readme` PSA driver can be enabled by setting the :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_OBERON` Kconfig option.
 
 .. _nrf_security_drivers_builtin:
 
@@ -89,7 +89,7 @@ Similarly, you can use the built-in Mbed TLS to add support for features not ava
 Enabling the built-in Mbed TLS support
 ======================================
 
-To enable the built-in Mbed TLS support, set the :kconfig:`CONFIG_PSA_CRYPTO_DRIVER_BUILTIN` Kconfig option to true.
+To enable the built-in Mbed TLS support, set the :kconfig:option:`CONFIG_PSA_CRYPTO_DRIVER_BUILTIN` Kconfig option to true.
 
 It is generally not needed to enable built-in Mbed TLS support manually, as there is Kconfig logic that does that, depending on the enabled cryptographic features or algorithms and the configuration of PSA drivers.
 
@@ -109,7 +109,7 @@ Enabling legacy Mbed TLS support
 
 The legacy Mbed TLS APIs can be configured by setting the option kconfig:`CONFIG_NORDIC_SECURITY_BACKEND` instead of setting the option kconfig:`CONFIG_NRF_SECURITY`.
 
-Additionally either :kconfig:`CONFIG_CC3XX_BACKEND` or :kconfig:`CONFIG_OBERON_BACKEND` must be enabled.
+Additionally either :kconfig:option:`CONFIG_CC3XX_BACKEND` or :kconfig:option:`CONFIG_OBERON_BACKEND` must be enabled.
 
 .. note::
-   Enabling the CryptoCell by using :kconfig:`CONFIG_CC3XX_BACKEND` in a non-secure image of a TF-M build will have no effect.
+   Enabling the CryptoCell by using :kconfig:option:`CONFIG_CC3XX_BACKEND` in a non-secure image of a TF-M build will have no effect.

--- a/nrf_security/tfm/CMakeLists.txt
+++ b/nrf_security/tfm/CMakeLists.txt
@@ -33,7 +33,8 @@ foreach(setting ${NRF_SECURITY_SETTINGS})
 endforeach()
 
 # Standard extensions of Zephyr included in the TF-M build
-include(${ZEPHYR_BASE}/cmake/extensions.cmake)
+list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_BASE}/cmake/modules)
+include(extensions)
 import_kconfig(CONFIG_ ${ZEPHYR_DOTCONFIG})
 
 # Additional TF-M build only settings:

--- a/zboss/README.rst
+++ b/zboss/README.rst
@@ -8,13 +8,13 @@ The |NCS|'s :ref:`nrf:ug_zigbee` stack uses ZBOSS – a portable, high-performan
 The nrfxlib repository contains the following versions of the ZBOSS libraries:
 
 * *Production* version that contains the latest stable ZBOSS libraries.
-  This version is enabled with the :kconfig:`CONFIG_ZIGBEE_LIBRARY_PRODUCTION` Kconfig option and its files are located in the :file:`zboss/production/` directory.
+  This version is enabled with the :kconfig:option:`CONFIG_ZIGBEE_LIBRARY_PRODUCTION` Kconfig option and its files are located in the :file:`zboss/production/` directory.
   This version is enabled by default.
 
   The production libraries fully conform to the certification, but they are not necessarily certified.
 
 * *Development* version that contains the latest version of ZBOSS libraries, with experimental features included.
-  This version is enabled with the :kconfig:`CONFIG_ZIGBEE_LIBRARY_DEVELOPMENT` Kconfig option and its files are located in the :file:`zboss/development/` directory.
+  This version is enabled with the :kconfig:option:`CONFIG_ZIGBEE_LIBRARY_DEVELOPMENT` Kconfig option and its files are located in the :file:`zboss/development/` directory.
 
   This version might not conform to the latest Zigbee Pro R22 test specification.
   There is no guarantee that the library conforms to the certification.

--- a/zboss/doc/zboss_configuration.rst
+++ b/zboss/doc/zboss_configuration.rst
@@ -28,7 +28,7 @@ For a complete list of the ZBOSS configuration options, see the following files:
 * :file:`zboss/production/include/osif/libzboss_config.h` - library for Coordinators and Routers
 * :file:`zboss/production/include/osif/libzboss_config.ed.h` - library for End Devices
 
-The ZBOSS production library version is enabled by default with the :kconfig:`CONFIG_ZIGBEE_LIBRARY_PRODUCTION` Kconfig option.
+The ZBOSS production library version is enabled by default with the :kconfig:option:`CONFIG_ZIGBEE_LIBRARY_PRODUCTION` Kconfig option.
 
 ZBOSS development libraries
 ***************************
@@ -40,7 +40,7 @@ For a complete list of the ZBOSS configuration options, see the following files:
 * :file:`zboss/development/include/osif/libzboss_config.h` - library for Coordinators and Routers
 * :file:`zboss/development/include/osif/libzboss_config.ed.h` - library for End Devices
 
-You can select the ZBOSS development library version with the :kconfig:`CONFIG_ZIGBEE_LIBRARY_DEVELOPMENT` Kconfig option.
+You can select the ZBOSS development library version with the :kconfig:option:`CONFIG_ZIGBEE_LIBRARY_DEVELOPMENT` Kconfig option.
 These libraries include implementation of the eight version of the ZCL specification.
 
 .. note::
@@ -49,14 +49,14 @@ These libraries include implementation of the eight version of the ZCL specifica
 Configuration options
 *********************
 
-In the |NCS|, you can enable the ZBOSS library using the :kconfig:`CONFIG_ZIGBEE` Kconfig option.
+In the |NCS|, you can enable the ZBOSS library using the :kconfig:option:`CONFIG_ZIGBEE` Kconfig option.
 Enabling this library is required when configuring the Zigbee protocol in the |NCS|, for example when testing the available :ref:`nrf:zigbee_samples`.
 
 To enable additional features in the ZBOSS libraries, you can use the following Kconfig options:
 
-* :kconfig:`CONFIG_ZIGBEE_LIBRARY_NCP_DEV` - With this option enabled, the application links with an additional library, which implements NCP commands.
+* :kconfig:option:`CONFIG_ZIGBEE_LIBRARY_NCP_DEV` - With this option enabled, the application links with an additional library, which implements NCP commands.
   This option is enabled by default in the :ref:`Zigbee NCP sample <nrf:zigbee_ncp_sample>`.
   This option uses a production version of ZBOSS that has not been certified.
-* :kconfig:`CONFIG_ZIGBEE_GP_CB` - With this option enabled, the application can support the Green Power Combo feature, which implements the basic set of Green Power Proxy and Green Power Sink functionalities within a single device.
+* :kconfig:option:`CONFIG_ZIGBEE_GP_CB` - With this option enabled, the application can support the Green Power Combo feature, which implements the basic set of Green Power Proxy and Green Power Sink functionalities within a single device.
   This option can only be enabled for application that is built from ZBOSS stack sources.
   This option is added only for evaluation purposes and does not have a dedicated sample.


### PR DESCRIPTION
The new Kconfig extension requires usage of :kconfig:option: role, since
it uses a language domain.