### PR TITLE
doc: remove usage of :members:

### DIFF
--- a/crypto/doc/api.rst
+++ b/crypto/doc/api.rst
@@ -14,7 +14,6 @@ nRF CC310 bootloader crypto library
 
 .. doxygengroup:: nrf_cc310_bl
    :project: nrfxlib
-   :members:
 
 
 .. _crypto_api_nrf_cc3xx_platform:
@@ -24,63 +23,54 @@ nRF CC3XX platform library
 
 .. doxygengroup:: nrf_cc3xx_platform
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - Defines
 ========================
 
 .. doxygengroup:: nrf_cc3xx_platform_defines
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - Initialization APIs
 ====================================
 
 .. doxygengroup:: nrf_cc3xx_platform_init
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - Entropy APIs
 =============================
 
 .. doxygengroup:: nrf_cc3xx_platform_entropy
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - Mutex APIs
 ===========================
 
 .. doxygengroup:: nrf_cc3xx_platform_mutex
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - Abort APIs
 ===========================
 
 .. doxygengroup:: nrf_cc3xx_platform_abort
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - KMU APIs
 =========================
 
 .. doxygengroup:: nrf_cc3xx_platform_kmu
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - CTR-DRBG APIs
 ==============================
 
 .. doxygengroup:: nrf_cc3xx_platform_ctr_drbg
    :project: nrfxlib
-   :members:
 
 CC3XX Platform - HMAC-DRBG APIs
 ===============================
 
 .. doxygengroup:: nrf_cc3xx_platform_hmac_drbg
    :project: nrfxlib
-   :members:
 
 .. _crypto_api_nrf_cc3xx_mbedcrypto:
 
@@ -89,14 +79,12 @@ nRF CC3XX mbedcrypto library
 
 .. doxygengroup:: nrf_cc3xx_mbedcrypto
    :project: nrfxlib
-   :members:
 
 KMU/KDR APIs
 ========================
 
 .. doxygengroup:: nrf_cc3xx_mbedcrypto_kmu
    :project: nrfxlib
-   :members:
 
 
 .. _crypto_api_nrf_oberon:
@@ -106,95 +94,81 @@ nrf_oberon crypto library
 
 .. doxygengroup:: ocrypto
    :project: nrfxlib
-   :members:
 
 AES - Advanced Encryption Standard APIs
 =======================================
 
 .. doxygengroup:: ocrypto_aes
    :project: nrfxlib
-   :members:
 
 AES-CTR - AES Counter Mode
 --------------------------
 
 .. doxygengroup:: ocrypto_aes_ctr
    :project: nrfxlib
-   :members:
 
 AES EAX APIs
 ------------
 
 .. doxygengroup:: ocrypto_aes_eax
    :project: nrfxlib
-   :members:
 
 AES GCM - AES Galois/Counter Mode APIs
 --------------------------------------
 
 .. doxygengroup:: ocrypto_aes_gcm
    :project: nrfxlib
-   :members:
 
 AES key sizes
 -------------
 
 .. doxygengroup:: ocrypto_aes_key
    :project: nrfxlib
-   :members:
 
 ChaCha20-Poly1305
 =================
 
 .. doxygengroup:: ocrypto_chacha_poly
    :project: nrfxlib
-   :members:
 
 ChaCha20-Poly1305 APIs
 ----------------------
 
 .. doxygengroup:: ocrypto_chacha_poly_inc
    :project: nrfxlib
-   :members:
 
 ChaCha20 APIs
 -------------
 
 .. doxygengroup:: ocrypto_chacha
    :project: nrfxlib
-   :members:
 
 Constant time APIs
 ==================
 
 .. doxygengroup:: ocrypto_constant_time
    :project: nrfxlib
-   :members:
 
 ECC secp256r1 low-level APIs
 ============================
 
 .. doxygengroup:: ocrypto_p256
    :project: nrfxlib
-   :members:
 
 ECC Curve25519 low-level APIs
 =============================
 
 .. doxygengroup:: ocrypto_curve25519
    :project: nrfxlib
