### PR TITLE
doc improvement: lc3: format qdid info for reuse

### DIFF
--- a/lc3/README.rst
+++ b/lc3/README.rst
@@ -7,12 +7,19 @@ Low Complexity Communication Codec (LC3)
    :local:
    :depth: 2
 
-Low Complexity Communication Codec (LC3) is the default software codec for the :ref:`nrf53_audio_app` application, conformant to the `Bluetooth® LE Audio specifications`_ (Bluetooth 5.2, QDID #156294).
-For more information about the codec usage in the application, see the application documentation page in the |NCS| documentation.
+Low Complexity Communication Codec (LC3) is the default software codec for the nRF5340 Audio application, conformant to the `Bluetooth® LE Audio specifications`_ (Bluetooth 5.2).
+For more information about the codec usage in the application, see the :ref:`application documentation page <nrf53_audio_app>`.
 
 The nrfxlib module includes the :file:`lc3/include/sw_codec_lc3.h` and :file:`lc3/src/sw_codec_lc3.c` files that form a translation layer for using a standardized API in the nRF5340 Audio application.
 
 For the terms and conditions for using the LC3 codec, see :file:`license.txt` and :file:`attribution.txt` at :file:`lc3/`.
+
+.. lc3_qdid_start
+
+Low Complexity Communication Codec QDID
+   The Low Complexity Communication Codec associated with this version of the |NCS| comes with the QDID #156294.
+
+.. lc3_qdid_end
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Moved QDID information for LC3 to a section that can be included in sdk-nrf. OCT-2692.