### PR TITLE
crypto: Delete Kconfig HW_CC3XX_INTERRUPT

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -76,9 +76,7 @@ endif()
 if (CONFIG_NRF_CC310_BL)
   assert(CONFIG_HAS_HW_NRF_CC310 "nrf_cc310_bl requires CryptoCell hardware.")
   set(CC310_BL_BASE ${CMAKE_CURRENT_SOURCE_DIR}/nrf_cc310_bl)
-  if (NOT CONFIG_HW_CC3XX_INTERRUPT)
-    set(CC310_FLAVOR no-interrupts)
-  endif()
+  set(CC310_FLAVOR no-interrupts)
   set(CC310_BL_VER 0.9.12)
 
   nrfxlib_calculate_lib_path(CC310_BL_LIB_DIR
@@ -107,9 +105,7 @@ if (CONFIG_NRF_CC3XX_PLATFORM)
 
   set (NRF_CC3XX_PLATFORM_BASE ${CMAKE_CURRENT_SOURCE_DIR}/nrf_${CC3XX_ARCH}_platform)
   set (NRF_CC3XX_PLATFORM_VER 0.9.17)
-  if (NOT CONFIG_HW_CC3XX_INTERRUPT)
-    set(CC3XX_PLATFORM_FLAVOR no-interrupts)
-  endif()
+  set(CC3XX_PLATFORM_FLAVOR no-interrupts)
 
   nrfxlib_calculate_lib_path(NRF_CC3XX_PLATFORM_LIB_DIR
     BASE_DIR ${NRF_CC3XX_PLATFORM_BASE}
@@ -166,9 +162,7 @@ if (CONFIG_CC3XX_BACKEND OR (CONFIG_PSA_CRYPTO_DRIVER_CC3XX AND NOT BUILD_WITH_T
   endif()
   set(NRF_CC3XX_BASE ${CMAKE_CURRENT_SOURCE_DIR}/nrf_${CC3XX_ARCH}_mbedcrypto)
   set(NRF_CC3XX_VER 0.9.17)
-  if (NOT CONFIG_HW_CC3XX_INTERRUPT)
-    set(CC3XX_FLAVOR no-interrupts)
-  endif()
+  set(CC3XX_FLAVOR no-interrupts)
 
   nrfxlib_calculate_lib_path(NRF_CC3XX_LIB_DIR
     BASE_DIR ${NRF_CC3XX_BASE}

--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -50,9 +50,6 @@ menuconfig NRF_CC3XX_PLATFORM
 
 if NRF_CC3XX_PLATFORM
 
-config HW_CC3XX_INTERRUPT
-	bool "Use interrupt version of nrf cc3xx platform library" if !(CC3XX_BACKEND || NRF_CC310_BL)
-
 choice CC3XX_LOCK_VARIANT
 	prompt "CC3XX lock variant"
 	default CC3XX_MUTEX_LOCK


### PR DESCRIPTION
Delete the Kconfig option HW_CC3XX_INTERRUPT as it is not supported.