### PR TITLE
workflow: compliance: bump junitparser version

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -26,7 +26,7 @@ jobs:
         pip3 install  -U setuptools
         export PATH="$HOME/.local/bin:$PATH"
         pip3 install  -U wheel
-        pip3 install  -U python-magic junitparser==1.6.3 gitlint pylint pykwalify
+        pip3 install  -U python-magic junitparser==2.8.0 gitlint pylint pykwalify
         pip3 install --user -U west
         pip3 show -f west
 


### PR DESCRIPTION
The script requires version > 2.0.
Aligns with the version used in sdk-nrf.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>