### PR TITLE
nrf_rpc: Fix array out-of-bounds warnings

### DIFF
--- a/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -7,7 +7,6 @@
 #include <stddef.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 
 BUILD_ASSERT(IS_ENABLED(CONFIG_MULTITHREADING),

--- a/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_MULTITHREADING),
 	"This file is intended for single-threading, but multi-threading is enabled. "

--- a/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -7,7 +7,6 @@
 #include <stddef.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 
 BUILD_ASSERT(IS_ENABLED(CONFIG_MULTITHREADING),

--- a/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
+++ b/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_no_mutex_zephyr.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 BUILD_ASSERT(!IS_ENABLED(CONFIG_MULTITHREADING),
 	"This file is intended for single-threading, but multi-threading is enabled. "

--- a/lc3/src/sw_codec_lc3.c
+++ b/lc3/src/sw_codec_lc3.c
@@ -41,11 +41,11 @@
  *
  */
 
-#include <zephyr.h>
+#include <zephyr/kernel.h>
 #include "sw_codec_lc3.h"
 #include "LC3API.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sw_codec_lc3);
 
 #define ENC_BITRATE_WRN_LVL_LOW 24000

--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -14,6 +14,12 @@
 #include "nrf_rpc_tr.h"
 #include "nrf_rpc_os.h"
 
+#if defined(__GNUC__)
+/* Content of "NRF_RPC_AUTO_ARR" arrays are added by the linker script,
+ * so the compiler should ignore any out of bounds warnings. */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 /* A pointer value to pass information that response */
 #define RESPONSE_HANDLED_PTR ((uint8_t *)1)
 

--- a/nrf_security/src/legacy/entropy_poll.c
+++ b/nrf_security/src/legacy/entropy_poll.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
 #include <mbedtls/entropy.h>

--- a/nrf_security/src/psa/psa_eits_zephyr_settings.c
+++ b/nrf_security/src/psa/psa_eits_zephyr_settings.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>


### PR DESCRIPTION
The newest zephyr-sdk contains GCC version that started
to complain about array out-of-bounds. This is false positive
because the actual content of the array is added by the linker.