### PR TITLE
nrf_security: Remove setting of crypto partition heap to mbedtls config

### DIFF
--- a/nrf_security/cmake/config_to_tf-m.cmake
+++ b/nrf_security/cmake/config_to_tf-m.cmake
@@ -34,12 +34,3 @@ if(CONFIG_TFM_BL2)
       -DMCUBOOT_MBEDCRYPTO_CONFIG_FILEPATH:STRING=${CONFIG_MBEDTLS_CFG_FILE}
   )
 endif()
-
-if(CONFIG_MBEDTLS_ENABLE_HEAP)
-  # The ENGINE_BUF_SIZE holds the dynamic allocation buffer for
-  # TF-M, which is the equivalent of dynamic allocation in MBEDTLS
-  set_property(TARGET zephyr_property_target
-    APPEND PROPERTY TFM_CMAKE_OPTIONS
-      -DCRYPTO_ENGINE_BUF_SIZE=${CONFIG_MBEDTLS_HEAP_SIZE}
-  )
-endif()


### PR DESCRIPTION
Remove crypto partition heap size set based on the mbedtls heap size
configuration.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>