### PR TITLE
zboss: add ota upgrade sub header structure

### DIFF
--- a/zboss/development/include/zcl/zb_zcl_ota_upgrade.h
+++ b/zboss/development/include/zcl/zb_zcl_ota_upgrade.h
@@ -238,6 +238,13 @@ typedef ZB_PACKED_PRE struct zb_zcl_ota_upgrade_sub_element_s
 
 } ZB_PACKED_STRUCT zb_zcl_ota_upgrade_sub_element_t;
 
+/*! @brief Structure representation of OTA File Sub-element header */
+typedef ZB_PACKED_PRE struct zb_zcl_ota_upgrade_sub_element_hdr_s
+{
+  zb_uint16_t tag_id;     /** Tag ID*/
+  zb_uint32_t length;     /** length */
+} ZB_PACKED_STRUCT zb_zcl_ota_upgrade_sub_element_hdr_t;
+
 
 /*! @brief OTA File header - Tag Identifiers
     @see ZCL8 specification, subsection 11.4.4

--- a/zboss/production/include/zcl/zb_zcl_ota_upgrade.h
+++ b/zboss/production/include/zcl/zb_zcl_ota_upgrade.h
@@ -238,6 +238,13 @@ typedef ZB_PACKED_PRE struct zb_zcl_ota_upgrade_sub_element_s
 
 } ZB_PACKED_STRUCT zb_zcl_ota_upgrade_sub_element_t;
 
+/*! @brief Structure representation of OTA File Sub-element header */
+typedef ZB_PACKED_PRE struct zb_zcl_ota_upgrade_sub_element_hdr_s
+{
+  zb_uint16_t tag_id;     /** Tag ID*/
+  zb_uint32_t length;     /** length */
+} ZB_PACKED_STRUCT zb_zcl_ota_upgrade_sub_element_hdr_t;
+
 
 /*! @brief OTA File header - Tag Identifiers
     @see ZCL8 specification, subsection 11.4.4


### PR DESCRIPTION
[KRKNWK-15657]
Add ota upgrade sub header structure due to warnings about array-bounds.
Associated with:
https://github.com/nrfconnect/sdk-nrf/pull/9290


Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>