### PR TITLE
doc: crypto: Refer to nrf91 instead of nrf9160 

### DIFF
--- a/crypto/doc/CHANGELOG_cc310_bl.rst
+++ b/crypto/doc/CHANGELOG_cc310_bl.rst
@@ -17,15 +17,15 @@ Initial release.
 Added
 =====
 
-Added the following crypto libraries for cc310 bootloader nRF52840 and nRF9160.
+Added the following crypto libraries for cc310 bootloader nRF52840 and nRF91 Series.
 
 .. note::
-   * The cc310 libraries require the CryptoCell 310 HW accelerator, available on nRF52840 and nRF9160 devices.
+   * The cc310 libraries require the CryptoCell 310 HW accelerator, available on nRF52840 and nRF91 Series devices.
    * short-wchar: These libraries are compiled with a wchar_t size of 16 bits.
    * no-interrupts: These libraries use blocking waits for long-running cryptography calculations.
 
 
-* nrf_cc310_bl, nrf9160 variants:
+* nrf_cc310_bl, nRF91 Series variants:
 
   * ``cortex-m33/hard-float/libnrf_cc310_bl_0.9.12.a``
   * ``cortex-m33/hard-float/no-interrupts/libnrf_cc310_bl_0.9.12.a``

--- a/crypto/doc/CHANGELOG_cc3xx_mbedcrypto.rst
+++ b/crypto/doc/CHANGELOG_cc3xx_mbedcrypto.rst
@@ -26,7 +26,7 @@ This version is dependent on the nrf_cc310_platform or nrf_cc312_platform librar
 Added
 =====
 
-Added a new build of nRF_cc3xx_mbedcrypto libraries for nRF9160, nRF52840, and nRF5340.
+Added a new build of nRF_cc3xx_mbedcrypto libraries for nRF91 Series, nRF52840, and nRF5340.
 
 .. note::
 
@@ -38,7 +38,7 @@ Added a new build of nRF_cc3xx_mbedcrypto libraries for nRF9160, nRF52840, and n
   * :file:`crypto/nrf_cc312_mbedcrypto/lib/cortex-m33/**/libnrf_cc312_legacy_crypto_0.9.17.a`
   * :file:`crypto/nrf_cc312_mbedcrypto/lib/cortex-m33/**/libnrf_cc312_core_0.9.17.a`
 
-* nrf_cc310_mbedcrypto, nRF9160 variants
+* nrf_cc310_mbedcrypto, nRF91 Series variants
 
   * :file:`crypto/nrf_cc310_mbedcrypto/lib/cortex-m33/**/libnrf_cc310_psa_crypto_0.9.17.a`
   * :file:`crypto/nrf_cc310_mbedcrypto/lib/cortex-m33/**/libnrf_cc310_legacy_crypto_0.9.17.a`

--- a/crypto/doc/CHANGELOG_cc3xx_platform.rst
+++ b/crypto/doc/CHANGELOG_cc3xx_platform.rst
@@ -22,7 +22,7 @@ Library built against Mbed TLS version 3.3.0.
 Added
 =====
 
-Added a new build of nrf_cc3xx_platform libraries for nRF9160, nRF52840, and nRF5340.
+Added a new build of nrf_cc3xx_platform libraries for nRF91 Series, nRF52840, and nRF5340.
 
 .. note::
 
@@ -32,7 +32,7 @@ Added a new build of nrf_cc3xx_platform libraries for nRF9160, nRF52840, and nRF
 
   * :file:`/nrf_cc312_platform/lib/cortex-m33/**/libnrf_cc312_psa_crypto_0.9.17.a`
 
-* nrf_cc310_platform, nRF9160 variants
+* nrf_cc310_platform, nRF91 Series variants
 
   * :file:`/nrf_cc310_platform/lib/cortex-m33/**/libnrf_cc310_platform_0.9.17.a`
 

--- a/crypto/doc/CHANGELOG_oberon.rst
+++ b/crypto/doc/CHANGELOG_oberon.rst
@@ -48,12 +48,12 @@ Removed
 
 Library built against Mbed TLS version 3.3.0.
 
