### PR TITLE
Revert "crypto: fix dereferencing for mutexes"

### DIFF
--- a/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc310_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -256,7 +256,7 @@ static void mutex_free_platform(nrf_cc3xx_platform_mutex_t *mutex) {
 
     /* Check if the mutex was allocated or being statically defined */
     if ((mutex->flags & NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ALLOCATED) != 0) {
-        k_mem_slab_free(&mutex_slab, mutex->mutex);
+        k_mem_slab_free(&mutex_slab, &mutex->mutex);
         mutex->mutex = NULL;
     }
     else {

--- a/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
+++ b/crypto/nrf_cc312_platform/src/nrf_cc3xx_platform_mutex_zephyr.c
@@ -256,7 +256,7 @@ static void mutex_free_platform(nrf_cc3xx_platform_mutex_t *mutex) {
 
     /* Check if the mutex was allocated or being statically defined */
     if ((mutex->flags & NRF_CC3XX_PLATFORM_MUTEX_MASK_IS_ALLOCATED) != 0) {
-        k_mem_slab_free(&mutex_slab, mutex->mutex);
+        k_mem_slab_free(&mutex_slab, &mutex->mutex);
         mutex->mutex = NULL;
     }
     else {


### PR DESCRIPTION
[DNM] I have messed up and merged something that should go to upmerge to main.
Because there is, a slim, chance that there will not be any fixes to nrfxlib we may not need the revert, but in case the update to nrfxlib is needed, this can be merged.
Note that, so far, the sdk-nrf west update has not been merged so it points to correct, previous, version of main.

This reverts commit db89a3e729046b77a1846cbedc2544192907c769.

Unfortunately this has been merged before required changes have been applied to sdk-zephyr.