### PR TITLE
nrf_security: Remove workaround in cipher_update

### DIFF
--- a/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -1248,12 +1248,6 @@ psa_status_t psa_driver_wrapper_cipher_update(
 #if defined(PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT)
 #if defined(PSA_CRYPTO_DRIVER_HAS_CIPHER_SUPPORT_CC3XX)
         case PSA_CRYPTO_CC3XX_DRIVER_ID:
-            /* Workaround until the cc3xx driver always return success with input
-             * length == 0. Check: NCSDK-16036
-             */
-            if(input_length == 0){
-                return PSA_SUCCESS;
-            }
             return( cc3xx_cipher_update(
                         &operation->ctx.cc3xx_driver_ctx,
                         input, input_length,


### PR DESCRIPTION
This removes the workaround described in NCSDK-16036. The issue was the the cc3xx_cipher_update didn't set the output length to 0 when the input had length 0. Now the cc3xx_cipher_udpate sets the output_length correctly so the workaround is not needed.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>