### PR TITLE
openthread: Added a name to anonymous NORDIC_LIBRARY choice

### DIFF
--- a/openthread/Kconfig
+++ b/openthread/Kconfig
@@ -41,7 +41,7 @@ config OPENTHREAD_NORDIC_LIBRARY
 	bool "Nordic library feature sets"
 	depends on !OPENTHREAD_SOURCES
 
-choice
+choice OPENTHREAD_NORDIC_LIBRARY_CONFIGURATION
 	prompt "Feature set"
 	default OPENTHREAD_USER_CUSTOM_LIBRARY
 	help


### PR DESCRIPTION
The anonymous choice that is used for selecting Nordic library configuration doesn't allow to override a default value in any other place of Kconfig structure and forces to that in the .conf file. It is not possible to set this symbol value in some Kconfig.xxx file that could be used for defining a subset of configuration for some specific purpose.

Added OPENTHREAD_NORDIC_LIBRARY_CONFIGURATION name to anonymous choice to allow overriding its default value in the other places of Kconfig structure.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>