-Added the following Oberon crypto libraries for nRF9160, nRF53, nRF52, and nRF51 architectures.
+Added the following Oberon crypto libraries for nRF91, nRF53, nRF52, and nRF51 Series.
 
 .. note::
    The *short-wchar* libraries are compiled with a wchar_t size of 16 bits.
 
-* nrf_oberon, nRF9160 and nRF53 application core variants
+* nrf_oberon, nRF91 and nRF53 Series application core variants
 
   * :file:`cortex-m33/hard-float/liboberon_3.0.13.a`
   * :file:`cortex-m33/hard-float/liboberon_mbedtls_3.0.13.a`

--- a/crypto/doc/nrf_cc310_bl.rst
+++ b/crypto/doc/nrf_cc310_bl.rst
@@ -7,7 +7,7 @@ nrf_cc310_bl crypto library
    :local:
    :depth: 2
 
-The nrf_cc310_bl library is a software library to interface with Arm CryptoCell CC310 hardware accelerator that is available on the nRF52840 SoC and the nRF9160 SiP.
+The nrf_cc310_bl library is a software library to interface with Arm CryptoCell CC310 hardware accelerator that is available on the nRF52840 SoC and the nRF91 Series.
 The library adds hardware support for cryptographic algorithms to be used in a bootloader-specific use cases.
 
 The nrf_cc310_bl library supports the following cryptographic algorithms:
@@ -56,7 +56,7 @@ The hardware is disabled by writing to a specific register.
    NRF_CRYPTOCELL->ENABLE=0;
 
 .. note::
-   Note that the structure type for the CryptoCell hardware register is called ``NRF_CRYPTOCELL_S`` in nRF9160 due to the hardware only being accessible from the Secure Processing Environment in the Cortex-M33 architecture.
+   Note that the structure type for the CryptoCell hardware register is called ``NRF_CRYPTOCELL_S`` in nRF91 Series devices, due to the hardware only being accessible from the Secure Processing Environment in the Cortex-M33 architecture.
 
 API documentation
 =================

--- a/crypto/doc/nrf_cc3xx_mbedcrypto.rst
+++ b/crypto/doc/nrf_cc3xx_mbedcrypto.rst
@@ -8,7 +8,7 @@ nrf_cc3xx_mbedcrypto library
    :local:
    :depth: 2
 
-The nrf_cc3xx_mbedcrypto library is software library to interface with the Arm CryptoCell CC310 hardware accelerator that is available on the nRF52840 SoC and the nRF9160 SiP.
+The nrf_cc3xx_mbedcrypto library is software library to interface with the Arm CryptoCell hardware accelerator that is available on the nRF52840 SoC, the nRF53 Series, and the nRF91 Series.
 The library adds hardware support for selected cryptographic algorithms.
 
 Integration with Mbed TLS
@@ -23,7 +23,7 @@ Some of the APIs expressed in this library use the Mbed TLS "alternative impleme
 Supported cryptographic algorithms
 ==================================
 
-The following tables show the supported cryptographic algorithms in the Arm CryptoCell CC310 hardware accelerator in nRF52840 and nRF9160, as well as the current state of support in the nrf_cc3xx_mbedcrypto library.
+The following tables show the current state of support.
 
 .. note::
    If `no Mbed TLS support` is listed in limitations, it indicates that the hardware supports it, but it is not exposed in an API that works with Mbed TLS.

--- a/crypto/doc/nrf_cc3xx_platform.rst
+++ b/crypto/doc/nrf_cc3xx_platform.rst
@@ -8,7 +8,7 @@ nrf_cc3xx_platform library
    :local:
    :depth: 2
 
-The nrf_cc3xx_platform library is software library to interface with the Arm CryptoCell CC310/CC312 hardware accelerator that is available on the nRF52840 SoC and the nRF9160 SiP.
+The nrf_cc3xx_platform library is software library to interface with the Arm CryptoCell CC310/CC312 hardware accelerator that is available on the nRF52840 SoC, the nRF53 Series, and the nRF91 Series.
 
 The platform library provides low-level functionality needed by the CC310/CC312
 mbedcrypto library.


### PR DESCRIPTION
Update crypto docs to refer to nrf91 instead of nrf9160 for
portability.

Also, update one place where nrf53 was omitted.

Only the most recent changelog is updated as changelogs do not really
need to be updated. We only update the changelogs to make it easier to
copy-paste the changelog on the next release.
