### PR TITLE
doc: Rename the nRF91 AT Commands Reference Guide

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -13,7 +13,7 @@
 
 .. ### Source: infocenter.nordicsemi.com
 
-.. _`AT Commands Reference Guide`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/intro.html
+.. _`nRF9160 AT Commands Reference Guide`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/intro.html
 
 .. _`Credential storage management %CMNG`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/cmng.html
 

--- a/nrf_modem/doc/at_interface.rst
+++ b/nrf_modem/doc/at_interface.rst
@@ -13,7 +13,7 @@ AT commands
 ***********
 
 AT commands are essentially a set of modem instructions that are used to configure the modem, establish a network connection (or in general, execute operations), and retrieve modem and connection status information.
-For the full set of supported AT commands, see the `AT Commands Reference Guide`_.
+For the full set of supported AT commands, see the `nRF9160 AT Commands Reference Guide`_.
 
 Initialization
 **************


### PR DESCRIPTION
Rename "nRF91 AT Commands Reference Guide" to
"nRF9160 AT Commands"