### PR TITLE
softdevice_controller: Production support for Periodic Adv on nRF53

### DIFF
--- a/softdevice_controller/README.rst
+++ b/softdevice_controller/README.rst
@@ -38,7 +38,6 @@ Variants for the Arm Cortex-M33 processor are available as soft-float only.
 +--------------------------------+-----------------+--------------+-----------+
 
 .. note::
-   Periodic Advertising is supported as an experimental feature on the nRF53 Series.
    For Connectionless CTE Advertising, angle of arrival (AoA) is supported, but angle of departure (AoD) is not.
 
 Proprietary feature support:


### PR DESCRIPTION
Mark Periodic Advertising as not experimental on nRF53.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>