-   :members:
 
 ECDH APIs
 =========
 
 .. doxygengroup:: ocrypto_ecdh_p256
    :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ecdh_p224
    :project: nrfxlib
-   :members:
 
 
 ECDSA APIs
@@ -202,106 +176,90 @@ ECDSA APIs
 
 .. doxygengroup:: ocrypto_ecdsa_p256
    :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ecdsa_p224
    :project: nrfxlib
-   :members:
 
 Ed25519 APIs
 =============
 
 .. doxygengroup:: ocrypto_ed25519
    :project: nrfxlib
-   :members:
 
 HKDF - HMAC based Key Derivation Function
 =========================================
 
 .. doxygengroup:: ocrypto_hkdf
    :project: nrfxlib
-   :members:
 
 HKDF APIs using SHA-256
 -----------------------
 
 .. doxygengroup:: ocrypto_hkdf_sha256
    :project: nrfxlib
-   :members:
 
 HKDF APIs using SHA-512
 -----------------------
 
 .. doxygengroup:: ocrypto_hkdf_512
    :project: nrfxlib
-   :members:
 
 HMAC - Hash-based Aessage Authentication Code
 =============================================
 
 .. doxygengroup:: ocrypto_hmac
    :project: nrfxlib
-   :members:
 
 HMAC APIs using SHA-256
 -----------------------
 
 .. doxygengroup:: ocrypto_hmac_sha256
    :project: nrfxlib
-   :members:
 
 HMAC APIs using SHA-512
 -----------------------
 
 .. doxygengroup:: ocrypto_hmac_sha512
    :project: nrfxlib
-   :members:
 
 RSA - Rivest-Shamir-Adleman algorithm
 =====================================
 
 .. doxygengroup:: ocrypto_rsa
    :project: nrfxlib
-   :members:   
 
 RSA APIs
 --------
 
 .. doxygengroup:: ocrypto_rsa_api
    :project: nrfxlib
-   :members:   
 
 RSA key APIs
 ------------
 
 .. doxygengroup:: ocrypto_rsa_key
    :project: nrfxlib
-   :members:   
 
 SHA-256 APIs
 ============
 
 .. doxygengroup:: ocrypto_sha_256
    :project: nrfxlib
-   :members:
 
 SHA-512 APIs
 ============
 
 .. doxygengroup:: ocrypto_sha_512
    :project: nrfxlib
-   :members:
 
 SRP - Secure Remote Password APIs
 =================================
 
 .. doxygengroup:: ocrypto_srp
    :project: nrfxlib
-   :members:
 
 SRPT - Secure Real-Time Transport Protocol APIs
 ===============================================
 
 .. doxygengroup:: ocrypto_srtp
    :project: nrfxlib
-   :members:

--- a/gzll/doc/api.rst
+++ b/gzll/doc/api.rst
@@ -9,18 +9,15 @@ API documentation
 
 .. doxygengroup:: gzll_api
    :project: nrfxlib
-   :members:
 
 Constants
 *********
 
 .. doxygengroup:: gzll_constants
    :project: nrfxlib
-   :members:
 
 Glue layer
 **********
 
 .. doxygengroup:: gzll_glue
    :project: nrfxlib
-   :members:

--- a/lc3/doc/api.rst
+++ b/lc3/doc/api.rst
@@ -15,7 +15,6 @@ Translation layer API documentation
 
 .. doxygengroup:: LC3_translation
    :project: nrfxlib
-   :members:
 
 LC3 API documentation
 *********************
@@ -24,4 +23,3 @@ LC3 API documentation
 
 .. doxygengroup:: LC3
    :project: nrfxlib
-   :members:

--- a/mpsl/doc/api.rst
+++ b/mpsl/doc/api.rst
@@ -12,7 +12,6 @@ Multiprotocol Service Layer interface
 
 .. doxygengroup:: mpsl
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_clk:
 
@@ -21,7 +20,6 @@ MPSL Clock
 
 .. doxygengroup:: mpsl_clock
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_timeslot:
 
@@ -30,7 +28,6 @@ MPSL Timeslot
 
 .. doxygengroup:: mpsl_timeslot
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_rn:
 
