### PR TITLE
nrf_rpc: Fix command response decoding

### DIFF
--- a/nrf_rpc/CHANGELOG.rst
+++ b/nrf_rpc/CHANGELOG.rst
@@ -12,6 +12,11 @@ All the notable changes to this project are documented on this page.
 Main branch
 ***********
 
+Bug fixes
+=========
+
+* Fixed an issue where the :c:func:`nrf_rpc_cbor_cmd_rsp` function decodes only the first response element.
+
 Changes
 =======
 

--- a/nrf_rpc/nrf_rpc_cbor.c
+++ b/nrf_rpc/nrf_rpc_cbor.c
@@ -69,7 +69,7 @@ int nrf_rpc_cbor_cmd_rsp(const struct nrf_rpc_group *group, uint8_t cmd,
 
 	if (err >= 0) {
 		zcbor_new_decode_state(ctx->zs, ARRAY_SIZE(ctx->zs),
-				       ctx->out_packet, rsp_size, 1);
+				       ctx->out_packet, rsp_size, NRF_RPC_MAX_PARAMETERS);
 	}
 
 	return err;


### PR DESCRIPTION
Fixed an issue where the nrf_rpc_cbor_cmd_rsp
function decodes only the first response element.