### PR TITLE
nrf_modem: remove `LicenseRef` from license string for `ISC`

### DIFF
--- a/nrf_modem/license.txt
+++ b/nrf_modem/license.txt
@@ -2,5 +2,5 @@
  * Copyright (c) 2017 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
- * SPDX-License-Identifier: LicenseRef-ISC
+ * SPDX-License-Identifier: ISC
  */


### PR DESCRIPTION
ISC license does not need `LicenseRef`, see https://spdx.org/licenses/ISC.html