### PR TITLE
nrf_modem: Use IRQ_PRIO_LOWEST as NRF_MODEM_APPLICATION_IRQ_PRIORITY

### DIFF
--- a/nrf_modem/include/nrf_modem_platform.h
+++ b/nrf_modem/include/nrf_modem_platform.h
@@ -40,7 +40,7 @@ extern "C" {
 #define NRF_MODEM_APPLICATION_IRQ EGU1_IRQn
 
 /**@brief Interrupt priority used on interrupt for communication with the application layer. */
-#define NRF_MODEM_APPLICATION_IRQ_PRIORITY 6
+#define NRF_MODEM_APPLICATION_IRQ_PRIORITY IRQ_PRIO_LOWEST
 
 /**@} */
 


### PR DESCRIPTION
... instead of the hard-coded value of 6 and this way allow successful
compilation also with zero-latency IRQs enabled (6 is not a valid
priority to be used in IRQ_CONNECT() then and a build assertion fails
when it is used).

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>