### PR TITLE
nrf_modem: os: increase number of semaphores required

### DIFF
--- a/nrf_modem/include/nrf_modem_os.h
+++ b/nrf_modem/include/nrf_modem_os.h
@@ -27,7 +27,7 @@ extern "C" {
 /** Infinite time-out. */
 #define NRF_MODEM_OS_FOREVER -1
 /** Number of OS semaphores required. */
-#define NRF_MODEM_OS_NUM_SEM_REQUIRED 6
+#define NRF_MODEM_OS_NUM_SEM_REQUIRED 7
 
 enum log_level {
 	NRF_MODEM_LOG_LEVEL_NONE,


### PR DESCRIPTION
There is the need for one more semaphore if the modem library is used in both normal and bootloader mode.