### PR TITLE
doc: Cellular Monitor tool replaces Trace Collector and LTE Link monitor

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -17,7 +17,7 @@
 
 .. _`Credential storage management %CMNG`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/cmng.html
 
-.. _`LTE Link Monitor`: https://infocenter.nordicsemi.com/topic/ug_link_monitor/UG/link_monitor/lm_certificate_manager.html
+.. _`Cellular Monitor`: https://infocenter.nordicsemi.com/topic/ug_cellular_monitor/UG/cellular_monitor/cellular_mon_cert_manager.html
 
 .. _`nRF IEEE 802.15.4 radio driver documentation`: https://infocenter.nordicsemi.com/topic/15.4_radio_driver_v2.0.0-1.prealpha/index.html
 
@@ -40,7 +40,7 @@
 
 .. _`%XMODEMTRACE AT command documentation`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xmodemtrace.html
 
-.. _`nRF Trace collector`: https://infocenter.nordicsemi.com/index.jsp?topic=%2Fug_trace_collector%2FUG%2Ftrace_collector%2Fintro.html
+.. _`nRF Connect Serial Terminal`: https://infocenter.nordicsemi.com/topic/ug_serial_terminal/UG/serial_terminal/intro.html
 
 .. _`coex interface of nRF9160`:  https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf9160%2Fip%2Fradio_lte%2Fdoc%2Fmagpio_if.html
 

--- a/nrf_modem/doc/modem_trace.rst
+++ b/nrf_modem/doc/modem_trace.rst
@@ -4,7 +4,7 @@ Modem traces
 ############
 
 The modem trace APIs in the Modem library are used to retrieve binary trace data from the modem core.
-The application is responsible for forwarding the trace data to a host computer, where it can be collected with the `nRF Trace collector`_ PC tool to extract PCAP data, or to save them to file for further inspection by Nordic Semiconductor.
+The application is responsible for forwarding the trace data to a host computer, where it can be collected with the `Cellular Monitor`_ PC tool to extract PCAP data, or to save them to file for further inspection by Nordic Semiconductor.
 
 In the |NCS|, the :ref:`nrf_modem_lib_readme` takes care of retrieving and forwarding the trace data, for example to a computer or to a non-volatile memory.
 

--- a/nrf_modem/doc/sockets.rst
+++ b/nrf_modem/doc/sockets.rst
@@ -406,8 +406,8 @@ To be able to provision credentials, the modem must be in offline mode.
 The credentials are provisioned through AT commands.
 See `Credential storage management %CMNG`_ for more information.
 If you are using the |NCS| to build your application, you can use the :ref:`nrf:modem_key_mgmt` library to manage credentials.
-If you prefer a graphical tool, use `LTE Link Monitor`_ instead.
-To manage credentials with LTE Link Monitor, your device must be running an |NCS| application.
+If you prefer a graphical tool, use `Cellular Monitor`_ instead.
+To manage credentials with Cellular Monitor, your device must be running an |NCS| application.
 
 The following figure shows how security tags are provisioned using AT commands:
 


### PR DESCRIPTION
The Cellular Monitor tool replaces the trace collector(s) and the LTE Link monitor.
Documents are updated with these details