### PR TITLE
nrf_security: Enable support for MBEDTLS debug logs

### DIFF
--- a/nrf_security/configs/nrf-config.h
+++ b/nrf_security/configs/nrf-config.h
@@ -396,6 +396,12 @@ extern "C" {
 #define MBEDTLS_PSA_BUILTIN_MAC
 #endif
 
+#if defined(CONFIG_MBEDTLS_DEBUG)
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_DEBUG_C
+#define MBEDTLS_SSL_DEBUG_ALL
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/nrf_security/src/CMakeLists.txt
+++ b/nrf_security/src/CMakeLists.txt
@@ -129,7 +129,11 @@ append_with_prefix(src_tls ${ARM_MBEDTLS_PATH}/library
     ssl_tls13_generic.c
 )
 
-
+if (CONFIG_MBEDTLS_DEBUG)
+  append_with_prefix(src_tls ${ARM_MBEDTLS_PATH}/library
+    ssl_debug_helpers_generated.c
+  )
+endif()
 
 if (COMPILE_PSA_APIS)
   # Add files for PSA build
@@ -280,6 +284,16 @@ if (CONFIG_MBEDTLS_TLS_LIBRARY)
     PUBLIC
       mbedcrypto_common
   )
+
+  if (CONFIG_MBEDTLS_DEBUG)
+    # Add Zephyr's mbedlts module include path because we need rely on their headers for debug logs.
+    target_include_directories(mbedcrypto_common
+        INTERFACE
+          ${ZEPHYR_BASE}/modules/mbedtls/include
+    )
+    zephyr_library_sources(${ZEPHYR_BASE}/modules/mbedtls/debug.c)
+    zephyr_library_sources(debug_init.c)
+  endif()
 endif()
 
 # Include EITS in Zephyr build

--- a/nrf_security/src/debug_init.c
+++ b/nrf_security/src/debug_init.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include <zephyr/init.h>
+#include <mbedtls/debug.h>
+
+static int _mbedtls_init(const struct device *device)
+{
+	ARG_UNUSED(device);
+
+#if defined(CONFIG_MBEDTLS_DEBUG_LEVEL)
+	mbedtls_debug_set_threshold(CONFIG_MBEDTLS_DEBUG_LEVEL);
+#endif
+
+	return 0;
+}
+
+SYS_INIT(_mbedtls_init, POST_KERNEL, 0);


### PR DESCRIPTION
Adds support for CONFIG_MBEDTLS_DEBUG, so that debug log callbacks and log level is set up for MBEDTLS.