### PR TITLE
test: update test-spec.yml

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -85,21 +85,20 @@
     - "!openthread/doc/**/*"
 
 "CI-nfc-test":
-  - "**/*"
-  - "!softdevice_controller/include/**/*"
-  - "!softdevice_controller/lib/**/*"
-  - "!mpsl/include/**/*"
-  - "!mpsl/lib/**/*"
+  - "nfc/**/*"
 
 "CI-matter-test":
   - "mpsl/include/**/*"
   - "mpsl/lib/**/*"
 
 "CI-find-my-test":
-  - "**/*"
+  - "crypto/**/*"
+  - "nfc/**/*"
+  - "nrf_security/**/*"
+  - "softdevice_controller/**/*"
 
 "CI-gazell-test":
-  - "**/*"
+  - "gzll/**/*"
 
 "CI-rpc-test":
   - "nrf_rpc/**/*"


### PR DESCRIPTION
Narrow the pattern that triggers Gazelle, NFC and Find My tests.

At least NFC and Find My tests were triggered by manifest updates
to sdk-nrf that only updated the Modem library, to which
they are completely unrelated.