### PR TITLE
nrf_security: tf-m: Remove MbedTLS dependency for HKDF

### DIFF
--- a/nrf_security/Kconfig.legacy
+++ b/nrf_security/Kconfig.legacy
@@ -670,7 +670,7 @@ endif # MBEDTLS_ECP_C
 config MBEDTLS_HKDF_C
 	bool
 	prompt "HKDF support"
-	default y
+	default y if !TFM_PROFILE_TYPE_MINIMAL
 	help
 	  Enable HKDF support.
 	  MBEDTLS_HKDF_C setting in mbed TLS config file.

--- a/nrf_security/src/legacy/CMakeLists.txt
+++ b/nrf_security/src/legacy/CMakeLists.txt
@@ -47,13 +47,6 @@ if(CONFIG_MBEDTLS_LEGACY_CRYPTO_C OR
   )
 endif()
 
-if(CONFIG_MBEDTLS_PSA_CRYPTO_SPM AND CONFIG_MBEDTLS_HKDF_C)
-  # TF-M 1.7.0 requires legacy mbedtls_hkdf function in key loader.
-  append_with_prefix(src_crypto_legacy ${ARM_MBEDTLS_PATH}/library
-    hkdf.c
-  )
-endif()
-
 if(CONFIG_CRYPTOCELL_CC310_USABLE)
 append_with_prefix(src_crypto_legacy ${ARM_MBEDTLS_PATH}/library
   gcm.c

--- a/nrf_security/tfm/CMakeLists.txt
+++ b/nrf_security/tfm/CMakeLists.txt
@@ -74,13 +74,6 @@ set(CONFIG_MBEDTLS_USE_PSA_CRYPTO                   False)
 # complete build with all libraries and a full mbedcrypto library for linking.
 set(CONFIG_BUILD_WITH_TFM                           False)
 
-# In TF-M 1.7.0 we required mbedtls_hkdf function in HUK derivation.
-if (CONFIG_TFM_PROFILE_TYPE_MINIMAL)
-  set(CONFIG_MBEDTLS_HKDF_C                         False)
-else()
-  set(CONFIG_MBEDTLS_HKDF_C                         True)
-endif()
-
 if (NOT CONFIG_TFM_PROFILE_TYPE_MINIMAL AND CONFIG_PSA_CORE_OBERON)
   set(CONFIG_PSA_CRYPTO_DRIVER_OBERON                 True)
   set(CONFIG_PSA_CRYPTO_DRIVER_HAS_KDF_SUPPORT_OBERON True)


### PR DESCRIPTION
Removes MbedTLS dependency for HKDF.