### PR TITLE
nrf_security: add openthread config for mbedtls debug

### DIFF
--- a/nrf_security/Kconfig.tls
+++ b/nrf_security/Kconfig.tls
@@ -439,3 +439,9 @@ endmenu
 
 
 endif # MBEDTLS_TLS_LIBRARY
+
+config OPENTHREAD_MBEDTLS_DEBUG
+	bool "MbedTLS logs for OpenThread"
+	select MBEDTLS
+	select MBEDTLS_DEBUG
+	select MBEDTLS_DEBUG_C


### PR DESCRIPTION
Adds config that makes it possible to enable mbedtls debug configs with openthread. Currently it's impossible to select MBEDTLS_DEBUG if not using CUSTOM_OPENTHREAD_SECURITY (as MBEDTLS is promptless in default openthread configuration).