### PR TITLE
nrf_security: Add missing configuration settings for legacy.

### DIFF
--- a/nrf_security/Kconfig.psa
+++ b/nrf_security/Kconfig.psa
@@ -52,7 +52,7 @@ config PSA_CRYPTO_SECURE
 
 config MBEDTLS_PSA_CRYPTO_CLIENT
 	bool
-	default y
+	default y if !MBEDTLS_LEGACY_CRYPTO_C
 
 rsource "src/drivers/Kconfig"
 
@@ -74,7 +74,7 @@ config MBEDTLS_PSA_CRYPTO_STORAGE_C
 
 config MBEDTLS_USE_PSA_CRYPTO
 	bool "PSA APIs for X.509 and TLS library"
-	default y
+	default y if !MBEDTLS_LEGACY_CRYPTO_C
 	help
 	  Corresponds to MBEDTLS_USE_PSA_CRYPTO setting in mbed TLS config file.
 

--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -100,9 +100,7 @@ kconfig_check_and_set_base(MBEDTLS_DEBUG_C)
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_SPM)
 
 # PSA is not to be enabled for SPM builds
-if (NOT CONFIG_SPM)
-  kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_C)
-endif()
+kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_C)
 
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_EXIT_ALT)
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_FPRINTF_ALT)

--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -101,6 +101,9 @@ kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_SPM)
 
 # PSA is not to be enabled for SPM builds
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_C)
+kconfig_check_and_set_base(MBEDTLS_USE_PSA_CRYPTO)
+kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_STORAGE_C)
+kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_CLIENT)
 
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_EXIT_ALT)
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_FPRINTF_ALT)


### PR DESCRIPTION
MBEDTLS_USE_PSA_CRYPTO
MBEDTLS_PSA_CRYPTO_STORAGE_C
MBEDTLS_PSA_CRYPTO_CLIENT
Was not correctly set in the legacy crypto configuration header.

Default these to disabled when legacy configuration is enabled
so that this does not cause any changes to the build.

Remove conditional check for SPM. This is removed so this is always
true.