### PR TITLE
crypto: Remove cryptocell usable configs and use HAS_HW instead

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -3,20 +3,8 @@ menu "Crypto libraries for nRF5x SOCs."
 config NRFXLIB_CRYPTO
 	bool
 
-config CRYPTOCELL_CC310_USABLE
-	bool
-	depends on SOC_NRF52840 || (SOC_SERIES_NRF91X && (BUILD_WITH_TFM || !TRUSTED_EXECUTION_NONSECURE))
-	default y
-
-config CRYPTOCELL_CC312_USABLE
-	bool
-	depends on SOC_NRF5340_CPUAPP && (BUILD_WITH_TFM || !TRUSTED_EXECUTION_NONSECURE)
-	default y
-
-config CRYPTOCELL_USABLE
-	bool
-	depends on CRYPTOCELL_CC310_USABLE || CRYPTOCELL_CC312_USABLE
-	default y
+config HAS_HW_NRF_CC3XX
+	def_bool HAS_HW_NRF_CC310 || HAS_HW_NRF_CC312
 
 config NRF_OBERON
 	bool "nrf_oberon SW crypto library for nRF5x."
@@ -42,7 +30,7 @@ endif
 
 menuconfig NRF_CC3XX_PLATFORM
 	bool "nrf_cc3xx_platform HW crypto library for nRF devices with CryptoCell CC3xx."
-	depends on CRYPTOCELL_USABLE && !BUILD_WITH_TFM
+	depends on HAS_HW_NRF_CC3XX && !BUILD_WITH_TFM
 	select NRFXLIB_CRYPTO if !BUILD_WITH_TFM
 	help
 	  This configuration is only available for direct use of nrf_cc3xx_platform

--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -22,12 +22,6 @@ config NRF_CC310_BL
 	  This configuration is only available for direct use of nrf_cc3xx_bl
 	  To use, link with nrfxlib_crypto in CMake.
 
-if NRF_CC310_BL
-	config HW_CC310_INTERRUPT
-	bool #"Use interrupt version of nrf cc310 bl library"
-	default n # Only the no-interrupts version currently verified to work with Zephyr.
-endif
-
 menuconfig NRF_CC3XX_PLATFORM
 	bool "nrf_cc3xx_platform HW crypto library for nRF devices with CryptoCell CC3xx."
 	depends on HAS_HW_NRF_CC3XX && !BUILD_WITH_TFM


### PR DESCRIPTION
Remove the configurations for cryptocell usable and use the standard HAS_HW configurations instead.