### PR TITLE
nrf_security: PSA storage in legacy configuration

### DIFF
--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -98,6 +98,7 @@ kconfig_check_and_set_base(MBEDTLS_PK_WRITE_C)
 kconfig_check_and_set_base(MBEDTLS_DEBUG_C)
 
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_SPM)
+kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_STORAGE_C)
 
 # PSA is not to be enabled for SPM builds
 if (NOT CONFIG_SPM)


### PR DESCRIPTION
Allow to enable PSA storage even when using the legacy configuration. Not sure if it was an omission or deliberate decision, so hope to find out using this PR.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>