### PR TITLE
nrf_modem: doc: gnss_interface: Update conceptual documentation

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -54,6 +54,8 @@
 
 .. _`Global navigation satellite system (GNSS)`: https://en.wikipedia.org/wiki/Satellite_navigation
 
+.. _`A-GNSS`: https://en.wikipedia.org/wiki/Assisted_GNSS
+
 .. _`A-GPS`: https://en.wikipedia.org/wiki/Assisted_GPS
 
 .. _`IANA`: https://en.wikipedia.org/wiki/Internet_Assigned_Numbers_Authority


### PR DESCRIPTION
Updated documentation to use the term "A-GNSS" instead of "A-GPS".

Removed notes related to legacy MFWs.

Improved dynamics mode description.