### PR TITLE
nrf_security: Properly close 'extern "C"' scopes

### DIFF
--- a/crypto/nrf_cc310_mbedcrypto/include/mbedtls/chachapoly_alt.h
+++ b/crypto/nrf_cc310_mbedcrypto/include/mbedtls/chachapoly_alt.h
@@ -32,10 +32,6 @@ typedef struct
 #endif
 
 #ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef __cplusplus
 }
 #endif
 

--- a/crypto/nrf_cc312_mbedcrypto/include/mbedtls/chachapoly_alt.h
+++ b/crypto/nrf_cc312_mbedcrypto/include/mbedtls/chachapoly_alt.h
@@ -32,10 +32,6 @@ typedef struct
 #endif
 
 #ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef __cplusplus
 }
 #endif
 

--- a/nrf_security/include/native_its/psa/internal_trusted_storage.h
+++ b/nrf_security/include/native_its/psa/internal_trusted_storage.h
@@ -139,4 +139,8 @@ psa_status_t psa_its_get_info(psa_storage_uid_t uid,
  */
 psa_status_t psa_its_remove(psa_storage_uid_t uid);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* PSA_CRYPTO_ITS_H */


### PR DESCRIPTION
Some headers either had multiple instances of 'extern "C"', or were missing a closing '}' if __cplusplus were defined. Fixed.