### PR TITLE
doc: Clarify that Periodic Advertising is experimental in nRF53 series

### DIFF
--- a/softdevice_controller/CHANGELOG.rst
+++ b/softdevice_controller/CHANGELOG.rst
@@ -36,7 +36,7 @@ All the notable changes included in the |NCS| v1.9.0 release are documented in t
 Added
 =====
 
-* Added support for Periodic Advertising for production.
+* Added support for Periodic Advertising for production for nRF52 Series.
 * Added support for a vendor-specific HCI command setting the periodic advertising event length (DRGN-16513).
 * Added ``SDC_CFG_TYPE_PERIODIC_ADV_LIST_SIZE`` to allow the application to configure the size of the periodic advertiser list (DRGN-16357).
 

--- a/softdevice_controller/README.rst
+++ b/softdevice_controller/README.rst
@@ -35,6 +35,9 @@ Variants for the Arm Cortex-M33 processor are available as soft-float only.
 | Coded PHY (Long Range)   |                 |              | X         |
 +--------------------------+-----------------+--------------+-----------+
 
+.. note::
+   Periodic Advertising is supported as an experimental feature on the nRF53 Series.
+
 Proprietary feature support:
 
 +--------------------------+-----------------+--------------+-----------+-----------------------------------------------------------------------------+


### PR DESCRIPTION
Clarifies that Periodic Advertising is supported as
an experimental feature for nRF53 Series.

Signed-off-by: Wille Backman <wille.backman@nordicsemi.no>