### PR TITLE
crypto: doc: Document that the key material can not be in flash

### DIFF
--- a/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_identity_key.h
+++ b/crypto/nrf_cc310_platform/include/nrf_cc3xx_platform_identity_key.h
@@ -24,8 +24,9 @@
  *
  * @note    This API assumes no format of the data stored.
  *
- * @note    The key material stored using this API should be kept secret, for instance
- *          by generating it directly or the device or securely provisioning it.
+ * @note The key material stored using this API may not be in flash
+ *          and should be kept secret, for instance by generating it
+ *          directly or the device or securely provisioning it.
  *
  *
  * @param[in]   slot_id     The first KMU slot ID for the new key (uses 2).

--- a/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_defines.h
+++ b/crypto/nrf_cc312_platform/include/nrf_cc3xx_platform_defines.h
@@ -77,7 +77,7 @@ extern "C"
 #define NRF_KMU_SLOT_MKEK               (2U)    //!< Key slot reserved for MKEK (Master Key Encryption Key).
 #define NRF_KMU_SLOT_MKEK_RESERVED      (3U)    //!< Key slot reserved for MKEK (CC312: Used for last 128 bits of key material).
 
-#define NRF_KMU_SLOT_MEXT               (4U)    //!< Key slot reserved for MEXT (Master Key Encryption Key).
+#define NRF_KMU_SLOT_MEXT               (4U)    //!< Key slot reserved for MEXT (Master key for encrypting EXTernal storage).
 #define NRF_KMU_SLOT_MEXT_RESERVED      (5U)    //!< Key slot reserved for MEXT (CC312: Used for last 128 bits of key material).
 
 #define NRF_KMU_SLOT_KIDENT             (6U)    //!< Key slot reserved for the encrypted KIDENT (Identity key).


### PR DESCRIPTION
Document that the function nrf_cc3xx_platform_identity_key_store can
not accept a pointer to a key that is stored in flash.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>