### PR TITLE
doc: a redundant character removal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Refer to their respective documentation for more information.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Contents
 
    crypto/README
    gzll/README


### PR DESCRIPTION
Removing a redundant colon from the nrfxlib ToC.

Signed-off-by: Anna Kielar <anna.kielar@nordicsemi.no>