### PR TITLE
cmake: remove get_mbedtls_dir() and use ZEPHYR_MBEDTLS_MODULE_DIR

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -75,25 +75,3 @@ function(nrfxlib_calculate_lib_path lib_path)
     set(${lib_path} "lib/${arch_soc_dir}/${float_dir}${short_wchar}" PARENT_SCOPE)
   endif()
 endfunction()
-
-function(get_mbedtls_dir ARM_MBEDTLS_PATH_ARG)
-  if(EXISTS ${${ARM_MBEDTLS_PATH_ARG}})
-  # Do nothing, just use the provided path
-  elseif(WEST)
-  ## Use `west` to find the mbedtls tree we use (this is not the
-  ## mbedtls tree distributed as a zephyr module).
-    execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} -c
-      "from west.manifest import Manifest; manifest = Manifest.from_file(); print(manifest.get_projects(['mbedtls-nrf'])[0].posixpath)"
-      OUTPUT_VARIABLE west_project_output
-      RESULT_VARIABLE result
-    )
-    string(REGEX REPLACE "[\r\n]+" "" arm_mbedtls_path "${west_project_output}")
-    if(${result})
-      message(FATAL_ERROR "Failed to find mbedtls, cannot build security libraries")
-    endif()
-    set(${ARM_MBEDTLS_PATH_ARG} ${arm_mbedtls_path} PARENT_SCOPE)
-  else()
-    message(FATAL_ERROR "west not installed, please provide ARM_MBEDTLS_PATH to CMake to support security libraries")
-  endif()
-endfunction()

--- a/nrf_security/CMakeLists.txt
+++ b/nrf_security/CMakeLists.txt
@@ -29,8 +29,8 @@ else()
   set(mbedtls_target    mbedtls)
 endif()
 
-# Populate ARM_MBEDTLS_PATH
-get_mbedtls_dir(ARM_MBEDTLS_PATH)
+# Populate ARM_MBEDTLS_PATH with the value of ZEPHYR_MBEDTLS_MODULE_DIR
+set(ARM_MBEDTLS_PATH ${ZEPHYR_MBEDTLS_MODULE_DIR})
 
 # MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER must be disabled for Zephyr
 # builds or when MBEDTLS_USE_PSA_CRYPTO is enabled (e.g. for TLS/DTLS

--- a/openthread/cmake/extensions.cmake
+++ b/openthread/cmake/extensions.cmake
@@ -72,8 +72,7 @@ function(openthread_libs_configuration_write CONFIG_FILE)
 
   find_package(Git QUIET)
   if(GIT_FOUND)
-    get_mbedtls_dir(ARM_MBEDTLS_PATH)
-    get_git_decribe(${ARM_MBEDTLS_PATH})
+    get_git_decribe(${ZEPHYR_MBEDTLS_MODULE_DIR})
     list(INSERT OPENTHREAD_SETTINGS 0 "MBEDTLS_commit=${git_describe}\n")
 
     get_git_decribe(${ZEPHYR_NRFXLIB_MODULE_DIR})


### PR DESCRIPTION
Zephyr's fork of mbed TLS has been updated to match a version required by nRF Security.
This means that the nRF Connect SDK manifest file points to the Zephyr fork and no longer points at arm mbed TLS github repository.

Therefore mbed TLS is now available as a Zephyr module and nRF Security can therefor use `ZEPHYR_MBEDTLS_MODULE_DIR` directly and thus remove the need for a custom `get_mbedtls_dir()` function.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>