### PR TITLE
ci: Updated test-spec.yml for Cloud CI testing

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -124,3 +124,9 @@
 
 "CI-positioning-test":
   - "nrf_modem/**/*"
+
+"CI-cloud-test":
+  - "nrf_modem/**/*"
+  - "nrf_security/**/*"
+  - "crypto/**/*"
+  - "nrf_rpc/**/*"


### PR DESCRIPTION
Added an entry for CI-cloud-test that will run the downstream job of test-fw-nrfconnect-nrf-iot_cloud when any of the listed modules change.

See IRIS-5423

Signed-off-by: Tony Le <tony.le@nordicsemi.no>