### PR TITLE
TF-M: Remove usage of HEAP

### DIFF
--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -99,10 +99,7 @@ kconfig_check_and_set_base(MBEDTLS_DEBUG_C)
 
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_SPM)
 
-# PSA is not to be enabled for SPM builds
-if (NOT CONFIG_SPM)
-  kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_C)
-endif()
+kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_C)
 
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_EXIT_ALT)
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_FPRINTF_ALT)

--- a/nrf_security/include/mbedtls/platform.h
+++ b/nrf_security/include/mbedtls/platform.h
@@ -81,12 +81,15 @@ extern "C" {
 #if !defined(MBEDTLS_PLATFORM_STD_FPRINTF)
 #define MBEDTLS_PLATFORM_STD_FPRINTF fprintf /**< The default \c fprintf function to use. */
 #endif
-#if !defined(MBEDTLS_PLATFORM_STD_CALLOC)
-#define MBEDTLS_PLATFORM_STD_CALLOC   calloc /**< The default \c calloc function to use. */
-#endif
-#if !defined(MBEDTLS_PLATFORM_STD_FREE)
-#define MBEDTLS_PLATFORM_STD_FREE       free /**< The default \c free function to use. */
-#endif
+
+/* We intentionally don't set MBEDTLS_PLATFORM_STD_CALLOC to 'calloc' and
+ * MBEDTLS_PLATFORM_STD_FREE to 'free' here.
+ * This would pull in stdlib heap usage such as the function `_sbrk'.
+ * When these are undefined platform.c will define stub functions, which are
+ * never used as we call mbedtls_platform_set_calloc_free to set alternative
+ * heap functions.
+ */
+
 #if !defined(MBEDTLS_PLATFORM_STD_EXIT)
 #define MBEDTLS_PLATFORM_STD_EXIT      exit /**< The default \c exit function to use. */
 #endif

--- a/nrf_security/tfm/CMakeLists.txt
+++ b/nrf_security/tfm/CMakeLists.txt
@@ -61,6 +61,9 @@ set(CONFIG_MBEDTLS_PLATFORM_ZEROIZE_ALT             True)
 set(CONFIG_MBEDTLS_THREADING_ALT                    False)
 set(CONFIG_MBEDTLS_THREADING_C                      False)
 
+# mbedtls_printf is used to print messages including error information.
+set(MBEDTLS_PLATFORM_PRINTF_ALT                     True)
+
 # Set the a define stating that KEY_ID encodes owner
 set(CONFIG_MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER  True)
 


### PR DESCRIPTION
Remove usage of HEAP in platform.c.
The functions free and calloc pulls in heap from the C standard library.
We always call mbedtls_platform_set_calloc_free to set alternative
heap management functions so this is unneccesary.

NCSDK-19561

TF-M uses the mbedtls_platform_set_printf to set 'printf' as the
mbedtls logging function. This is unneccary as we already have set
'printf' as the default function in platform.h, but we don't want to
modify the TF-M source code unless we have to.The functions free and calloc pulls in heap from the C standard library.
We always call mbedtls_platform_set_calloc_free to set alternative
heap management functions so this is unneccesary.