### PR TITLE
nrf_security: Fix mbedlts Kconfig issues for MD5 and MbedTLS

### DIFF
--- a/nrf_security/Kconfig
+++ b/nrf_security/Kconfig
@@ -182,6 +182,9 @@ config MBEDTLS_MAC_SHA256_ENABLED
 	select PSA_WANT_ALG_SHA_256
 	select PSA_WANT_ALG_HMAC
 
+config MBEDTLS_MAC_MD5_ENABLED
+	bool "MD5 hash algorithm"
+
 config MBEDTLS_CTR_DRBG_ENABLED
 	bool "Enable the CTR_DRBG AES-256-based random generator"
 	select PSA_WANT_ALG_CTR_DRBG

--- a/nrf_security/src/zephyr/CMakeLists.txt
+++ b/nrf_security/src/zephyr/CMakeLists.txt
@@ -64,8 +64,17 @@ if(DEFINED src_zephyr)
     $<TARGET_PROPERTY:${mbedcrypto_target},INTERFACE_COMPILE_DEFINITIONS>
   )
 
-  zephyr_library_sources_ifdef(CONFIG_USERSPACE mbedtls_partition.c)
+  # We need the k_mbedtls_partition when userspace is
+  # used and nrf_security is enabled. However when CONFIG_MBEDTLS
+  # is enabled the partition is defined by Zephyr and therefore
+  # we cannot redefine it here.
+  # (see zephyr/doc/kernel/usermode/memory_domain.rst)
+  if((NOT CONFIG_MBEDTLS) AND CONFIG_USERSPACE)
+    zephyr_library_sources(mbedtls_partition.c)
+  endif()
+
   zephyr_library_app_memory(k_mbedtls_partition)
+
 endif()
 
 # Add configuration/options from zephyr interface libraries


### PR DESCRIPTION
This fixes two issues that we found while trying to build some zephyr samples.
1) When CONFIG_MBEDTLS and CONFIG_USERSPACE are enabled the mbedtls_partition is defined
    by zephyr so nrf_security should not define it. Redefinition of the partition is not allowed and is causing 
    a build failure.

2) The CONFIG_MBEDTLS_MAC_MD5_ENABLED was not defined in nrf_security before. This was
    originally defined in: zephyr/modules/mbedtls/Kconfig.tls-generic. But we have a patch on this file which 
    does not allow this Kconfig to be enabled when CONFIG_NRF_SECURITY is not enabled. 
    The addition here allows the Kconfig to be enabled since
    it is used by some network protocols and it is supported by nrf_security. 

Ref: NCSDK-17995

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>