### PR TITLE
Add mbedtls debug output

### DIFF
--- a/nrf_security/Kconfig.tls
+++ b/nrf_security/Kconfig.tls
@@ -150,8 +150,23 @@ endif # MBEDTLS_SSL_PROTO_TLS1_2
 config MBEDTLS_DEBUG_C
 	bool
 	prompt "Enable the debug functions for TLS."
+	select CBPRINTF_PACKAGE_LONGDOUBLE
 	help
 	  Enable the debug functions for TLS.
+
+config MBEDTLS_DEBUG_LEVEL
+	int "mbed TLS default debug level"
+	depends on MBEDTLS_DEBUG_C
+	default 0
+	range 0 4
+	help
+	  Default mbed TLS debug logging level for Zephyr integration code
+	  (from ext/lib/crypto/mbedtls/include/mbedtls/debug.h):
+	  0 No debug
+	  1 Error
+	  2 State change
+	  3 Information
+	  4 Verbose
 
 config MBEDTLS_SSL_PROTO_DTLS
 	bool "Enable support for DTLS"

--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -147,6 +147,7 @@ kconfig_check_and_set_base(MBEDTLS_SSL_CACHE_C)
 kconfig_check_and_set_base(MBEDTLS_SSL_TICKET_C)
 kconfig_check_and_set_base(MBEDTLS_SSL_EXPORT_KEYS)
 kconfig_check_and_set_base(MBEDTLS_SSL_CIPHERSUITES)
+kconfig_check_and_set_base(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
 
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 

--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -95,6 +95,7 @@ kconfig_check_and_set_base(MBEDTLS_PK_C)
 kconfig_check_and_set_base(MBEDTLS_PKCS5_C)
 kconfig_check_and_set_base(MBEDTLS_PK_PARSE_C)
 kconfig_check_and_set_base(MBEDTLS_PK_WRITE_C)
+kconfig_check_and_set_base(MBEDTLS_DEBUG_C)
 
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_SPM)
 

--- a/nrf_security/cmake/psa_crypto_config.cmake
+++ b/nrf_security/cmake/psa_crypto_config.cmake
@@ -202,6 +202,7 @@ kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_C)
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_MEMORY)
 kconfig_check_and_set_base_to_one(MBEDTLS_NO_PLATFORM_ENTROPY)
 kconfig_check_and_set_base_to_one(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
+kconfig_check_and_set_base_to_one(MBEDTLS_DEBUG_C)
 
 # Platform configurations for _ALT defines
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_EXIT_ALT)

--- a/nrf_security/cmake/psa_crypto_config.cmake
+++ b/nrf_security/cmake/psa_crypto_config.cmake
@@ -308,6 +308,7 @@ if (NOT CONFIG_MBEDTLS_PSA_CRYPTO_SPM)
   kconfig_check_and_set_base_int(MBEDTLS_SSL_IN_CONTENT_LEN)
   kconfig_check_and_set_base_int(MBEDTLS_SSL_OUT_CONTENT_LEN)
   kconfig_check_and_set_base(MBEDTLS_SSL_CIPHERSUITES)
+  kconfig_check_and_set_base(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
 
   kconfig_check_and_set_base_int(MBEDTLS_MPI_MAX_SIZE)
 


### PR DESCRIPTION
Make it possible to see internal Mbed TLS logs.

Also enable extended master secret DTLS option.