### PR TITLE
ci: reduce test scope for crypto and tfm

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -10,11 +10,8 @@
   - "nrf_modem/**/*"
 
 "CI-tfm-test":
-  - "**/*"
-  - "!softdevice_controller/include/**/*"
-  - "!softdevice_controller/lib/**/*"
-  - "!mpsl/include/**/*"
-  - "!mpsl/lib/**/*"
+  - "nrf_crypto/**/*"
+  - "nrf_security/**/*"
 
 "CI-ble-test":
   - "softdevice_controller/include/**/*"
@@ -46,11 +43,7 @@
   - "softdevice_controller/lib/**/*"
 
 "CI-crypto-test":
-  - "**/*"
-  - "!softdevice_controller/include/**/*"
-  - "!softdevice_controller/lib/**/*"
-  - "!mpsl/include/**/*"
-  - "!mpsl/lib/**/*"
+  - "nrf_crypto/**/*"
 
 "CI-rs-test":
   - "mpsl/include/**/*"


### PR DESCRIPTION
No need to run tests if unrelated code changes.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>