### PR TITLE
mpsl: allow for fem as separate libs

### DIFF
--- a/mpsl/CMakeLists.txt
+++ b/mpsl/CMakeLists.txt
@@ -19,4 +19,6 @@ zephyr_include_directories(include)
 zephyr_include_directories(include/protocol)
 zephyr_link_libraries(${MPSL_LIB_DIR}/libmpsl.a)
 
+add_subdirectory(fem)
+
 endif()

--- a/mpsl/fem/CMakeLists.txt
+++ b/mpsl/fem/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+# No FEM libraries are available yet


### PR DESCRIPTION
This PR adds the possibility to include FEM libraries if they are built separately from MPSL and placed in the mpsl/fem directory. The contents of the `mpsl/fem` directory will be filled when updating MPSL and SDC revisions.