### PR TITLE
nrf_dm: Add missing cmsis dependency

### DIFF
--- a/nrf_dm/Kconfig
+++ b/nrf_dm/Kconfig
@@ -11,6 +11,7 @@ config NRF_DM
 	select CMSIS_DSP_TRANSFORM
 	select CMSIS_DSP_COMPLEXMATH
 	select CMSIS_DSP_STATISTICS
+	select CMSIS_DSP_MATRIX
 	select EXPERIMENTAL
 	help
 		Enable nRF DM (Distance Measurement) library


### PR DESCRIPTION
If the nrf_dm_high_precision_calc() function is being used, there is a
dependency to cmsis_dsp_matrix that was missing.

Verification in https://github.com/nrfconnect/sdk-nrf/pull/7879

Signed-off-by: Jan Müller <jan.mueller@nordicsemi.no>