### PR TITLE
softdevice_controller: production support for CTE AoA TX

### DIFF
--- a/mpsl/doc/bluetooth_coex.rst
+++ b/mpsl/doc/bluetooth_coex.rst
@@ -99,6 +99,10 @@ The 1-wire protocol lets Bluetooth LE nRF chips coexist alongside an LTE device 
 It was specifically designed for the `coex interface of nRF9160 <https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf9160%2Fip%2Fradio_lte%2Fdoc%2Fmagpio_if.html>`_.
 
 
+.. note::
+   The 1-Wire coexistence feature is experimental.
+
+
 Hardware resources
 ==================
 

--- a/softdevice_controller/CHANGELOG.rst
+++ b/softdevice_controller/CHANGELOG.rst
@@ -23,7 +23,7 @@ Added
 * Added support for periodic advertising intervals larger than ten seconds (DRGN-16873).
 * Added support for periodic sync timeouts larger than 128 seconds (DRGN-16434).
 * Added :c:func:`sdc_support_ext_central` which makes the extended initiator role configurable (DRGN-16392).
-* Added experimental support for connectionless angle of arrival (AoA) transmitter (DRGN-16588).
+* Added support for connectionless angle of arrival (AoA) transmitter (DRGN-16588).
   The following HCI commands are now supported (DRGN-16713):
 
     * LE Set Connectionless CTE Transmit Parameters

--- a/softdevice_controller/README.rst
+++ b/softdevice_controller/README.rst
@@ -39,7 +39,7 @@ Variants for the Arm Cortex-M33 processor are available as soft-float only.
 
 .. note::
    Periodic Advertising is supported as an experimental feature on the nRF53 Series.
-   For Connectionless CTE Advertising, angle of arrival (AoA) is supported as an experimental feature, but angle of departure (AoD) is not supported.
+   For Connectionless CTE Advertising, angle of arrival (AoA) is supported, but angle of departure (AoD) is not.
 
 Proprietary feature support:
 


### PR DESCRIPTION
Remove "experimental support for AoA" in README
and CHANGELOG

Signed-off-by: Yuxuan Cai <yuxuan.cai@nordicsemi.no>