### PR TITLE
adding .github/test-spec.yml

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -1,0 +1,101 @@
+# This is the Jenkins ci variant of the .github/labler.yaml
+
+"CI-iot-samples-test":
+  - "**/*"
+
+"CI-iot-libraries-test":
+  - "**/*"
+
+"CI-lwm2m-test":
+  - "**/*"
+
+"CI-boot-dfu-test":
+  - "**/*"
+
+"CI-tfm-test":
+  - "**/*"
+
+"CI-ble-test":
+  - "softdevice_controller/include/**/*"
+  - "softdevice_controller/lib/**/*"
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+
+"CI-mesh-test":
+  - "**/*"
+
+"CI-zigbee-test":
+  - "softdevice_controller/include/**/*"
+  - "softdevice_controller/lib/**/*"
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+  - "nrf_802154/driver/**/*"
+  - "nrf_802154/serialization/**/*"
+  - "nrf_802154/sl/**/*"
+  - any:
+    - "zboss/**/*"
+    - "!zboss/*.rst"
+    - "!zboss/doc/**/*"
+
+"CI-thingy91-test":
+  - "**/*"
+
+"CI-desktop-test":
+  - "softdevice_controller/include/**/*"
+  - "softdevice_controller/lib/**/*"
+
+"CI-crypto-test":
+  - "**/*"
+
+"CI-rs-test":
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+
+"CI-homekit-test":
+  - "crypto/**/*"
+  - "openthread/**/*"
+  - "softdevice_controller/include/**/*"
+  - "softdevice_controller/lib/**/*"
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+  - "nfc/**/*"
+  - "nrf_802154/driver/**/*"
+  - "nrf_802154/serialization/**/*"
+  - "nrf_802154/sl/**/*"
+  - "nrf_security/**/*"
+
+"CI-thread-test":
+  - "softdevice_controller/include/**/*"
+  - "softdevice_controller/lib/**/*"
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+  - "nrf_802154/driver/**/*"
+  - "nrf_802154/serialization/**/*"
+  - "nrf_802154/sl/**/*"
+  - "crypto/**/*"
+  - any:
+    - "openthread/**/*"
+    - "!openthread/*.rst"
+    - "!openthread/doc/**/*"
+
+"CI-nfc-test":
+  - "**/*"
+
+"CI-matter-test":
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+
+"CI-find-my-test":
+  - "**/*"
+
+"CI-gazell-test":
+  - "**/*"
+
+"CI-rpc-test":
+  - "**/*"
+
+"CI-modemshell-test":
+  - "**/*"
+
+"CI-positioning-test":
+  - "**/*"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 /CODEOWNERS                               @carlescufi
 /LICENSE                                  @carlescufi
 /Jenkinsfile                              @thst-nordic
-/README.rst                               @ru-fu @carlescufi
+/README.rst                               @carlescufi
 /.checkpatch.conf                         @carlescufi
 /.gitattributes                           @thst-nordic
 /.gitlint                                 @thst-nordic
@@ -32,8 +32,9 @@ doc/*                                     @b-gent
 
 # All subfolders
 /.github/                                 @thst-nordic
+/.github/test-spec.yml                    @nrfconnect/ncs-test-leads
 /softdevice_controller/                   @rugeGerritsen
-/nrf_modem/                               @rlubos @lemrey @evenl
+/nrf_modem/                               @rlubos @lemrey
 /crypto/                                  @frkv @tejlmand
 /gzll/                                    @leewkb4567
 /mpsl/                                    @rugeGerritsen


### PR DESCRIPTION
Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>

This PR is meant to be a starting point to create the .github/test-spec.yml
Which will work similar to the [sdk-nrf/.github/test-spec.yml](https://github.com/nrfconnect/sdk-nrf/blob/main/.github/test-spec.yml)

You can add changes to the `test-spec` branch. I'll combine them to a single commit on Friday (18.03)