### PR TITLE
ci: Add Wi-Fi crypto dependency to test-spec

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -130,3 +130,7 @@
   - "nrf_security/**/*"
   - "crypto/**/*"
   - "nrf_rpc/**/*"
+
+"CI-wifi":
+  - "crypto/**/*"
+  - "nrf_security/**/*"


### PR DESCRIPTION
Wi-Fi crypto has dependencies on MbedTLS, so, add an entry to the test-spec to catch any breaking changes.