### PR TITLE
cmake: openthread: Fix mbed tls config file location.

### DIFF
--- a/openthread/cmake/extensions.cmake
+++ b/openthread/cmake/extensions.cmake
@@ -104,7 +104,7 @@ function(get_active_mbedtls_configs_from_file fileName returnMatch1List)
 endfunction()
 
 function(check_openthread_dependencies ot_lib_nrf_security_mbedtls_config_file)
-  set(nrf_security_mbedtls_config_file "${CMAKE_CURRENT_BINARY_DIR}/../nrf_security/src/include/generated/${CONFIG_MBEDTLS_CFG_FILE}")
+  set(nrf_security_mbedtls_config_file "${CMAKE_CURRENT_BINARY_DIR}/../../../nrf/subsys/nrf_security/src/include/generated/${CONFIG_MBEDTLS_CFG_FILE}")
   get_active_mbedtls_configs_from_file(${nrf_security_mbedtls_config_file} mbedtls_conf_list)
   get_active_mbedtls_configs_from_file(${ot_lib_nrf_security_mbedtls_config_file} ot_mbedtls_conf_list)
 


### PR DESCRIPTION
When building from libraries openthread took CONFIG_MBEDTLS_CFG_FILE form incorrect location. This commit fixes that.