### PR TITLE
nrf_security: add openthread config for mbedtls debug

### DIFF
--- a/nrf_security/Kconfig.tls
+++ b/nrf_security/Kconfig.tls
@@ -171,6 +171,12 @@ config MBEDTLS_DEBUG_LEVEL
 	  3 Information
 	  4 Verbose
 
+config OPENTHREAD_MBEDTLS_DEBUG
+	bool "MbedTLS logs for OpenThread"
+	select MBEDTLS
+	select MBEDTLS_DEBUG
+	select MBEDTLS_DEBUG_C
+
 config MBEDTLS_SSL_PROTO_DTLS
 	bool "Enable support for DTLS"
 	depends on MBEDTLS_SSL_PROTO_TLS1_2


### PR DESCRIPTION
Adds config that makes it possible to enable mbedtls debug configs with openthread. Currently it's impossible to select MBEDTLS_DEBUG if not using CUSTOM_OPENTHREAD_SECURITY (as MBEDTLS is promptless in default openthread configuration).