### PR TITLE
Exclude some ci when changing mpsl and sdc

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -9,9 +9,6 @@
 "CI-lwm2m-test":
   - "nrf_modem/**/*"
 
-"CI-boot-dfu-test":
-  - "**/*"
-
 "CI-tfm-test":
   - "**/*"
   - "!softdevice_controller/include/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -1,13 +1,13 @@
 # This is the Jenkins ci variant of the .github/labler.yaml
 
 "CI-iot-samples-test":
-  - "**/*"
+  - "nrf_modem/**/*"
 
 "CI-iot-libraries-test":
-  - "**/*"
+  - "nrf_modem/**/*"
 
 "CI-lwm2m-test":
-  - "**/*"
+  - "nrf_modem/**/*"
 
 "CI-boot-dfu-test":
   - "**/*"
@@ -95,7 +95,7 @@
   - "**/*"
 
 "CI-modemshell-test":
-  - "**/*"
+  - "nrf_modem/**/*"
 
 "CI-positioning-test":
-  - "**/*"
+  - "nrf_modem/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -98,7 +98,7 @@
   - "**/*"
 
 "CI-rpc-test":
-  - "**/*"
+  - "nrf_rpc/**/*"
 
 "CI-modemshell-test":
   - "nrf_modem/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -88,6 +88,10 @@
 
 "CI-nfc-test":
   - "**/*"
+  - "!softdevice_controller/include/**/*"
+  - "!softdevice_controller/lib/**/*"
+  - "!mpsl/include/**/*"
+  - "!mpsl/lib/**/*"
 
 "CI-matter-test":
   - "mpsl/include/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -14,6 +14,10 @@
 
 "CI-tfm-test":
   - "**/*"
+  - "!softdevice_controller/include/**/*"
+  - "!softdevice_controller/lib/**/*"
+  - "!mpsl/include/**/*"
+  - "!mpsl/lib/**/*"
 
 "CI-ble-test":
   - "softdevice_controller/include/**/*"
@@ -46,6 +50,10 @@
 
 "CI-crypto-test":
   - "**/*"
+  - "!softdevice_controller/include/**/*"
+  - "!softdevice_controller/lib/**/*"
+  - "!mpsl/include/**/*"
+  - "!mpsl/lib/**/*"
 
 "CI-rs-test":
   - "mpsl/include/**/*"

--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -41,9 +41,6 @@
     - "!zboss/*.rst"
     - "!zboss/doc/**/*"
 
-"CI-thingy91-test":
-  - "**/*"
-
 "CI-desktop-test":
   - "softdevice_controller/include/**/*"
   - "softdevice_controller/lib/**/*"


### PR DESCRIPTION
At the moment we are executing more CI than necessary when only updating MPSL and SDC. See https://github.com/nrfconnect/sdk-nrf/pull/7194#issuecomment-1078970199

This PR is a rewrite from https://github.com/nrfconnect/sdk-nrfxlib/pull/694, fixing the syntax. 

It cherry-picks the changes from https://github.com/nrfconnect/sdk-nrfxlib/pull/698 and https://github.com/nrfconnect/sdk-nrfxlib/pull/697
