### PR TITLE
nrf_rpc: Allow multiple initialization of nRF RPC

### DIFF
--- a/nrf_rpc/CHANGELOG.rst
+++ b/nrf_rpc/CHANGELOG.rst
@@ -9,6 +9,14 @@ Changelog
 
 All the notable changes to this project are documented on this page.
 
+Main branch
+***********
+
+Changes
+=======
+
+* Enabled the nRF RPC library to be initialized more than once.
+
 nRF Connect SDK v2.2.0
 **********************
 

--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -95,6 +95,9 @@ static uint8_t group_count;
 
 static uint8_t initialized_group_count;
 
+/* nRF RPC initialization status. */
+static bool is_initialized;
+
 /* Error handler provided to the init function. */
 static nrf_rpc_err_handler_t global_err_handler;
 
@@ -966,6 +969,10 @@ int nrf_rpc_init(nrf_rpc_err_handler_t err_handler)
 
 	NRF_RPC_DBG("Initializing nRF RPC module");
 
+	if (is_initialized) {
+		return 0;
+	}
+
 	global_err_handler = err_handler;
 
 	for (NRF_RPC_AUTO_ARR_FOR(iter, group, &nrf_rpc_groups_array,
@@ -1008,6 +1015,7 @@ int nrf_rpc_init(nrf_rpc_err_handler_t err_handler)
 		return err;
 	}
 
+	is_initialized = true;
 	NRF_RPC_DBG("Done initializing nRF RPC module");
 
 	return err;


### PR DESCRIPTION
This commit enables the initialization of nRF RPC more than once. 
Subsequent initialization of an already properly initialized nRF RPC will succeed.

Manifest update: https://github.com/nrfconnect/sdk-nrf/pull/10775
