### PR TITLE
cmake: nrf_security_add_zephyr_options() adds dependency to z_interface

### DIFF
--- a/nrf_security/cmake/extensions.cmake
+++ b/nrf_security/cmake/extensions.cmake
@@ -99,8 +99,10 @@ macro(nrf_security_add_zephyr_options lib_name)
   if(TARGET zephyr_interface)
     # Add compile options and includes from zephyr
     target_compile_options(${lib_name} PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>)
+    target_compile_definitions(${lib_name} PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_DEFINITIONS>)
     target_include_directories(${lib_name} PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(${lib_name} PRIVATE $<TARGET_PROPERTY:zephyr_interface,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
+    add_dependencies(${lib_name} zephyr_interface)
 
     # Unsure if these are needed any more
     target_compile_options(${lib_name} PRIVATE ${TOOLCHAIN_C_FLAGS})


### PR DESCRIPTION
nrf_security_add_zephyr_options() now adds a dependency to zephyr_interface for libraries which requires include paths defined by zephyr_interface.
This ensures that all header files generated through zephyr_interface sub-dependencies will be available upon compilation of the library passed to nrf_security_add_zephyr_options().

Examples of headers that could otherwise be missing:
- syscall_list.h
- kobj-types-enum.h