### PR TITLE
license: Add tag for detecting license of binary files

### DIFF
--- a/crypto/nrf_cc310_bl/license.txt
+++ b/crypto/nrf_cc310_bl/license.txt
@@ -26,3 +26,11 @@ conditions are met:
  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+########################################################################
+# The following tags tell the "west ncs-sbom" tool which files are     #
+# covered by the license information above.                            #
+# SPDX-License-Identifier: LicenseRef-west-ncs-sbom-ARM-obj-and-header #
+# NCS-SBOM-Apply-To-File: ./lib/**/*.a                                 #
+########################################################################

--- a/crypto/nrf_cc310_mbedcrypto/license.txt
+++ b/crypto/nrf_cc310_mbedcrypto/license.txt
@@ -3,4 +3,8 @@
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/crypto/nrf_cc312_mbedcrypto/license.txt
+++ b/crypto/nrf_cc312_mbedcrypto/license.txt
@@ -3,4 +3,8 @@
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/crypto/nrf_cc312_platform/license.txt
+++ b/crypto/nrf_cc312_platform/license.txt
@@ -2,4 +2,8 @@
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/crypto/nrf_oberon/license.txt
+++ b/crypto/nrf_oberon/license.txt
@@ -2,4 +2,8 @@
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/gzll/license.txt
+++ b/gzll/license.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  *

--- a/nrf_802154/sl/sl/LICENSE
+++ b/nrf_802154/sl/sl/LICENSE
@@ -34,3 +34,11 @@ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+###############################################################################
+# The following tags tell the "west ncs-sbom" tool which files are covered    #
+# by the license information above.                                           #
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause                         #
+# NCS-SBOM-Apply-To-File: ./lib/**/*.a                                        #
+###############################################################################

--- a/nrf_modem/license.txt
+++ b/nrf_modem/license.txt
@@ -3,4 +3,8 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  * SPDX-License-Identifier: ISC
+ *
+ * The following tag tells the "west ncs-sbom" tool which files are covered
+ * by the license information above.
+ * NCS-SBOM-Apply-To-File: ./lib/**/*.a
  */

--- a/openthread/license.txt
+++ b/openthread/license.txt
@@ -25,3 +25,10 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
+
+/*
+ *  The following tags tell the "west ncs-sbom" tool which files are covered
+ *  by the license information above.
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  NCS-SBOM-Apply-To-File: ./lib/**/*.a
+ */


### PR DESCRIPTION
A new tool for a license report generation will be introduced in the new NCS. It will recognize licenses from the source code, but it needs additional information for binary files. This commit adds special tag to license files allowing clear binary files license recognition.

To codeowners of changed files: Please review the license information. The tool, for now, only gets licences type, not details about copyright owners, so you have to check only if the license type is correct.

Soon, contributing file with missing or invalid license information will be blocked, see https://github.com/nrfconnect/sdk-nrf/pull/8022. We have to sort out license information for the libraries in the repository otherwise you will experience problems merging the new PRs.