@@ -39,7 +36,6 @@ MPSL Radio Notification
 
 .. doxygengroup:: mpsl_radio_notification
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_txp:
 
@@ -48,7 +44,6 @@ MPSL TX Power
 
 .. doxygengroup:: mpsl_tx_power
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem:
 
@@ -57,7 +52,6 @@ MPSL FEM
 
 .. doxygengroup:: mpsl_fem
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_common:
 
@@ -66,7 +60,6 @@ MPSL FEM common configuration
 
 .. doxygengroup:: mpsl_fem_config_common
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_21540_config:
 
@@ -75,7 +68,6 @@ MPSL FEM common nRF21540 configuration
 
 .. doxygengroup:: mpsl_fem_nrf21540_common
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_21540_gpio:
 
@@ -84,7 +76,6 @@ MPSL FEM nRF21540 GPIO
 
 .. doxygengroup:: mpsl_fem_nrf21540_gpio
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_21540_gpiospi:
 
@@ -93,7 +84,6 @@ MPSL FEM nRF21540 GPIO/SPI
 
 .. doxygengroup:: mpsl_fem_nrf21540_gpio_spi
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_simple:
 
@@ -102,7 +92,6 @@ MPSL FEM Simple GPIO
 
 .. doxygengroup:: mpsl_fem_simple_gpio
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_power:
 
@@ -111,7 +100,6 @@ MPSL FEM power model
 
 .. doxygengroup:: mpsl_fem_power_model
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_sr_cx:
 
@@ -120,7 +108,6 @@ MPSL CX (Coexistence)
 
 .. doxygengroup:: mpsl_cx
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_temp:
 
@@ -129,7 +116,6 @@ MPSL Temp
 
 .. doxygengroup:: mpsl_temp
    :project: nrfxlib
-   :members:
 
 .. _mpsl_api_dppi:
 
@@ -138,4 +124,3 @@ MPSL DPPI Protocol
 
 .. doxygengroup:: mpsl_dppi_protocol_api
    :project: nrfxlib
-   :members:

--- a/nfc/doc/type_2_tag.rst
+++ b/nfc/doc/type_2_tag.rst
@@ -399,4 +399,3 @@ API documentation
 
 .. doxygengroup:: nfc_t2t_lib
    :project: nrfxlib
-   :members:

--- a/nfc/doc/type_4_tag.rst
+++ b/nfc/doc/type_4_tag.rst
@@ -72,4 +72,3 @@ API documentation
 
 .. doxygengroup:: nfc_t4t_lib
    :project: nrfxlib
-   :members:

--- a/nrf_802154/doc/api.rst
+++ b/nrf_802154/doc/api.rst
@@ -14,7 +14,6 @@ Setting addresses and PAN ID of the device
 
 .. doxygengroup:: nrf_802154_addresses
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_data:
 
@@ -23,7 +22,6 @@ Functions to calculate data given by the driver
 
 .. doxygengroup:: nrf_802154_data
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_transitions:
 
@@ -32,7 +30,6 @@ Functions to request FSM transitions and check the current state
 
 .. doxygengroup:: nrf_802154_transitions
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_calls:
 
@@ -41,7 +38,6 @@ Calls to the higher layer
 
 .. doxygengroup:: nrf_802154_calls
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_memman:
 
@@ -50,7 +46,6 @@ Driver memory management
 
 .. doxygengroup:: nrf_802154_memman
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_rssi:
 
@@ -59,7 +54,6 @@ RSSI measurement function
 
 .. doxygengroup:: nrf_802154_rssi
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_prom:
 
@@ -68,7 +62,6 @@ Promiscuous mode
 
 .. doxygengroup:: nrf_802154_prom
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_autoack:
 
@@ -77,7 +70,6 @@ Auto ACK management
 
 .. doxygengroup:: nrf_802154_autoack
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_cca:
 
@@ -86,7 +78,6 @@ CCA configuration management
 
 .. doxygengroup:: nrf_802154_cca
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_csma:
 
@@ -95,7 +86,6 @@ CSMA-CA procedure
 
 .. doxygengroup:: nrf_802154_csma
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_timeout:
 
