### PR TITLE
adding .github/test-spec.yml

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -1,0 +1,25 @@
+# This is the Jenkins ci variant of the .github/labler.yaml
+
+CI-ble-test:
+  - 'softdevice_controller/**/*'
+  - 'mpsl/**/*'
+
+CI-zigbee-test:
+  - 'mpsl/**/*'
+  - 'softdevice_controller/**/*'
+
+CI-desktop-test:
+  - 'softdevice_controller/*'
+
+CI-rs-test:
+  - 'mpsl/**/*'
+
+CI-homekit-test:
+  - 'mpsl/**/*'
+  - 'softdevice_controller/**/*'
+
+CI-thread-test:
+  - 'mpsl/**/*'
+
+CI-matter-test:
+  - 'mpsl/**/*'


### PR DESCRIPTION
Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>

This PR is meant to be a starting point to create the .github/test-spec.yml
Which will work similar to the [sdk-nrf/.github/test-spec.yml](https://github.com/nrfconnect/sdk-nrf/blob/main/.github/test-spec.yml)