### PR TITLE
nrf_modem: Make the irq priorities configurable via KConfig

### DIFF
--- a/nrf_modem/Kconfig
+++ b/nrf_modem/Kconfig
@@ -11,6 +11,14 @@ config NRF_MODEM_LINK_BINARY
 
 endchoice
 
+config NRF_MODEM_NETWORK_IRQ_PRIORITY
+	int "Modem network layer communication interrupt priority"
+	default 1
+
+config NRF_MODEM_APPLICATION_IRQ_PRIORITY
+	int "Modem application layer communication interrupt priority"
+	default 4
+
 config NRF_MODEM_LOG
 	bool "Enable library logging"
 

--- a/nrf_modem/include/nrf_modem_platform.h
+++ b/nrf_modem/include/nrf_modem_platform.h
@@ -35,13 +35,13 @@ extern "C" {
 #define NRF_MODEM_NETWORK_IRQ IPC_IRQn
 
 /**@brief Interrupt priority used on interrupt for communication with the network layer. */
-#define NRF_MODEM_NETWORK_IRQ_PRIORITY 0
+#define NRF_MODEM_NETWORK_IRQ_PRIORITY CONFIG_NRF_MODEM_NETWORK_IRQ_PRIORITY
 
 /**@brief Interrupt used for communication with the application layer. */
 #define NRF_MODEM_APPLICATION_IRQ EGU1_IRQn
 
 /**@brief Interrupt priority used on interrupt for communication with the application layer. */
-#define NRF_MODEM_APPLICATION_IRQ_PRIORITY 6
+#define NRF_MODEM_APPLICATION_IRQ_PRIORITY CONFIG_NRF_MODEM_APPLICATION_IRQ_PRIORITY
 
 /**@} */
 


### PR DESCRIPTION
When zero-latency-interrupts are enabled, the current values for the interrupt priority are no longer valid. I introduced the interrupt priorities as parameter to the KConfig. The defaut values are selected so that applications start without an assert from the irq system.  

Signed-off-by: Sven Hädrich <sven.haedrich@grandcentrix.net>