@@ -104,7 +94,6 @@ ACK timeout procedure
 
 .. doxygengroup:: nrf_802154_timeout
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_stats:
 
@@ -113,7 +102,6 @@ Statistics and measurements
 
 .. doxygengroup:: nrf_802154_stats
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_ifs:
 
@@ -122,7 +110,6 @@ Inter-frame spacing feature
 
 .. doxygengroup:: nrf_802154_ifs
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_capabilities:
 
@@ -131,7 +118,6 @@ Radio driver run-time capabilities feature
 
 .. doxygengroup:: nrf_802154_capabilities
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_security:
 
@@ -140,7 +126,6 @@ Radio driver MAC security feature
 
 .. doxygengroup:: nrf_802154_security
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_ie_writer:
 
@@ -149,7 +134,6 @@ Radio driver Information Element data injection feature
 
 .. doxygengroup:: nrf_802154_ie_writer
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_radio:
 
@@ -158,7 +142,6 @@ Radio driver configuration
 
 .. doxygengroup:: nrf_802154_config_radio
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_csma:
 
@@ -167,7 +150,6 @@ CSMA/CA procedure configuration
 
 .. doxygengroup:: nrf_802154_config_csma
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_timeout:
 
@@ -176,7 +158,6 @@ ACK timeout feature configuration
 
 .. doxygengroup:: nrf_802154_config_timeout
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_transmission:
 
@@ -185,7 +166,6 @@ Transmission start notification feature configuration
 
 .. doxygengroup:: nrf_802154_config_transmission
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_ie:
 
@@ -194,7 +174,6 @@ Information Elements configuration
 
 .. doxygengroup:: nrf_802154_ie
    :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_other:
 
@@ -203,4 +182,3 @@ Other functions
 
 .. doxygengroup:: nrf_802154
    :project: nrfxlib
-   :members:

--- a/nrf_dm/doc/api.rst
+++ b/nrf_dm/doc/api.rst
@@ -12,4 +12,3 @@ Distance Measurement interface
 
 .. doxygengroup:: nrf_dm
    :project: nrfxlib
-   :members:

--- a/nrf_fuel_gauge/doc/api.rst
+++ b/nrf_fuel_gauge/doc/api.rst
@@ -7,4 +7,3 @@ API documentation
 
 .. doxygengroup:: nrf_fuel_gauge
    :project: nrfxlib
-   :members:

--- a/nrf_modem/doc/api.rst
+++ b/nrf_modem/doc/api.rst
@@ -12,14 +12,12 @@ Library Management
 
 .. doxygengroup:: nrf_modem
    :project: nrfxlib
-   :members:
 
 nrf_modem_init() return values for modem firmware updates
 =========================================================
 
 .. doxygengroup:: nrf_modem_dfu
    :project: nrfxlib
-   :members:
 
 .. _nrf_modem_trace:
 
@@ -28,7 +26,6 @@ Modem traces
 
 .. doxygengroup:: nrf_modem_trace
    :project: nrfxlib
-   :members:
 
 .. _nrf_modem_fault:
 
@@ -37,14 +34,12 @@ Modem fault reasons
 
 .. doxygengroup:: nrf_modem_fault_handling
    :project: nrfxlib
-   :members:
 
 Limits of the Modem library
 ***************************
 
 .. doxygengroup:: nrf_modem_limits
    :project: nrfxlib
-   :members:
 
 Socket parameter enumerators
 ****************************
@@ -54,95 +49,81 @@ Socket families
 
 .. doxygengroup:: nrf_socket_families
    :project: nrfxlib
-   :members:
 
 Socket types
 ============
 
 .. doxygengroup:: nrf_socket_types
    :project: nrfxlib
-   :members:
 
 Socket protocols
 ================
 
 .. doxygengroup:: nrf_socket_protocols
    :project: nrfxlib
-   :members:
 
 Socket option levels
 ====================
 
 .. doxygengroup:: nrf_socket_options_levels
    :project: nrfxlib
-   :members:
 
 Generic socket options
 ======================
 
 .. doxygengroup:: nrf_socket_options_sockets
    :project: nrfxlib
