### PR TITLE
nrf_security: Use default import_key from PSA core

### DIFF
--- a/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -716,15 +716,15 @@ psa_status_t psa_driver_wrapper_import_key(
                return( status );
 #endif /* PSA_CRYPTO_DRIVER_HAS_ACCEL_KEY_TYPES_OBERON */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
-            /* Fell through, meaning no accelerator supports this operation */
-#if defined(MBEDTLS_PSA_BUILTIN_HAS_KEY_TYPE)
-            return( psa_import_key_into_slot( attributes,
-                                              data, data_length,
-                                              key_buffer, key_buffer_size,
-                                              key_buffer_length, bits ) );
-#else
-            return ( PSA_ERROR_NOT_SUPPORTED );
-#endif /* !MBEDTLS_PSA_BUILTIN_HAS_KEY_TYPE */
+        /*
+         * Fall through, meaning no accelerator supports this operation.
+         * Oberon doesn't support importing symmetric keys at the moment
+         * so this is necessary for Oberon to work.
+         */
+        return( psa_import_key_into_slot( attributes,
+                                          data, data_length,
+                                          key_buffer, key_buffer_size,
+                                          key_buffer_length, bits ) );
         default:
             (void)status;
             return( PSA_ERROR_INVALID_ARGUMENT );

--- a/nrf_security/src/psa_crypto_driver_wrappers.c
+++ b/nrf_security/src/psa_crypto_driver_wrappers.c
@@ -844,17 +844,16 @@ psa_status_t psa_driver_wrapper_export_public_key(
                  return( status );
 #endif /* PSA_CRYPTO_DRIVER_HAS_ACCEL_KEY_TYPES_OBERON */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
-#if defined(MBEDTLS_PSA_BUILTIN_HAS_KEY_TYPE)
-            /* Fell through, meaning no accelerator supports this operation */
-            return( psa_export_public_key_internal( attributes,
-                                                    key_buffer,
-                                                    key_buffer_size,
-                                                    data,
-                                                    data_size,
-                                                    data_length ) );
-#else
-            return ( PSA_ERROR_NOT_SUPPORTED );
-#endif /* !MBEDTLS_PSA_BUILTIN_HAS_KEY_TYPE */
+        /* Fell through, meaning no accelerator supports this operation.
+         * The CryptoCell driver doesn't support export public keys when
+         * the key is a public key itself, so this is necessary.
+         */
+        return( psa_export_public_key_internal( attributes,
+                                                key_buffer,
+                                                key_buffer_size,
+                                                data,
+                                                data_size,
+                                                data_length ) );
         default:
             /* Key is declared with a lifetime not known to us */
             return( status );


### PR DESCRIPTION
This makes sure that we always call the function
psa_import_key_into_slot when no crypto accelerator import_key functionality is available. This is needed because our Oberon library does not support import_key for symmetric keys but it supports doing operations with symmetric keys. The psa_import_key_into_slot function always includes the logic for symmetric keys, which has minor effects in increasing the code size. The support for asymmetric keys on the other hand is configurable which is a good for us since Oberon does support
import_key with asymmetric keys.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>