### PR TITLE
doc: Remove EDITING.TXT from nrf_rpc figures

### DIFF
--- a/nrf_rpc/doc/img/EDITING.TXT
+++ b/nrf_rpc/doc/img/EDITING.TXT
@@ -1,8 +1,0 @@
-
-How to edit the images
-======================
-
-The SVG images contained in this directory were created by the diagrams.net.
-Use it to maintain editability of the images.
-
-Go to https://www.diagrams.net/ to download the application or edit on-line.


### PR DESCRIPTION
The figures for nrf_rpc documentation were updated to follow
current diagrams guidelines in #670. The information
contained in EDITING.TXT is no longer valid.

Signed-off-by: Dominik Kilian <Dominik.Kilian@nordicsemi.no>