### PR TITLE
nrf_security: Kconfig: align for vanilla Zephyr

### DIFF
--- a/nrf_security/Kconfig.psa
+++ b/nrf_security/Kconfig.psa
@@ -17,12 +17,14 @@ if MBEDTLS_PSA_CRYPTO_C
 config MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
 	bool
 
-source "modules/mbedtls/Kconfig.psa"
+osource "modules/mbedtls/Kconfig.psa"
 
 config PSA_WANT_ALG_CTR_DRBG
+	bool
 	default y if ENTROPY_GENERATOR
 
 config PSA_WANT_ALG_HMAC_DRBG
+	bool
 	default y if PSA_WANT_ALG_DETERMINISTIC_ECDSA
 
 config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG


### PR DESCRIPTION
Ref: NCSDK-21851