### PR TITLE
nRF RPC: Protocol versioning

### DIFF
--- a/nrf_rpc/include/nrf_rpc.h
+++ b/nrf_rpc/include/nrf_rpc.h
@@ -26,6 +26,9 @@
 extern "C" {
 #endif
 
+/** @brief nRF RPC protocol version. */
+#define NRF_RPC_PROTOCOL_VERSION 0
+
 /** @brief Special value to indicate that ID is unknown or irrelevant. */
 #define NRF_RPC_ID_UNKNOWN 0xFF
 


### PR DESCRIPTION
This PR introduces protocol versioning for the nRF RPC library.
The protocol version range is exchanged  and checked between remote processor during the group initialization process.