### PR TITLE
MPSL: Allow linking with MPSL compiled for babblesim

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -36,6 +36,8 @@ function(nrfxlib_calculate_lib_path lib_path)
   if(${CALC_LIB_PATH_SOC_MODE})
     # CMake regex does not support {4}
     string(REGEX REPLACE "_[a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z]$" "" arch_soc_dir ${CONFIG_SOC})
+  elseif(CONFIG_SOC_SERIES_BSIM_NRFXX)
+    set(arch_soc_dir "bsim_nrfxx")
   else()
     # Add Arch type
     assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")

--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -10,7 +10,7 @@ config MPSL
 	select IEEE802154_NRF5_EXT_IRQ_MGMT if IEEE802154_NRF5
 	select NRF_802154_MULTIPROTOCOL_SUPPORT if NRF_802154_RADIO_DRIVER
 	select MULTITHREADING_LOCK
-	depends on (SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
+	depends on (SOC_SERIES_BSIM_NRFXX || SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET)
 	help
 	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,
 	  providing services for single and multi-protocol implementations.


### PR DESCRIPTION
Allows the build system to find and build with an MPSL library compiled for the babblesim target.

Only intended for internal use for now.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>