### PR TITLE
nrf_security: Set default MPI window size according to nrf_cc3xx

### DIFF
--- a/nrf_security/Kconfig.legacy
+++ b/nrf_security/Kconfig.legacy
@@ -254,6 +254,15 @@ config OBERON_ONLY_ENABLED
 
 menu "Legacy mbed TLS crypto APIs"
 
+config MBEDTLS_MPI_WINDOW_SIZE
+	int
+	default 6
+	range 1 6
+	help
+	  Maximum window size used for modular exponentiation.
+	  The default value of 6 is set to match with the configuration used
+	  when building the CryptoCell runtime libraries.
+
 config MBEDTLS_MPI_MAX_SIZE
 	int
 	default 256 if CRYPTOCELL_CC310_USABLE || !CRYPTOCELL_USABLE

--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -155,6 +155,7 @@ kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG)
 kconfig_check_and_set_base_int(MBEDTLS_SSL_OUT_CONTENT_LEN)
 kconfig_check_and_set_base_int(MBEDTLS_SSL_IN_CONTENT_LEN)
 kconfig_check_and_set_base_int(MBEDTLS_ENTROPY_MAX_SOURCES)
+kconfig_check_and_set_base_int(MBEDTLS_MPI_WINDOW_SIZE)
 kconfig_check_and_set_base_int(MBEDTLS_MPI_MAX_SIZE)
 
 # Set all enabled TLS/DTLS key exchange methods

--- a/nrf_security/cmake/psa_crypto_config.cmake
+++ b/nrf_security/cmake/psa_crypto_config.cmake
@@ -334,6 +334,7 @@ if (NOT CONFIG_MBEDTLS_PSA_CRYPTO_SPM)
   kconfig_check_and_set_base(MBEDTLS_SSL_CIPHERSUITES)
   kconfig_check_and_set_base_to_one(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
 
+  kconfig_check_and_set_base_int(MBEDTLS_MPI_WINDOW_SIZE)
   kconfig_check_and_set_base_int(MBEDTLS_MPI_MAX_SIZE)
 
   # x509 configurations

--- a/nrf_security/configs/legacy_crypto_config.h.template
+++ b/nrf_security/configs/legacy_crypto_config.h.template
@@ -3023,7 +3023,7 @@
  */
 
 /* MPI / BIGNUM options */
-#define MBEDTLS_MPI_WINDOW_SIZE            3 /**< Maximum window size used. */
+#cmakedefine MBEDTLS_MPI_WINDOW_SIZE       @MBEDTLS_MPI_WINDOW_SIZE@ /**< Maximum window size used. */
 #cmakedefine MBEDTLS_MPI_MAX_SIZE          @MBEDTLS_MPI_MAX_SIZE@ /**< Maximum number of bytes for usable MPIs. */
 
 /* CTR_DRBG options */

--- a/nrf_security/configs/psa_crypto_config.h.template
+++ b/nrf_security/configs/psa_crypto_config.h.template
@@ -382,7 +382,7 @@
 #cmakedefine MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED               @MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED@
 
 /* Controlling some MPI sizes */
-#define MBEDTLS_MPI_WINDOW_SIZE            3 /**< Maximum window size used. */
+#cmakedefine MBEDTLS_MPI_WINDOW_SIZE       @MBEDTLS_MPI_WINDOW_SIZE@ /**< Maximum window size used. */
 #cmakedefine MBEDTLS_MPI_MAX_SIZE          @MBEDTLS_MPI_MAX_SIZE@ /**< Maximum number of bytes for usable MPIs. */
 
 #endif /* PSA_CRYPTO_CONFIG_H */


### PR DESCRIPTION
-Convert the constant configuration of MBEDTLS_MPI_WINDOW_SIZE to
 Kconfig and change the default to match with the configuration used
 when building the CryptoCell runtime libraries.

ref: NCSDK-18406

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>