### PR TITLE
license: Add tag for detecting license of binary files

### DIFF
--- a/mpsl/license.txt
+++ b/mpsl/license.txt
@@ -2,4 +2,8 @@
  * Copyright (c) Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/nfc/license.txt
+++ b/nfc/license.txt
@@ -2,4 +2,8 @@
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/nrf_dm/license.txt
+++ b/nrf_dm/license.txt
@@ -2,4 +2,8 @@
  * Copyright (c) 2021 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/softdevice_controller/license.txt
+++ b/softdevice_controller/license.txt
@@ -2,4 +2,8 @@
  * Copyright (c) Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/zboss/license.txt
+++ b/zboss/license.txt
@@ -38,3 +38,10 @@
  * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+ 
+/*
+ *  The following tags tell the "west ncs-sbom" tool which files are covered
+ *  by the license information above.
+ *  SPDX-License-Identifier:  LicenseRef-ZBOSS-4-Clause
+ *  NCS-SBOM-Apply-To-File: ./**/*.a
+ */


### PR DESCRIPTION
A new tool for a license report generation will be introduced in
the new NCS. It will recognize licenses from the source code,
but it needs additional information for binary files. This commit
adds special tag to license files allowing clear binary files
license recognition.

Manifest update PR: https://github.com/nrfconnect/sdk-nrf/pull/7701

The tool is in the PR:
https://github.com/nrfconnect/sdk-nrf/pull/7209

You can see sample generated report from all `.a` file in nrfxlib repository:
https://doki-nordic.github.io/test-demo-docs/temp/nrfxlib-binary.html