### PR TITLE
ci: Fix CI_LIB's version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@
 // express written agreement with Nordic Semiconductor ASA.
 //
 
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.9-branch") _
 
 def pipeline = new ncs.sdk_nrfxlib.Main()
 


### PR DESCRIPTION
This branch should use v1.9-branch branch of CI_LIB.

Signed-off-by: Jan Gałda <jan.galda@nordicsemi.no>