### PR TITLE
doc: update secure and non-secure terminology

### DIFF
--- a/crypto/doc/nrf_cc310_mbedcrypto.rst
+++ b/crypto/doc/nrf_cc310_mbedcrypto.rst
@@ -119,9 +119,9 @@ The :c:func:`calloc` and :c:func:`free` functions can be changed with the follow
 
 .. code-block:: c
     :caption: Setting custom calloc/free
-	
+
     int ret;
-    
+
     ret = mbedtls_platform_set_calloc_free(calloc_fn, free_fn);
     if (ret != 0) {
             /* Failed to set the alternative calloc/free */
@@ -160,10 +160,10 @@ You can initialize it by calling the :c:func:`mbedtls_platform_setup`/:c:func:`m
 
 .. code-block:: c
     :caption: Initializing the library
-	
+
     int ret;
     static mbedtls_platform_context platform_context = {0};
-    
+
     ret = mbedtls_platform_setup(&platform_context);
     if (ret != 0) {
             /* Failed to initialize nrf_cc3xx_mbedcrypto platform */
@@ -183,12 +183,12 @@ An alternative to allocating this on the heap is to provide a reference to a sta
 
 .. code-block:: c
     :caption: Preventing heap-allocation for RNG initialization
-	
+
     int ret;
     static mbedtls_rng_workbuf_internal rng_workbuf;
     static mbedtls_platform_context platform_context = {0};
     platform_context.p_rnd_workbuf = &rng_workbuf;
-    
+
     ret = mbedtls_platform_setup(&platform_context);
     if (ret != 0) {
             /* Failed to initialize nrf_cc3xx_mbedcrypto platform */
@@ -198,7 +198,7 @@ An alternative to allocating this on the heap is to provide a reference to a sta
 Usage restrictions
 ------------------
 
-The library cannot be used in the non-secure domain of an application that uses ARM TrustZone.
+The library cannot be used in the :ref:`Non-Secure Processing Environment (NSPE) <nrf:app_boards_spe_nspe>` of an application that uses ARM TrustZone.
 
 The hardware can only process one request at a time.
 Therefore, this library has used mutexes to make the library thread-safe.

--- a/nfc/doc/integration_notes.rst
+++ b/nfc/doc/integration_notes.rst
@@ -47,7 +47,7 @@ nfc_platform_setup()
 
 nfc_platform_nfcid1_default_bytes_get()
   This function is used to fetch default bytes for NFCID1 that are stored in FICR registers.
-  Access to FICR registers differs between secure and non-secure environments.
+  Access to FICR registers differs between Secure and Non-Secure Processing Environments.
 
 nfc_platform_event_handler()
   This event handler is called by the NFC libraries to forward NFC events received from the NFCT driver.

--- a/nrf_modem/doc/ug_nrf_modem_porting_os.rst
+++ b/nrf_modem/doc/ug_nrf_modem_porting_os.rst
@@ -22,8 +22,8 @@ Arrows indicate that the elements can communicate with each other directly.
 
 To use the Modem library, you must make sure that the following requirements are met:
 
-* The application using the Modem library is run in the non-secure domain.
-* The IPC and FPU peripherals are available in the non-secure domain.
+* The application using the Modem library is run in :ref:`Non-Secure Processing Environment (NSPE) <nrf:app_boards_spe_nspe>`.
+* The IPC and FPU peripherals are available in NSPE.
 * The shared memory resides in the lower 128 KB of RAM.
 * The application provides an implementation of the OS interface in the :file:`nrf_modem_os.h` file.
 * The library depends on the nrfx IPC driver or equivalent IPC driver.
@@ -46,15 +46,15 @@ If the OS has its own IRQ handler scheme that does not directly forward the IPC_
 Peripheral configuration
 ************************
 
-As the Modem library has been compiled to operate on peripherals in the non-secure domain, the following two peripherals must be configured to be non-secure:
+As the Modem library has been compiled to operate on peripherals in NSPE, the following two peripherals must be configured to be non-secure:
 
 * NRF_IPC
 * NRF_POWER
 
-If you are using the hard-float variant of the Modem library, the FPU must be activated in both the secure domain and the non-secure domain, and must be configured to allow the non-secure application to run FPU instructions.
+If you are using the hard-float variant of the Modem library, the FPU must be activated in both Secure Processing Environment (SPE) and NSPE, and must be configured to allow the non-secure application to run FPU instructions.
 
 The :file:`nrfx/mdk/system_nrf9160.c` file provides a template on how to configure the FPU in both cases.
-The system file also provides several Errata workarounds specific to the chip variant used, which are needed for any secure domain application.
+The system file also provides several Errata workarounds specific to the chip variant used, which are needed for any SPE application.
 
 Memory
 ******


### PR DESCRIPTION
Replaced "domains" with SPE and NSPE.
NCSDK-17646.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>