### PR TITLE
nrf_modem: include: add dfu to nrf_modem_init return values

### DIFF
--- a/nrf_modem/include/nrf_modem.h
+++ b/nrf_modem/include/nrf_modem.h
@@ -225,6 +225,9 @@ char *nrf_modem_build_version(void);
  * @param[in] init_params Initialization parameters.
  *
  * @retval Zero on success.
+ * @retval A positive value from @ref nrf_modem_dfu when executing
+ *         Modem firmware updates.
+ *
  * @retval -NRF_EPERM The Modem library is already initialized.
  * @retval -NRF_EFAULT @c init_params is @c NULL.
  * @retval -NRF_ENOLCK Not enough semaphores.


### PR DESCRIPTION
When performing DFU, the nrf_modem_init() return value will contain the DFU result. This was missing from the documentation when splitting the normal and bootloader mode into separate functions.