### PR TITLE
nrf_security: Remove usage of CONFIG_SPM configuration

### DIFF
--- a/nrf_security/cmake/legacy_crypto_config.cmake
+++ b/nrf_security/cmake/legacy_crypto_config.cmake
@@ -99,10 +99,7 @@ kconfig_check_and_set_base(MBEDTLS_DEBUG_C)
 
 kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_SPM)
 
-# PSA is not to be enabled for SPM builds
-if (NOT CONFIG_SPM)
-  kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_C)
-endif()
+kconfig_check_and_set_base(MBEDTLS_PSA_CRYPTO_C)
 
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_EXIT_ALT)
 kconfig_check_and_set_base_to_one(MBEDTLS_PLATFORM_FPRINTF_ALT)


### PR DESCRIPTION
Remove usage of CONFIG_SPM configuration.
SPM has been removed so the if-statement is always true.