-   :members:
 
 Socket send and recv flags
 ==========================
 
 .. doxygengroup:: nrf_socket_send_recv_flags
    :project: nrfxlib
-   :members:
 
 fcntl parameters
 ================
 
 .. doxygengroup:: nrf_fcnt_commands
    :project: nrfxlib
-   :members:
 
 .. doxygengroup:: nrf_fcnt_flags
    :project: nrfxlib
-   :members:
 
 Socket API
 **********
 
 .. doxygengroup:: nrf_socket_api
    :project: nrfxlib
-   :members:
 
 TLS socket
 **********
 
 .. doxygengroup:: nrf_socket_tls
    :project: nrfxlib
-   :members:
 
 DTLS handshake timeout values
 =============================
 
 .. doxygengroup:: nrf_socket_so_sec_handshake_timeouts
    :project: nrfxlib
-   :members:
 
 TLS/DTLS peer verification options
 ==================================
 
 .. doxygengroup:: nrf_socket_sec_peer_verify_options
    :project: nrfxlib
-   :members:
 
 TLS/DTLS session cache options
 ==============================
 
 .. doxygengroup:: nrf_socket_session_cache_options
    :project: nrfxlib
-   :members:
 
 TLS/DTLS socket connection roles
 ================================
 
 .. doxygengroup:: nrf_socket_sec_roles
    :project: nrfxlib
-   :members:
 
 .. _nrf_supported_tls_cipher_suites:
 
@@ -151,28 +132,24 @@ Supported cipher suites
 
 .. doxygengroup:: nrf_socket_tls_cipher_suites
    :project: nrfxlib
-   :members:
 
 DTLS connection ID settings
 ===========================
 
 .. doxygengroup:: nrf_so_sec_dtls_cid_settings
    :project: nrfxlib
-   :members:
 
 DTLS connection ID statuses
 ===========================
 
 .. doxygengroup:: nrf_so_sec_dtls_cid_statuses
    :project: nrfxlib
-   :members:
 
 TLS/DTLS handshake statuses
 ===========================
 
 .. doxygengroup:: nrf_so_sec_handshake_statuses
    :project: nrfxlib
-   :members:
 
 
 Socket address resolution API
@@ -180,7 +157,6 @@ Socket address resolution API
 
 .. doxygengroup:: nrf_socket_address_resolution
    :project: nrfxlib
-   :members:
 
 Socket polling API
 ******************
@@ -190,7 +166,6 @@ events on one or more sockets using nrf_poll().
 
 .. doxygengroup:: nrf_socket_api_poll
    :project: nrfxlib
-   :members:
 
 .. _nrf_modem_at_api:
 
@@ -199,7 +174,6 @@ AT API
 
 .. doxygengroup:: nrf_modem_at
    :project: nrfxlib
-   :members:
 
 .. _nrf_modem_bootloader_api:
 .. _nrf_modem_full_dfu_api:
@@ -209,7 +183,6 @@ Bootloader API
 
 .. doxygengroup:: nrf_modem_bootloader
    :project: nrfxlib
-   :members:
 
 .. _nrf_modem_delta_dfu_api:
 
@@ -218,11 +191,9 @@ Delta DFU API
 
 .. doxygengroup:: nrf_modem_delta_dfu
    :project: nrfxlib
-   :members:
 
 .. doxygengroup:: nrf_modem_delta_dfu_errors
    :project: nrfxlib
-   :members:
 
 .. _nrf_modem_gnss_api:
 
@@ -231,109 +202,93 @@ GNSS API
 
 .. doxygengroup:: nrf_modem_gnss
    :project: nrfxlib
-   :members:
 
 Event types
 ===========
 
 .. doxygengroup:: nrf_modem_gnss_event_type
    :project: nrfxlib
-   :members:
 
 Data types
 ==========
 
 .. doxygengroup:: nrf_modem_gnss_data_type
    :project: nrfxlib
-   :members:
 
 PVT notification flags bitmask values
 =====================================
 
 .. doxygengroup:: nrf_modem_gnss_pvt_flag_bitmask
    :project: nrfxlib
