### PR TITLE
nrf_security: Add definition of appmem partition for mbedtls library

### DIFF
--- a/nrf_security/src/zephyr/CMakeLists.txt
+++ b/nrf_security/src/zephyr/CMakeLists.txt
@@ -64,6 +64,7 @@ if(DEFINED src_zephyr)
     $<TARGET_PROPERTY:${mbedcrypto_target},INTERFACE_COMPILE_DEFINITIONS>
   )
 
+  zephyr_library_sources_ifdef(CONFIG_USERSPACE mbedtls_partition.c)
   zephyr_library_app_memory(k_mbedtls_partition)
 endif()
 

--- a/nrf_security/src/zephyr/mbedtls_partition.c
+++ b/nrf_security/src/zephyr/mbedtls_partition.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ */
+
+#include <zephyr/app_memory/app_memdomain.h>
+
+K_APPMEM_PARTITION_DEFINE(k_mbedtls_partition);


### PR DESCRIPTION
... to make it possible to build with `CONFIG_USERSPACE` enabled
(there is such definition in userspace.c in Zephyr but it is compiled
only when `CONFIG_MBEDTLS` is enabled, what is not the case here).

Ref.: NCSDK-15305