### PR TITLE
nrf_security: make asn1 parser and writer configurable

### DIFF
--- a/nrf_security/configs/legacy_crypto_config.h.template
+++ b/nrf_security/configs/legacy_crypto_config.h.template
@@ -1919,7 +1919,7 @@
  *          library/pkcs5.c
  *          library/pkparse.c
  */
-#define MBEDTLS_ASN1_PARSE_C
+#cmakedefine MBEDTLS_ASN1_PARSE_C
 
 /**
  * \def MBEDTLS_ASN1_WRITE_C
@@ -1933,7 +1933,7 @@
  *          library/x509write_crt.c
  *          library/x509write_csr.c
  */
-#define MBEDTLS_ASN1_WRITE_C
+#cmakedefine MBEDTLS_ASN1_WRITE_C
 
 /**
  * \def MBEDTLS_BASE64_C


### PR DESCRIPTION
 Two macros `MBEDTLS_PK_WRITE_C` and `MBEDTLS_PK_PARSE_C` are defined
but not effective since the corresponding mbedTLS macros are not affected by them. 
So, define the mbedTLS macros by using `cmakedefine`