-   :members:
 
 Satellite flags bitmask values
 ==============================
 
 .. doxygengroup:: nrf_modem_gnss_sv_flag_bitmask
    :project: nrfxlib
-   :members:
 
 A-GPS data request bitmask values
 =================================
 
 .. doxygengroup:: nrf_modem_gnss_agps_data_bitmask
    :project: nrfxlib
-   :members:
 
 A-GPS data types
 ================
 
 .. doxygengroup:: nrf_modem_gnss_agps_data_type
    :project: nrfxlib
-   :members:
 
 Delete bitmask values
 =====================
 
 .. doxygengroup:: nrf_modem_gnss_delete_bitmask
    :project: nrfxlib
-   :members:
 
 GNSS system bitmask values
 ==========================
 
 .. doxygengroup:: nrf_modem_gnss_system_bitmask
    :project: nrfxlib
-   :members:
 
 NMEA string bitmask values
 ==========================
 
 .. doxygengroup:: nrf_modem_gnss_nmea_string_bitmask
    :project: nrfxlib
-   :members:
 
 Power save modes
 ================
 
 .. doxygengroup:: nrf_modem_gnss_power_save_modes
    :project: nrfxlib
-   :members:
 
 Use case bitmask values
 =======================
 
 .. doxygengroup:: nrf_modem_gnss_use_case_bitmask
    :project: nrfxlib
-   :members:
 
 Sleep timing sources
 ====================
 
 .. doxygengroup:: nrf_modem_gnss_timing_source
    :project: nrfxlib
-   :members:
 
 QZSS NMEA modes
 ===============
 
 .. doxygengroup:: nrf_modem_gnss_qzss_nmea_mode
    :project: nrfxlib
-   :members:
 
 Dynamics modes
 ==============
 
 .. doxygengroup:: nrf_modem_gnss_dynamics_mode
    :project: nrfxlib
-   :members:
 
 OS specific definitions
 ***********************
 
 .. doxygengroup:: nrf_modem_os
    :project: nrfxlib
-   :members:

--- a/nrf_rpc/doc/api.rst
+++ b/nrf_rpc/doc/api.rst
@@ -17,7 +17,6 @@ This API uses pointers to raw packet data.
 
 .. doxygengroup:: nrf_rpc
    :project: nrfxlib
-   :members:
 
 .. _nrf_rpc_cbor_api_documentation:
 
@@ -29,4 +28,3 @@ See :ref:`nrf_rpc_core_api_documentation` for more information on how to use nRF
 
 .. doxygengroup:: nrf_rpc_cbor
    :project: nrfxlib
-   :members:

--- a/softdevice_controller/doc/api.rst
+++ b/softdevice_controller/doc/api.rst
@@ -12,14 +12,12 @@ SoftDevice Controller
 
 .. doxygengroup:: sdc
    :project: nrfxlib
-   :members:
 
 Memory requirement defines
 ==========================
 
 .. doxygengroup:: sdc_mem_defines
    :project: nrfxlib
-   :members:
 
 
 SoftDevice Controller HCI
@@ -27,7 +25,6 @@ SoftDevice Controller HCI
 
 .. doxygengroup:: sdc_hci
    :project: nrfxlib
-   :members:
 
 
 SoftDevice Controller HCI VS
@@ -35,39 +32,33 @@ SoftDevice Controller HCI VS
 
 .. doxygengroup:: sdc_hci_vs
    :project: nrfxlib
-   :members:
 
 HCI Types
 ============
 
 .. doxygengroup:: HCI_TYPES
    :project: nrfxlib
-   :members:
 
 HCI Events
 =============
 
 .. doxygengroup:: HCI_EVENTS
    :project: nrfxlib
-   :members:
 
 HCI Commands
 ===============
 
 .. doxygengroup:: HCI_COMMAND_PARAMETERS
    :project: nrfxlib
-   :members:
 
 HCI VS API
 ==========
 
 .. doxygengroup:: HCI_VS_API
    :project: nrfxlib
-   :members:
 
 SoftDevice Controller SoC
 ***************************
 
 .. doxygengroup:: sdc_soc
    :project: nrfxlib
-   :members:


### PR DESCRIPTION
It's not supported by docleaf.