### PR TITLE
nrf_security: Fix for cipher_update with 0 input

### DIFF
--- a/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -1723,6 +1723,12 @@ psa_status_t psa_driver_wrapper_cipher_update(
 #endif /* PSA_CRYPTO_DRIVER_TEST */
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
         case PSA_CRYPTO_CC3XX_DRIVER_ID:
+            /* Workaround until the cc3xx driver always return success with input
+             * length == 0. Check: NCSDK-16036
+             */
+            if(input_length == 0){
+                return PSA_SUCCESS;
+            }
             return( cc3xx_cipher_update(
                         &operation->ctx.cc3xx_driver_ctx,
                         input, input_length,


### PR DESCRIPTION
-This makes sure that the cipher_update for cc3xx
 always returns success when the input length is
 0. This commit should be dropped when a new
 version of the runtime library is released.

Ref: NCSDK-16036

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>