### PR TITLE
KRKNWK-13793: 820 and 811 cleanup from Radio Driver

### DIFF
--- a/nrf_802154/driver/src/nrf_802154_debug.h
+++ b/nrf_802154/driver/src/nrf_802154_debug.h
@@ -51,25 +51,12 @@
 extern "C" {
 #endif
 
-#ifdef NRF52811_XXAA
-
-#define PIN_DBG_RADIO_EVT_END        13
-#define PIN_DBG_RADIO_EVT_DISABLED   14
-#define PIN_DBG_RADIO_EVT_READY      17
-#define PIN_DBG_RADIO_EVT_FRAMESTART 18
-#define PIN_DBG_RADIO_EVT_EDEND      25
-#define PIN_DBG_RADIO_EVT_PHYEND     24
-
-#else
-
 #define PIN_DBG_RADIO_EVT_END        11
 #define PIN_DBG_RADIO_EVT_DISABLED   12
 #define PIN_DBG_RADIO_EVT_READY      13
 #define PIN_DBG_RADIO_EVT_FRAMESTART 14
 #define PIN_DBG_RADIO_EVT_EDEND      25
 #define PIN_DBG_RADIO_EVT_PHYEND     24
-
-#endif
 
 #define PPI_DBG_RADIO_EVT_END           0
 #define PPI_DBG_RADIO_EVT_DISABLED      1

--- a/nrf_802154/driver/src/nrf_802154_nrfx_addons.h
+++ b/nrf_802154/driver/src/nrf_802154_nrfx_addons.h
@@ -44,10 +44,10 @@
    that the maximum value in EDSAMPLE which can be reported in compliance with the 802.15.4 specification is
    255/ED_RSSISCALE. */
 
-#if defined (NRF52840_XXAA) || defined(NRF52811_XXAA)
+#if defined (NRF52840_XXAA)
 #define ED_RSSIOFFS  (-92) ///< dBm value corresponding to value 0 in the EDSAMPLE register.
 #define ED_RSSISCALE 4     ///< Factor needed to calculate the ED result based on the data from the RADIO peripheral.
-#elif defined (NRF52833_XXAA) || defined(NRF52820_XXAA) || defined(NRF5340_XXAA)
+#elif defined (NRF52833_XXAA) || defined(NRF5340_XXAA)
 #define ED_RSSIOFFS  (-93) ///< dBm value corresponding to value 0 in the EDSAMPLE register.
 #define ED_RSSISCALE 5     ///< Factor needed to calculate the ED result based on the data from the RADIO peripheral.
 #else

--- a/nrf_802154/driver/src/nrf_802154_peripherals_nrf52.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals_nrf52.h
@@ -59,11 +59,7 @@ extern "C" {
  */
 #ifndef NRF_802154_EGU_INSTANCE_NO
 
-#if defined(NRF52811_XXAA)
-#define NRF_802154_EGU_INSTANCE_NO 0
-#else
 #define NRF_802154_EGU_INSTANCE_NO 3
-#endif
 
 #endif // NRF_802154_EGU_INSTANCE_NO
 
@@ -112,11 +108,7 @@ extern "C" {
  */
 #ifndef NRF_802154_RTC_INSTANCE_NO
 
-#if defined(NRF52811_XXAA) || defined(NRF52820_XXAA)
-#define NRF_802154_RTC_INSTANCE_NO 0
-#else
 #define NRF_802154_RTC_INSTANCE_NO 2
-#endif
 
 #endif // NRF_802154_RTC_INSTANCE_NO
 

--- a/nrf_802154/driver/src/nrf_802154_rssi.c
+++ b/nrf_802154/driver/src/nrf_802154_rssi.c
@@ -56,8 +56,8 @@ int8_t nrf_802154_rssi_sample_temp_corr_value_get(uint8_t rssi_sample)
     int8_t temp = nrf_802154_temperature_get();
     int8_t result;
 
-#if defined(NRF52840_XXAA) || defined(NRF52820_XXAA) || defined(NRF52833_XXAA)
-    /* Implementation based on Errata 153 for nRF52840 SoC and Errata 225 for nRF52820 nRF52833 SoCs.. */
+#if defined(NRF52840_XXAA) || defined(NRF52833_XXAA)
+    /* Implementation based on Errata 153 for nRF52840 SoC and Errata 225 for nRF52833 SoCs.. */
     if (temp <= -30)
     {
         result = 3;

--- a/nrf_802154/driver/src/nrf_802154_trx.c
+++ b/nrf_802154/driver/src/nrf_802154_trx.c
@@ -65,9 +65,7 @@
 #define EGU_SYNC_INTMASK NRF_EGU_INT_TRIGGERED3
 
 #if defined(NRF52840_XXAA) || \
-    defined(NRF52833_XXAA) || \
-    defined(NRF52820_XXAA) || \
-    defined(NRF52811_XXAA)
+    defined(NRF52833_XXAA)
 #define PPI_CCAIDLE_FEM  NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE ///< PPI that connects RADIO CCAIDLE event with GPIOTE tasks used by FEM
 #define PPI_CHGRP_ABORT  NRF_802154_PPI_ABORT_GROUP                 ///< PPI group used to disable PPIs when async event aborting radio operation is propagated through the system
 #define RADIO_BASE       NRF_RADIO_BASE
@@ -404,9 +402,7 @@ static void fem_for_tx_reset(bool cca)
 }
 
 #if defined(NRF52840_XXAA) || \
-    defined(NRF52833_XXAA) || \
-    defined(NRF52820_XXAA) || \
-    defined(NRF52811_XXAA)
+    defined(NRF52833_XXAA)
 /** @brief Applies DEVICE-CONFIG-254.
  *
  * Shall be called after every RADIO peripheral reset.
@@ -493,9 +489,7 @@ void nrf_802154_trx_enable(void)
     nrf_radio_reset();
 
 #if defined(NRF52840_XXAA) || \
-    defined(NRF52833_XXAA) || \
-    defined(NRF52820_XXAA) || \
-    defined(NRF52811_XXAA)
+    defined(NRF52833_XXAA)
     // Apply DEVICE-CONFIG-254 if needed.
     if (mpsl_fem_device_config_254_apply_get())
     {
@@ -542,9 +536,7 @@ void nrf_802154_trx_enable(void)
     mpsl_fem_pa_is_configured(&m_fem_gain_in_disabled);
 
 #if defined(NRF52840_XXAA) || \
-    defined(NRF52833_XXAA) || \
-    defined(NRF52820_XXAA) || \
-    defined(NRF52811_XXAA)
+    defined(NRF52833_XXAA)
     mpsl_fem_abort_set(nrf_radio_event_address_get(NRF_RADIO, NRF_RADIO_EVENT_DISABLED),
                        PPI_CHGRP_ABORT);
 #elif defined(NRF53_SERIES)

--- a/nrf_802154/serialization/src/include/nrf_802154_nrfx_addons.h
+++ b/nrf_802154/serialization/src/include/nrf_802154_nrfx_addons.h
@@ -44,10 +44,10 @@
    that the maximum value in EDSAMPLE which can be reported in compliance with the 802.15.4 specification is
    255/ED_RSSISCALE. */
 
-#if defined (NRF52840_XXAA) || defined(NRF52811_XXAA)
+#if defined (NRF52840_XXAA)
 #define ED_RSSIOFFS  (-92) ///< dBm value corresponding to value 0 in the EDSAMPLE register.
 #define ED_RSSISCALE 4     ///< Factor needed to calculate the ED result based on the data from the RADIO peripheral.
-#elif defined (NRF52833_XXAA) || defined(NRF52820_XXAA) || defined(NRF5340_XXAA)
+#elif defined (NRF52833_XXAA) || defined(NRF5340_XXAA)
 #define ED_RSSIOFFS  (-93) ///< dBm value corresponding to value 0 in the EDSAMPLE register.
 #define ED_RSSISCALE 5     ///< Factor needed to calculate the ED result based on the data from the RADIO peripheral.
 #else

--- a/nrf_802154/sl/include/nrf_802154_sl_periphs.h
+++ b/nrf_802154/sl/include/nrf_802154_sl_periphs.h
@@ -83,11 +83,7 @@
  */
 #ifndef NRF_802154_RTC_INSTANCE_NO
 
-#if defined(NRF52811_XXAA) || defined(NRF52820_XXAA)
-#define NRF_802154_RTC_INSTANCE_NO 0
-#else
 #define NRF_802154_RTC_INSTANCE_NO 2
-#endif
 
 #endif // NRF_802154_RTC_INSTANCE_NO
 


### PR DESCRIPTION
Removed code explicitly related to 820 and 811.

Signed-off-by: Piotr Sławęcki <piotr.slawecki@nordicsemi.no>