### PR TITLE
CI: Remove boot/fw-update tests

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -26,6 +26,10 @@
 
 "CI-tfm-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"
 
 "CI-ble-test":
   - "softdevice_controller/include/**/*"
@@ -58,6 +62,10 @@
 
 "CI-crypto-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"
 
 "CI-rs-test":
   - "mpsl/include/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -2,12 +2,24 @@
 
 "CI-iot-samples-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"
 
 "CI-iot-libraries-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"
 
 "CI-lwm2m-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"
 
 "CI-boot-dfu-test":
   - "**/*"
@@ -96,6 +108,14 @@
 
 "CI-modemshell-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"
 
 "CI-positioning-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -21,9 +21,6 @@
   - !"mpsl/include/**/*"
   - !"mpsl/lib/**/*"
 
-"CI-boot-dfu-test":
-  - "**/*"
-
 "CI-tfm-test":
   - "**/*"
   - !"softdevice_controller/include/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -53,9 +53,6 @@
     - "!zboss/*.rst"
     - "!zboss/doc/**/*"
 
-"CI-thingy91-test":
-  - "**/*"
-
 "CI-desktop-test":
   - "softdevice_controller/include/**/*"
   - "softdevice_controller/lib/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -100,6 +100,10 @@
 
 "CI-nfc-test":
   - "**/*"
+  - !"softdevice_controller/include/**/*"
+  - !"softdevice_controller/lib/**/*"
+  - !"mpsl/include/**/*"
+  - !"mpsl/lib/**/*"
 
 "CI-matter-test":
   - "mpsl/include/**/*"


### PR DESCRIPTION
NRFX lib is not part of any boot or dfu test targets, so remove the
lable for it.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>