### PR TITLE
nrf_security: Fix TF-M FPU flags and TF-M relink dependency

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -77,16 +77,16 @@ if (CONFIG_NRF_OBERON OR CONFIG_BUILD_WITH_TFM OR CONFIG_OBERON_BACKEND OR CONFI
       # Generate a new library with this symbol redefined.
       set(OBERON_MBEDCRYPTO__PSA_LIB ${CMAKE_CURRENT_BINARY_DIR}/liboberon_mbedcrypto__psa_${OBERON_VER}.a)
 
-      add_custom_target(mbedcrypto_oberon_mbedcrypto__psa_rename
+      add_custom_command(
+        OUTPUT ${OBERON_MBEDCRYPTO__PSA_LIB}
         COMMAND ${CMAKE_OBJCOPY}
-        "${OBERON_PSA_LIB}"
-        "${OBERON_MBEDCRYPTO__PSA_LIB}"
-        --redefine-sym psa_generate_random=mbedcrypto__psa_generate_random
-        BYPRODUCTS
-        "${OBERON_MBEDCRYPTO__PSA_LIB}"
+          ${OBERON_PSA_LIB}
+          ${OBERON_MBEDCRYPTO__PSA_LIB}
+          --redefine-sym psa_generate_random=mbedcrypto__psa_generate_random
       )
-      add_dependencies(mbedcrypto_oberon_imported
-      mbedcrypto_oberon_mbedcrypto__psa_rename)
+      add_custom_target(mbedcrypto_oberon_mbedcrypto__psa_rename DEPENDS ${OBERON_MBEDCRYPTO__PSA_LIB})
+
+      add_dependencies(mbedcrypto_oberon_imported mbedcrypto_oberon_mbedcrypto__psa_rename)
 
       set(OBERON_PSA_LIB ${OBERON_MBEDCRYPTO__PSA_LIB})
     endif()


### PR DESCRIPTION
Add TF-M compile flags required when enabling FPU in TF-M.
TF-M documentation on FPU support:
"Secure and non-secure libraries are compiled with COMPILER_CP_FLAG and
linked with LINKER_CP_OPTION for different FP ABI types. All those
libraries shall be built with COMPLIER_CP_FLAG"

NCSDK-14513

Revert "crypto: Add workaround for liboberon PSA API prefix

The workaround is no longer needed since the Oberon library no
longer calls psa_generate_random.

The workaround had some cmake dependency issues and the command
was always run, causing dependent targets to be re-run.

This reverts commit https://github.com/joerchan/nrfxlib/commit/be4f031dcf7617e6b18a49a58a18fd37221e4671.