### PR TITLE
softdevice_controller: Do not use header files when SDC build from src

### DIFF
--- a/softdevice_controller/CMakeLists.txt
+++ b/softdevice_controller/CMakeLists.txt
@@ -4,9 +4,12 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-zephyr_interface_library_named (SOFTDEVICE_CONTROLLER_LIB_HEADERS)
-target_include_directories(SOFTDEVICE_CONTROLLER_LIB_HEADERS
-  INTERFACE include)
+if (CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE)
+  zephyr_interface_library_named (SOFTDEVICE_CONTROLLER_LIB_HEADERS)
+  target_include_directories(SOFTDEVICE_CONTROLLER_LIB_HEADERS
+    INTERFACE include)
+  zephyr_link_libraries(INTERFACE SOFTDEVICE_CONTROLLER_LIB_HEADERS)
+endif()
 
 if(CONFIG_BT_LL_SOFTDEVICE AND CONFIG_BT_LL_SOFTDEVICE_BUILD_TYPE_LIB)
   nrfxlib_calculate_lib_path(SOFTDEVICE_CONTROLLER_LIB_DIR
@@ -32,5 +35,4 @@ if(CONFIG_BT_LL_SOFTDEVICE AND CONFIG_BT_LL_SOFTDEVICE_BUILD_TYPE_LIB)
   set(SOFTDEVICE_CONTROLLER_LIB
     ${SOFTDEVICE_CONTROLLER_LIB_DIR}/libsoftdevice_controller_${softdevice_controller_variant}.a)
   zephyr_link_libraries(${SOFTDEVICE_CONTROLLER_LIB})
-
 endif()


### PR DESCRIPTION
If softdevice controller is build from sources as a submodule it should not use header files exported to nrfxlib. These header files may be not changed in SDC used to build. That could end with strange runtime errors that are hard to track.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>