### PR TITLE
doc: mpsl: Update docs to mark 1-wire coex as supported for production

### DIFF
--- a/mpsl/CHANGELOG.rst
+++ b/mpsl/CHANGELOG.rst
@@ -15,10 +15,11 @@ All the notable changes included in the main branch are documented in this secti
 Changes
 =======
 
-* Removed the :c:func:`nrf_802154_fal_tx_power_get` function that is not used anymore by nRF 802.15.4 Radio Driver (KRKNWK-14336).
+* Removed the :c:func:`nrf_802154_fal_tx_power_get` function that is not used anymore by nRF 802.15.4 Radio Driver. (KRKNWK-14336)
 * Changed :c:func:`mpsl_fem_tx_power_split` function so the :c:member:`mpsl_tx_power_split_t.radio_tx_power` field contains a value supported by the RADIO peripheral.
-  Previously the value needed to be adjusted before applying to the RADIO peripheral. (KRKNWK-14323).
-* Changed :c:struct:`mpsl_fem_gpiote_pin_config_t` and :c:struct:`mpsl_fem_gpio_pin_config_t` to require GPIO port address, port number and relative pin number instead of the absolute pin number (KRKNWK-11891).
+  Previously the value needed to be adjusted before applying to the RADIO peripheral. (KRKNWK-14323)
+* Changed :c:struct:`mpsl_fem_gpiote_pin_config_t` and :c:struct:`mpsl_fem_gpio_pin_config_t` to require GPIO port address, port number and relative pin number instead of the absolute pin number. (KRKNWK-11891)
+* Added production support for the 1-wire coexistence interface on the Nordic nRF52 Series. (DRGN-16439)
 
 nRF Connect SDK v2.0.0
 **********************

--- a/mpsl/doc/bluetooth_coex.rst
+++ b/mpsl/doc/bluetooth_coex.rst
@@ -99,10 +99,6 @@ The 1-wire protocol lets Bluetooth LE nRF chips coexist alongside an LTE device 
 It was specifically designed for the `coex interface of nRF9160 <https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf9160%2Fip%2Fradio_lte%2Fdoc%2Fmagpio_if.html>`_.
 
 
-.. note::
-   The 1-Wire coexistence feature is experimental.
-
-
 Hardware resources
 ==================
 


### PR DESCRIPTION
Update the changelog to state that we have production support for 1-wire
coex and remove experimental note from the coex documentation.

Related PR in sdk-nrf to update the kconfig: https://github.com/nrfconnect/sdk-nrf/pull/8280

Signed-off-by: Thoresen, Olav <olav.thoresen@nordicsemi.no>