### PR TITLE
CODEOWNERS: add jori-nordic for softdevice_controller

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,7 +33,7 @@ doc/*                                     @b-gent
 # All subfolders
 /.github/                                 @thst-nordic
 /.github/test-spec.yml                    @nrfconnect/ncs-test-leads
-/softdevice_controller/                   @rugeGerritsen
+/softdevice_controller/                   @rugeGerritsen @jori-nordic
 /nrf_modem/                               @rlubos @lemrey
 /crypto/                                  @frkv @tejlmand
 /gzll/                                    @leewkb4567


### PR DESCRIPTION
It's a dependency for CI plans I maintain.