### PR TITLE
nrf_rpc: Initialize transports independently of each other

### DIFF
--- a/nrf_rpc/CHANGELOG.rst
+++ b/nrf_rpc/CHANGELOG.rst
@@ -19,6 +19,12 @@ Added
 
 * Added the :kconfig:option:`CONFIG_NRF_RPC_ZCBOR_BACKUPS` Kconfig option for setting up the number of zcbor backups.
 
+Changes
+=======
+
+* Enabled independent initialization of transport in each group.
+  This makes RPC available for the groups that are ready, even though initialization of others may have failed.
+
 nRF Connect SDK v2.1.0
 **********************
 

--- a/nrf_rpc/include/nrf_rpc.h
+++ b/nrf_rpc/include/nrf_rpc.h
@@ -108,6 +108,7 @@ struct nrf_rpc_group_data {
 	uint8_t src_group_id;
 	uint8_t dst_group_id;
 	struct nrf_rpc_os_event decode_done_event;
+	bool transport_initialized;
 };
 
 /** @brief Defines a group of commands and events.
@@ -175,6 +176,7 @@ struct nrf_rpc_err_report {
 	static struct nrf_rpc_group_data NRF_RPC_CONCAT(_name, _group_data) = {   \
 		.src_group_id = NRF_RPC_ID_UNKNOWN,                               \
 		.dst_group_id = NRF_RPC_ID_UNKNOWN,                               \
+		.transport_initialized = false,					  \
 	};                                                                        \
 										  \
 	NRF_RPC_AUTO_ARR_ITEM(const struct nrf_rpc_group, _name, "grp",	         \
@@ -237,6 +239,15 @@ struct nrf_rpc_err_report {
 		.handler = _handler,					       \
 		.handler_data = _data,					       \
 	}
+
+/** @brief Check group status.
+ *
+ * Macro checks whether the group and the transport assigned to it have been initialized.
+ *
+ * @param _group Name of the group.
+ */
+#define NRF_RPC_GROUP_STATUS(_group)								\
+	(_group.data->transport_initialized && (_group.data->dst_group_id != NRF_RPC_ID_UNKNOWN))
 
 /** @brief Initialize the nRF RPC
  *

--- a/nrf_rpc/include/nrf_rpc_cbor.h
+++ b/nrf_rpc/include/nrf_rpc_cbor.h
@@ -135,6 +135,14 @@ struct nrf_rpc_cbor_ctx {
 #define NRF_RPC_CBOR_DISCARD(_group, _ctx)            \
 	nrf_rpc_free_tx_buf(_group, (_ctx).out_packet)
 
+/** @brief Check that the memory for a packet has been allocated.
+ *
+ * @param ctx  Context allocated by @ref NRF_RPC_CBOR_ALLOC.
+ *
+ * @return     true if memory is valid otherwise false.
+ */
+bool nrf_rpc_cbor_is_alloc(struct nrf_rpc_cbor_ctx *ctx);
+
 /** @brief Send a command and provide callback to handle response.
  *
  * @param group        Group that command belongs to.

--- a/nrf_rpc/nrf_rpc_cbor.c
+++ b/nrf_rpc/nrf_rpc_cbor.c
@@ -21,6 +21,11 @@ static inline size_t nrf_rpc_cbor_data_len(const struct nrf_rpc_cbor_ctx *ctx)
 	return ctx->zs->payload_mut - ctx->out_packet;
 }
 
+bool nrf_rpc_cbor_is_alloc(struct nrf_rpc_cbor_ctx *ctx)
+{
+	return (ctx->out_packet != NULL);
+}
+
 int nrf_rpc_cbor_cmd(const struct nrf_rpc_group *group, uint8_t cmd,
 		     struct nrf_rpc_cbor_ctx *ctx,
 		     nrf_rpc_cbor_handler_t handler, void *handler_data)


### PR DESCRIPTION
This adds support to initialize transports independently. 
If one transport fails to bond, the others are attempted to initialize.