### PR TITLE
nrf_security: Remove NRF_SECURITY_RNG

### DIFF
--- a/nrf_security/Kconfig.legacy
+++ b/nrf_security/Kconfig.legacy
@@ -322,20 +322,6 @@ config OBERON_BACKEND
 	  PSA_CRYPTO_DRIVER_OBERON should be used instead and will replace this once
 	  PSA crypto APIs are standardized.
 
-menuconfig NRF_SECURITY_RNG
-	bool
-	prompt "Random Number Generator support" if !BUILD_WITH_TFM
-	depends on ENTROPY_HAS_DRIVER
-	default y
-	select MBEDTLS_SHA256_C
-	help
-	  The Random Number Generator support in nRF Security provides a
-	  Pseudorandom Number Generator, PRNG.
-	  The Pseudorandom Number Generator is seeded by a True Random Number
-	  Generator, TRNG, available in hardware.
-
-if NRF_SECURITY_RNG
-
 config MBEDTLS_CTR_DRBG_C
 	bool
 	prompt "PRNG using CTR_DRBG"
@@ -378,8 +364,6 @@ config MBEDTLS_ENTROPY_C
 	  Enable this setting to build entropy APIs usable to gather entropy
 	  form external sources. Only in use for devices that doesn't have 
 	  CryptoCell.
-
-endif # NRF_SECURITY_RNG
 
 menuconfig MBEDTLS_AES_C
 	bool


### PR DESCRIPTION
This removes NRF_SECURITY_RNG since we now
fully support the Zephyr RNG model for TF-M and
secure only targets. It also selects the PSA RNG
driver from Zephyr for TF-M targets.

Ref: NCSDK-14509

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>