### PR TITLE
ci: Check licenses contained in the PR

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,10 @@
+name: License Check
+
+on: pull_request
+
+jobs:
+  call-workflow:
+    uses: doki-nordic/fw-nrfconnect-nrf/.github/workflows/license-reusable.yml
+    with:
+      path: nrfxlib
+      license_allow_list: nrfxlib/scripts/ci/license_allow_list.yaml

--- a/scripts/ci/license_allow_list.yaml
+++ b/scripts/ci/license_allow_list.yaml
@@ -1,0 +1,30 @@
+# List of licenses allowed by the "license_check.py" script.
+# Key is a license identifier, value is a regular expression (see Python's
+# re.search) that matches the files that are allowed to have the license.
+# The value can be multiline string. Each line is a regexp that can optionally
+# start with a '!' character to indicate that it is a negative match.
+# File paths are relative to west workspace directory.
+# Special key "none" match no license. Special key "any" match any license
+# including no license.
+# You can add a '-' character to the beginning of the license identifier to
+# allow specific license, but using it will generate a warning.
+
+# Nordic 5-Clause is always allowed.
+LicenseRef-Nordic-5-Clause: ".*"
+
+# ZBOSS 4-clause is allowed only in zboss directory.
+LicenseRef-ZBOSS-4-Clause: "^nrfxlib/zboss/"
+
+# Missing license information is allowed in all files except the ones listed below using
+# negative match.
+none: |
+  .*
+  !\.c$
+  !\.h$
+  !\.cpp$
+  !\.a$
+  !\.py$
+
+# Any license information is allowed in Python scripts, but it will generate a warning.
+-any: |
+  \.py$


### PR DESCRIPTION
The license information is important for many users, so it have to be accurate. As history shows, incorrect license information can easily sneak in the repository. This script and workflow checks all files changed in each PR and and verifies if they have correct license information.