### PR TITLE
nrf_rpc: Make number of states configurable

### DIFF
--- a/nrf_rpc/Kconfig
+++ b/nrf_rpc/Kconfig
@@ -19,6 +19,15 @@ config NRF_RPC_CBOR
 	help
 	  Adds API that helps use of CBOR library for data serialization.
 
+config NRF_RPC_ZCBOR_BACKUPS
+	int "Number of ZCBOR backups"
+	default 0
+	help
+	  ZCBOR needs to take a backup for each list/map. The application should
+	  configure this to be the maximum list depth expected in the CBOR data.
+	  E.g., if we have a nested list (2 levels deep) then ZCBOR will need 2
+	  backup states.
+
 config NRF_RPC_CMD_CTX_POOL_SIZE
 	int "Number of available context structures for commands"
 	default 8

--- a/nrf_rpc/include/nrf_rpc_cbor.h
+++ b/nrf_rpc/include/nrf_rpc_cbor.h
@@ -20,7 +20,7 @@
 /* Max ZCBOR states: 2 means that no backups are available but we can use constant state
  * to enable stop_on_error.
  */
-#define NRF_RPC_ZCBOR_STATES	2
+#define NRF_RPC_ZCBOR_STATES	(2 + CONFIG_NRF_RPC_ZCBOR_BACKUPS)
 
 /**
  * @defgroup nrf_rpc_cbor TinyCBOR serialization layer for nRF RPC.


### PR DESCRIPTION
We need to have multiple states to be able to decode nested lists or
maps.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>