### PR TITLE
Add fix for GNU compilation for ssize_t (again) + Add fix for restrict

### DIFF
--- a/nrf_modem/include/nrf_socket.h
+++ b/nrf_modem/include/nrf_socket.h
@@ -17,7 +17,22 @@
 extern "C" {
 #endif
 
+#if !defined(__GNUC__) || (__GNUC__ == 0)
 typedef int32_t ssize_t;
+#else
+#include <sys/types.h>
+#ifdef __SES_ARM
+typedef int32_t ssize_t;
+#endif
+#endif
+
+#ifdef __cplusplus
+#   ifdef __GNUC__
+#       define restrict __restrict__ // G++ has restrict
+#   else
+#       define restrict // C++ in general doesn't
+#   endif
+#endif
 
 /**@addtogroup nrf_socket_address_resolution
  *@{


### PR DESCRIPTION
Include of nrf_socket.h prevented successful compilation under GNU:

a) Double declaration of "ssize_t" - check from v1.5.1 has been removed? Why?
b) restrict keyword broke compilation if included as extern "C" in a C++ file.