### PR TITLE
nrf_wifi: Remove extra logline from log

### DIFF
--- a/nrf_wifi/bus_if/bal/src/bal.c
+++ b/nrf_wifi/bus_if/bal/src/bal.c
@@ -39,7 +39,7 @@ static void nrf_wifi_rpu_bal_sleep_chk(struct nrf_wifi_bal_dev_ctx *bal_ctx,
 
 	if ((sleep_reg_val & rpu_ps_state_mask) != rpu_ps_state_mask) {
 		nrf_wifi_osal_log_err(bal_ctx->bpriv->opriv,
-				      "%s:RPU is being accessed when it is not ready !!! (Reg val = 0x%X)\n",
+				      "%s:RPU is being accessed when it is not ready !!! (Reg val = 0x%X)",
 				      __func__,
 				      sleep_reg_val);
 	}
@@ -59,7 +59,7 @@ struct nrf_wifi_bal_dev_ctx *nrf_wifi_bal_dev_add(struct nrf_wifi_bal_priv *bpri
 
 	if (!bal_dev_ctx) {
 		nrf_wifi_osal_log_err(bpriv->opriv,
-				      "%s: Unable to allocate bal_dev_ctx\n", __func__);
+				      "%s: Unable to allocate bal_dev_ctx", __func__);
 		goto out;
 	}
 
@@ -71,7 +71,7 @@ struct nrf_wifi_bal_dev_ctx *nrf_wifi_bal_dev_add(struct nrf_wifi_bal_priv *bpri
 
 	if (!bal_dev_ctx->bus_dev_ctx) {
 		nrf_wifi_osal_log_err(bpriv->opriv,
-				      "%s: Bus dev_add failed\n", __func__);
+				      "%s: Bus dev_add failed", __func__);
 		goto out;
 	}
 
@@ -110,7 +110,7 @@ enum nrf_wifi_status nrf_wifi_bal_dev_init(struct nrf_wifi_bal_dev_ctx *bal_dev_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(bal_dev_ctx->bpriv->opriv,
-				      "%s: dev_init failed\n", __func__);
+				      "%s: dev_init failed", __func__);
 		goto out;
 	}
 out:
@@ -149,7 +149,7 @@ nrf_wifi_bal_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (!bpriv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate memory for bpriv\n", __func__);
+				      "%s: Unable to allocate memory for bpriv", __func__);
 		goto out;
 	}
 
@@ -165,7 +165,7 @@ nrf_wifi_bal_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (!bpriv->bus_priv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Failed\n", __func__);
+				      "%s: Failed", __func__);
 		nrf_wifi_osal_mem_free(opriv,
 				       bpriv);
 		bpriv = NULL;

--- a/nrf_wifi/bus_if/bus/qspi/src/qspi.c
+++ b/nrf_wifi/bus_if/bus/qspi/src/qspi.c
@@ -44,7 +44,7 @@ static void *nrf_wifi_bus_qspi_dev_add(void *bus_priv,
 
 	if (!qspi_dev_ctx) {
 		nrf_wifi_osal_log_err(qspi_priv->opriv,
-				      "%s: Unable to allocate qspi_dev_ctx\n", __func__);
+				      "%s: Unable to allocate qspi_dev_ctx", __func__);
 		goto out;
 	}
 
@@ -57,7 +57,7 @@ static void *nrf_wifi_bus_qspi_dev_add(void *bus_priv,
 
 	if (!qspi_dev_ctx->os_qspi_dev_ctx) {
 		nrf_wifi_osal_log_err(qspi_priv->opriv,
-				      "%s: nrf_wifi_osal_bus_qspi_dev_add failed\n", __func__);
+				      "%s: nrf_wifi_osal_bus_qspi_dev_add failed", __func__);
 
 		nrf_wifi_osal_mem_free(qspi_priv->opriv,
 				       qspi_dev_ctx);
@@ -83,7 +83,7 @@ static void *nrf_wifi_bus_qspi_dev_add(void *bus_priv,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(qspi_dev_ctx->qspi_priv->opriv,
-				      "%s: Unable to register interrupt to the OS\n",
+				      "%s: Unable to register interrupt to the OS",
 				      __func__);
 
 		nrf_wifi_osal_bus_qspi_dev_intr_unreg(qspi_dev_ctx->qspi_priv->opriv,
@@ -134,7 +134,7 @@ static enum nrf_wifi_status nrf_wifi_bus_qspi_dev_init(void *bus_dev_ctx)
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(qspi_dev_ctx->qspi_priv->opriv,
-				      "%s: nrf_wifi_osal_qspi_dev_init failed\n", __func__);
+				      "%s: nrf_wifi_osal_qspi_dev_init failed", __func__);
 
 		goto out;
 	}
@@ -165,7 +165,7 @@ static void *nrf_wifi_bus_qspi_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (!qspi_priv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate memory for qspi_priv\n",
+				      "%s: Unable to allocate memory for qspi_priv",
 				      __func__);
 		goto out;
 	}
@@ -183,7 +183,7 @@ static void *nrf_wifi_bus_qspi_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (!qspi_priv->os_qspi_priv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to register QSPI driver\n",
+				      "%s: Unable to register QSPI driver",
 				      __func__);
 
 		nrf_wifi_osal_mem_free(opriv,

--- a/nrf_wifi/bus_if/bus/spi/src/spi.c
+++ b/nrf_wifi/bus_if/bus/spi/src/spi.c
@@ -44,7 +44,7 @@ static void *nrf_wifi_bus_spi_dev_add(void *bus_priv,
 
 	if (!spi_dev_ctx) {
 		nrf_wifi_osal_log_err(spi_priv->opriv,
-				      "%s: Unable to allocate spi_dev_ctx\n", __func__);
+				      "%s: Unable to allocate spi_dev_ctx", __func__);
 		goto out;
 	}
 
@@ -57,7 +57,7 @@ static void *nrf_wifi_bus_spi_dev_add(void *bus_priv,
 
 	if (!spi_dev_ctx->os_spi_dev_ctx) {
 		nrf_wifi_osal_log_err(spi_priv->opriv,
-				      "%s: nrf_wifi_osal_bus_spi_dev_add failed\n", __func__);
+				      "%s: nrf_wifi_osal_bus_spi_dev_add failed", __func__);
 
 		nrf_wifi_osal_mem_free(spi_priv->opriv,
 				       spi_dev_ctx);
@@ -83,7 +83,7 @@ static void *nrf_wifi_bus_spi_dev_add(void *bus_priv,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(spi_dev_ctx->spi_priv->opriv,
-				      "%s: Unable to register interrupt to the OS\n",
+				      "%s: Unable to register interrupt to the OS",
 				      __func__);
 
 		nrf_wifi_osal_bus_spi_dev_intr_unreg(spi_dev_ctx->spi_priv->opriv,
@@ -131,7 +131,7 @@ static enum nrf_wifi_status nrf_wifi_bus_spi_dev_init(void *bus_dev_ctx)
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(spi_dev_ctx->spi_priv->opriv,
-				      "%s: nrf_wifi_osal_spi_dev_init failed\n", __func__);
+				      "%s: nrf_wifi_osal_spi_dev_init failed", __func__);
 
 		goto out;
 	}
@@ -162,7 +162,7 @@ static void *nrf_wifi_bus_spi_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (!spi_priv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate memory for spi_priv\n",
+				      "%s: Unable to allocate memory for spi_priv",
 				      __func__);
 		goto out;
 	}
@@ -179,7 +179,7 @@ static void *nrf_wifi_bus_spi_init(struct nrf_wifi_osal_priv *opriv,
 	spi_priv->os_spi_priv = nrf_wifi_osal_bus_spi_init(opriv);
 	if (!spi_priv->os_spi_priv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to register QSPI driver\n",
+				      "%s: Unable to register QSPI driver",
 				      __func__);
 
 		nrf_wifi_osal_mem_free(opriv,

--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -25,7 +25,7 @@ struct host_rpu_msg *umac_cmd_alloc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to allocate UMAC cmd\n",
+				      "%s: Failed to allocate UMAC cmd",
 				      __func__);
 		goto out;
 	}
@@ -50,7 +50,7 @@ enum nrf_wifi_status umac_cmd_cfg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 		umac_hdr = (struct nrf_wifi_umac_hdr *)params;
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC buff config not yet done(%d)\n",
+				      "%s: UMAC buff config not yet done(%d)",
 				      __func__,
 				      umac_hdr->cmd_evnt);
 		goto out;
@@ -62,7 +62,7 @@ enum nrf_wifi_status umac_cmd_cfg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -77,7 +77,7 @@ enum nrf_wifi_status umac_cmd_cfg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					    (sizeof(*umac_cmd) + len));
 
 	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Command %d sent to RPU\n",
+			      "%s: Command %d sent to RPU",
 			      __func__,
 			      ((struct nrf_wifi_umac_hdr *)params)->cmd_evnt);
 
@@ -116,7 +116,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -149,7 +149,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	umac_cmd_data->tcp_ip_checksum_offload = 1;
 #endif /* CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD */
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv, "RPU LPM type: %s\n",
+	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv, "RPU LPM type: %s",
 		umac_cmd_data->sys_params.sleep_enable == 2 ? "HW" :
 		umac_cmd_data->sys_params.sleep_enable == 1 ? "SW" : "DISABLED");
 #ifndef CONFIG_NRF700X_RADIO_TEST
@@ -214,7 +214,7 @@ enum nrf_wifi_status umac_cmd_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 				  len);
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -245,7 +245,7 @@ enum nrf_wifi_status umac_cmd_btcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -288,7 +288,7 @@ enum nrf_wifi_status umac_cmd_he_ltf_gi(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -338,7 +338,7 @@ enum nrf_wifi_status umac_cmd_prog_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -377,7 +377,7 @@ enum nrf_wifi_status umac_cmd_prog_tx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -417,7 +417,7 @@ enum nrf_wifi_status umac_cmd_prog_rx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -458,7 +458,7 @@ enum nrf_wifi_status umac_cmd_prog_rf_test(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -504,7 +504,7 @@ enum nrf_wifi_status umac_cmd_prog_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
@@ -65,7 +65,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_init_tx(struct nrf_wifi_fmac_dev_ctx *
 
 	if (!def_dev_ctx->tx_buf_info) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No space for TX buf info\n",
+				      "%s: No space for TX buf info",
 				      __func__);
 		goto out;
 	}
@@ -114,7 +114,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_init_rx(struct nrf_wifi_fmac_dev_ctx *
 
 	if (!def_dev_ctx->rx_buf_info) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No space for RX buf info\n",
+				      "%s: No space for RX buf info",
 				      __func__);
 		goto out;
 	}
@@ -126,7 +126,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_init_rx(struct nrf_wifi_fmac_dev_ctx *
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_fmac_rx_cmd_send(INIT) failed for desc_id = %d\n",
+					      "%s: nrf_wifi_fmac_rx_cmd_send(INIT) failed for desc_id = %d",
 					      __func__,
 					      desc_id);
 			goto out;
@@ -137,7 +137,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_init_rx(struct nrf_wifi_fmac_dev_ctx *
 							       NRF_WIFI_TASKLET_TYPE_RX);
 	if (!def_dev_ctx->rx_tasklet) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No space for RX tasklet\n",
+				      "%s: No space for RX tasklet",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -146,7 +146,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_init_rx(struct nrf_wifi_fmac_dev_ctx *
 	def_dev_ctx->rx_tasklet_event_q = nrf_wifi_utils_q_alloc(fpriv->opriv);
 	if (!def_dev_ctx->rx_tasklet_event_q) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No space for RX tasklet event queue\n",
+				      "%s: No space for RX tasklet event queue",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -188,7 +188,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_deinit_rx(struct nrf_wifi_fmac_dev_ctx
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_fmac_rx_cmd_send(DEINIT) failed for desc_id = %d\n",
+					      "%s: nrf_wifi_fmac_rx_cmd_send(DEINIT) failed for desc_id = %d",
 					      __func__,
 					      desc_id);
 			goto out;
@@ -226,7 +226,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init(struct nrf_wifi_fmac_dev_ctx *
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Init TX failed\n",
+				      "%s: Init TX failed",
 				      __func__);
 		goto out;
 	}
@@ -236,7 +236,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init(struct nrf_wifi_fmac_dev_ctx *
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Init RX failed\n",
+				      "%s: Init RX failed",
 				      __func__);
 #ifdef CONFIG_NRF700X_DATA_TX
 		nrf_wifi_fmac_deinit_tx(fmac_dev_ctx);
@@ -258,7 +258,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init(struct nrf_wifi_fmac_dev_ctx *
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC init failed\n",
+				      "%s: UMAC init failed",
 				      __func__);
 		nrf_wifi_fmac_deinit_rx(fmac_dev_ctx);
 #ifdef CONFIG_NRF700X_DATA_TX
@@ -278,7 +278,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init(struct nrf_wifi_fmac_dev_ctx *
 
 	if (!fmac_dev_ctx->fw_init_done) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC init timed out\n",
+				      "%s: UMAC init timed out",
 				      __func__);
 		nrf_wifi_fmac_deinit_rx(fmac_dev_ctx);
 #ifdef CONFIG_NRF700X_DATA_TX
@@ -305,7 +305,7 @@ static void nrf_wifi_fmac_fw_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC deinit failed\n",
+				      "%s: UMAC deinit failed",
 				      __func__);
 		goto out;
 	}
@@ -323,7 +323,7 @@ static void nrf_wifi_fmac_fw_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	if (!fmac_dev_ctx->fw_deinit_done) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC deinit timed out\n",
+				      "%s: UMAC deinit timed out",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -365,7 +365,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 
 	if (!fmac_dev_ctx) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid device context\n",
+				      "%s: Invalid device context",
 				      __func__);
 		goto out;
 	}
@@ -374,7 +374,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_hal_dev_init failed\n",
+				      "%s: nrf_wifi_hal_dev_init failed",
 				      __func__);
 		goto out;
 	}
@@ -390,7 +390,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU OTP information failed\n",
+				      "%s: Fetching of RPU OTP information failed",
 				      __func__);
 		goto out;
 	}
@@ -408,7 +408,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 
 		if (ret == -1) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: hex_str_to_val failed\n",
+					      "%s: hex_str_to_val failed",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
@@ -420,7 +420,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: RF parameters get failed\n",
+					      "%s: RF parameters get failed",
 					      __func__);
 			goto out;
 		}
@@ -439,7 +439,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_fw_init failed\n",
+				      "%s: nrf_wifi_fmac_fw_init failed",
 				      __func__);
 		goto out;
 	}
@@ -477,7 +477,7 @@ struct nrf_wifi_fmac_priv *nrf_wifi_fmac_init(struct nrf_wifi_data_config_params
 
 	if (!fpriv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate fpriv\n",
+				      "%s: Unable to allocate fpriv",
 				      __func__);
 		goto out;
 	}
@@ -543,7 +543,7 @@ struct nrf_wifi_fmac_priv *nrf_wifi_fmac_init(struct nrf_wifi_data_config_params
 
 	if (!fpriv->hpriv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to do HAL init\n",
+				      "%s: Unable to do HAL init",
 				      __func__);
 		nrf_wifi_osal_mem_free(opriv,
 				       fpriv);
@@ -588,7 +588,7 @@ enum nrf_wifi_status nrf_wifi_fmac_scan(void *dev_ctx,
 
 	if (def_dev_ctx->vif_ctx[if_idx]->if_type == NRF_WIFI_IFTYPE_AP) {
 		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-				       "%s: Scan operation not supported in AP mode\n",
+				       "%s: Scan operation not supported in AP mode",
 				       __func__);
 		goto out;
 	}
@@ -598,7 +598,7 @@ enum nrf_wifi_status nrf_wifi_fmac_scan(void *dev_ctx,
 
 	if (!scan_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -637,7 +637,7 @@ enum nrf_wifi_status nrf_wifi_fmac_abort_scan(void *dev_ctx,
 
 	if (def_dev_ctx->vif_ctx[if_idx]->if_type == NRF_WIFI_IFTYPE_AP) {
 		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-				       "%s: Scan operation not supported in AP mode\n",
+				       "%s: Scan operation not supported in AP mode",
 				       __func__);
 		goto out;
 	}
@@ -647,7 +647,7 @@ enum nrf_wifi_status nrf_wifi_fmac_abort_scan(void *dev_ctx,
 
 	if (!scan_abort_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -683,7 +683,7 @@ enum nrf_wifi_status nrf_wifi_fmac_scan_res_get(void *dev_ctx,
 
 	if (def_dev_ctx->vif_ctx[vif_idx]->if_type == NRF_WIFI_IFTYPE_AP) {
 		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-				       "%s: Scan operation not supported in AP mode\n",
+				       "%s: Scan operation not supported in AP mode",
 				       __func__);
 		goto out;
 	}
@@ -693,7 +693,7 @@ enum nrf_wifi_status nrf_wifi_fmac_scan_res_get(void *dev_ctx,
 
 	if (!scan_res_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -735,7 +735,7 @@ enum nrf_wifi_status nrf_wifi_fmac_auth(void *dev_ctx,
 
 	if (!auth_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -797,7 +797,7 @@ enum nrf_wifi_status nrf_wifi_fmac_deauth(void *dev_ctx,
 
 	if (!deauth_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -855,7 +855,7 @@ enum nrf_wifi_status nrf_wifi_fmac_assoc(void *dev_ctx,
 
 	if (!assoc_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -950,7 +950,7 @@ enum nrf_wifi_status nrf_wifi_fmac_disassoc(void *dev_ctx,
 
 	if (!disassoc_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1004,7 +1004,7 @@ enum nrf_wifi_status nrf_wifi_fmac_add_key(void *dev_ctx,
 
 	if (!key_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -1034,7 +1034,7 @@ enum nrf_wifi_status nrf_wifi_fmac_add_key(void *dev_ctx,
 
 		if (peer_id == -1) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Invalid peer\n",
+					      "%s: Invalid peer",
 					      __func__);
 			goto out;
 		}
@@ -1042,7 +1042,7 @@ enum nrf_wifi_status nrf_wifi_fmac_add_key(void *dev_ctx,
 		def_dev_ctx->tx_config.peers[peer_id].pairwise_cipher = key_info->cipher_suite;
 	} else {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid key type %d\n",
+				      "%s: Invalid key type %d",
 				      __func__,
 				      key_info->key_type);
 		goto out;
@@ -1092,7 +1092,7 @@ enum nrf_wifi_status nrf_wifi_fmac_del_key(void *dev_ctx,
 
 	if (!key_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1153,7 +1153,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_key(void *dev_ctx,
 
 	if (!set_key_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1197,7 +1197,7 @@ enum nrf_wifi_status nrf_wifi_fmac_chg_sta(void *dev_ctx,
 
 	if (!chg_sta_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1268,7 +1268,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_bss(void *dev_ctx,
 
 	if (!set_bss_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1323,7 +1323,7 @@ enum nrf_wifi_status nrf_wifi_fmac_chg_bcn(void *dev_ctx,
 
 	if (!set_bcn_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -1337,7 +1337,7 @@ enum nrf_wifi_status nrf_wifi_fmac_chg_bcn(void *dev_ctx,
 			      sizeof(set_bcn_cmd->info));
 
 	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Sending command to rpu\n",
+			      "%s: Sending command to rpu",
 			      __func__);
 
 	status = umac_cmd_cfg(fmac_dev_ctx,
@@ -1370,7 +1370,7 @@ enum nrf_wifi_status nrf_wifi_fmac_start_ap(void *dev_ctx,
 
 	if (!start_ap_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1432,7 +1432,7 @@ enum nrf_wifi_status nrf_wifi_fmac_start_ap(void *dev_ctx,
 
 	if (!wiphy_info) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1452,7 +1452,7 @@ enum nrf_wifi_status nrf_wifi_fmac_start_ap(void *dev_ctx,
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_set_wiphy_params failes\n",
+				      "%s: nrf_wifi_fmac_set_wiphy_params failes",
 				      __func__);
 		goto out;
 	}
@@ -1492,7 +1492,7 @@ enum nrf_wifi_status nrf_wifi_fmac_stop_ap(void *dev_ctx,
 
 	if (!stop_ap_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1531,7 +1531,7 @@ enum nrf_wifi_status nrf_wifi_fmac_del_sta(void *dev_ctx,
 
 	if (!del_sta_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1589,7 +1589,7 @@ enum nrf_wifi_status nrf_wifi_fmac_add_sta(void *dev_ctx,
 
 	if (!add_sta_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1691,7 +1691,7 @@ enum nrf_wifi_status nrf_wifi_fmac_mgmt_frame_reg(void *dev_ctx,
 
 	if (!frame_reg_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1738,7 +1738,7 @@ enum nrf_wifi_status nrf_wifi_fmac_p2p_dev_start(void *dev_ctx,
 
 	if (!start_p2p_dev_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -1774,7 +1774,7 @@ enum nrf_wifi_status nrf_wifi_fmac_p2p_dev_stop(void *dev_ctx,
 
 	if (!stop_p2p_dev_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1811,7 +1811,7 @@ enum nrf_wifi_status nrf_wifi_fmac_p2p_roc_start(void *dev_ctx,
 
 	if (!roc_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1861,7 +1861,7 @@ enum nrf_wifi_status nrf_wifi_fmac_p2p_roc_stop(void *dev_ctx,
 
 	if (!cancel_roc_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1902,7 +1902,7 @@ enum nrf_wifi_status nrf_wifi_fmac_mgmt_tx(void *dev_ctx,
 
 	if (!mgmt_tx_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -1960,7 +1960,7 @@ enum nrf_wifi_status nrf_wifi_fmac_mac_addr(struct nrf_wifi_fmac_dev_ctx *fmac_d
 
 	if (((unsigned short)addr[5] + vif_idx) > 0xff) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: MAC Address rollover!!\n",
+				      "%s: MAC Address rollover!!",
 				      __func__);
 	}
 
@@ -1992,7 +1992,7 @@ unsigned char nrf_wifi_fmac_add_vif(void *dev_ctx,
 		break;
 	default:
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: VIF type not supported\n",
+				      "%s: VIF type not supported",
 				      __func__);
 		goto err;
 	}
@@ -2007,7 +2007,7 @@ unsigned char nrf_wifi_fmac_add_vif(void *dev_ctx,
 
 	if (!vif_ctx) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory for VIF ctx\n",
+				      "%s: Unable to allocate memory for VIF ctx",
 				      __func__);
 		goto err;
 	}
@@ -2025,7 +2025,7 @@ unsigned char nrf_wifi_fmac_add_vif(void *dev_ctx,
 
 	if (vif_idx == MAX_NUM_VIFS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to add additional VIF\n",
+				      "%s: Unable to add additional VIF",
 				      __func__);
 		goto err;
 	}
@@ -2040,7 +2040,7 @@ unsigned char nrf_wifi_fmac_add_vif(void *dev_ctx,
 
 		if (!add_vif_cmd) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Unable to allocate memory for cmd\n",
+					      "%s: Unable to allocate memory for cmd",
 					      __func__);
 			goto err;
 		}
@@ -2064,7 +2064,7 @@ unsigned char nrf_wifi_fmac_add_vif(void *dev_ctx,
 
 		if (status == NRF_WIFI_STATUS_FAIL) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: NRF_WIFI_UMAC_CMD_NEW_INTERFACE failed\n",
+					      "%s: NRF_WIFI_UMAC_CMD_NEW_INTERFACE failed",
 					      __func__);
 			goto err;
 		}
@@ -2115,7 +2115,7 @@ enum nrf_wifi_status nrf_wifi_fmac_del_vif(void *dev_ctx,
 		break;
 	default:
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: VIF type not supported\n",
+				      "%s: VIF type not supported",
 				      __func__);
 		goto out;
 	}
@@ -2124,7 +2124,7 @@ enum nrf_wifi_status nrf_wifi_fmac_del_vif(void *dev_ctx,
 
 	if (!vif_ctx) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: VIF ctx does not exist\n",
+				      "%s: VIF ctx does not exist",
 				      __func__);
 		goto out;
 	}
@@ -2139,7 +2139,7 @@ enum nrf_wifi_status nrf_wifi_fmac_del_vif(void *dev_ctx,
 
 		if (!del_vif_cmd) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Unable to allocate memory for cmd\n",
+					      "%s: Unable to allocate memory for cmd",
 					      __func__);
 			goto out;
 		}
@@ -2154,7 +2154,7 @@ enum nrf_wifi_status nrf_wifi_fmac_del_vif(void *dev_ctx,
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: NRF_WIFI_UMAC_CMD_DEL_INTERFACE failed\n",
+					      "%s: NRF_WIFI_UMAC_CMD_DEL_INTERFACE failed",
 					      __func__);
 			goto out;
 		}
@@ -2197,7 +2197,7 @@ enum nrf_wifi_status nrf_wifi_fmac_chg_vif(void *dev_ctx,
 		break;
 	default:
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: VIF type not supported\n", __func__);
+				      "%s: VIF type not supported", __func__);
 		goto out;
 	}
 
@@ -2211,7 +2211,7 @@ enum nrf_wifi_status nrf_wifi_fmac_chg_vif(void *dev_ctx,
 
 	if (!chg_vif_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2261,7 +2261,7 @@ enum nrf_wifi_status nrf_wifi_fmac_chg_vif_state(void *dev_ctx,
 
 	if (!chg_vif_state_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2290,7 +2290,7 @@ enum nrf_wifi_status nrf_wifi_fmac_chg_vif_state(void *dev_ctx,
 	if (count == 0) {
 		status = NRF_WIFI_STATUS_FAIL;
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: RPU is unresponsive for %d sec\n",
+				      "%s: RPU is unresponsive for %d sec",
 				      __func__, RPU_CMD_TIMEOUT_MS / 1000);
 		goto out;
 	}
@@ -2329,7 +2329,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_vif_macaddr(void *dev_ctx,
 
 	if (!mac_addr) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid MAC address\n",
+				      "%s: Invalid MAC address",
 				      __func__);
 		goto out;
 	}
@@ -2341,7 +2341,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_vif_macaddr(void *dev_ctx,
 
 	if (!cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate cmd\n",
+				      "%s: Unable to allocate cmd",
 				      __func__);
 		goto out;
 	}
@@ -2384,7 +2384,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_wiphy_params(void *dev_ctx,
 
 	if (!wiphy_info) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: wiphy_info: Invalid memory\n",
+				      "%s: wiphy_info: Invalid memory",
 				       __func__);
 		goto out;
 	}
@@ -2394,7 +2394,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_wiphy_params(void *dev_ctx,
 
 	if (!set_wiphy_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2491,7 +2491,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_tx_power(void *dev_ctx,
 
 	if (!cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2526,7 +2526,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_channel(void *dev_ctx,
 
 	if (!cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2563,7 +2563,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_station(void *dev_ctx,
 
 	if (!cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2606,7 +2606,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_interface(void *dev_ctx,
 
 	if (!cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2643,7 +2643,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_qos_map(void *dev_ctx,
 
 	if (!set_qos_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2690,7 +2690,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_power_save(void *dev_ctx,
 
 	if (!set_ps_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -2731,7 +2731,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_uapsd_queue(void *dev_ctx,
 						  sizeof(*set_uapsdq_cmd));
 	if (!set_uapsdq_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2770,7 +2770,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_power_save_timeout(void *dev_ctx,
 
 	if (!set_ps_timeout_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -2810,7 +2810,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_wiphy(void *dev_ctx, unsigned char if_idx
 
 	if (!get_wiphy) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2848,7 +2848,7 @@ enum nrf_wifi_status nrf_wifi_fmac_register_frame(void *dev_ctx, unsigned char i
 		nrf_wifi_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv, sizeof(*frame_reg_cmd));
 
 	if (!frame_reg_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv, "%s: Unable to allocate memory\n",
+		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv, "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2889,7 +2889,7 @@ enum nrf_wifi_status nrf_wifi_fmac_twt_setup(void *dev_ctx,
 
 	if (!twt_setup_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2936,7 +2936,7 @@ enum nrf_wifi_status nrf_wifi_fmac_twt_teardown(void *dev_ctx,
 
 	if (!twt_teardown_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -2974,7 +2974,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_mcast_addr(struct nrf_wifi_fmac_dev_ctx *
 
 	if (!set_mcast_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -3015,7 +3015,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_conn_info(void *dev_ctx,
 
 	if (!cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -3049,7 +3049,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_power_save_info(void *dev_ctx,
 
 	if (!get_ps_info_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -3085,7 +3085,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_listen_interval(void *dev_ctx,
 
 	if (!set_listen_interval_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 
@@ -3123,7 +3123,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_ps_wakeup_mode(void *dev_ctx,
 
 	if (!set_ps_wakeup_mode_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n", __func__);
+				      "%s: Unable to allocate memory", __func__);
 		goto out;
 	}
 

--- a/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/nrf_wifi/fw_if/umac_if/src/event.c
@@ -36,7 +36,7 @@ nrf_wifi_fmac_if_carr_state_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 
 	if (!fmac_dev_ctx || !umac_head) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 
 		goto out;
@@ -44,7 +44,7 @@ nrf_wifi_fmac_if_carr_state_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 
 	if (!def_priv->callbk_fns.if_carr_state_chg_callbk_fn) {
 		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No callback handler registered\n",
+				      "%s: No callback handler registered",
 				      __func__);
 
 		status = NRF_WIFI_STATUS_SUCCESS;
@@ -55,7 +55,7 @@ nrf_wifi_fmac_if_carr_state_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 
 	if (if_idx >= MAX_NUM_VIFS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid wdev_id recd from UMAC %d\n",
+				      "%s: Invalid wdev_id recd from UMAC %d",
 				      __func__,
 				      if_idx);
 		goto out;
@@ -68,7 +68,7 @@ nrf_wifi_fmac_if_carr_state_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Interface carrier state change callback function failed for VIF idx = %d\n",
+				      "%s: Interface carrier state change callback function failed for VIF idx = %d",
 				      __func__,
 				      if_idx);
 		goto out;
@@ -96,7 +96,7 @@ static void umac_event_connect(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	vif_ctx = def_dev_ctx->vif_ctx[if_index];
 	if (if_index >= MAX_NUM_VIFS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid wdev_id recd from UMAC %d\n",
+				      "%s: Invalid wdev_id recd from UMAC %d",
 				      __func__,
 				      if_index);
 		return;
@@ -120,7 +120,7 @@ static void umac_event_connect(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 			if (peer_id == -1) {
 				nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-						      "%s:Can't add new station.\n",
+						      "%s:Can't add new station.",
 						      __func__);
 				return;
 			}
@@ -157,7 +157,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 
 	if (!fmac_dev_ctx || !event_data) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -175,7 +175,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 
 	if (if_id >= MAX_NUM_VIFS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid wdev_id recd from UMAC %d\n",
+				      "%s: Invalid wdev_id recd from UMAC %d",
 				      __func__,
 				      if_id);
 
@@ -186,7 +186,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	callbk_fns = &def_priv->callbk_fns;
 
 	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event %d received from UMAC\n",
+			      "%s: Event %d received from UMAC",
 			      __func__,
 			      event_num);
 
@@ -198,7 +198,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -209,7 +209,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -220,7 +220,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -235,7 +235,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							    more_res);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -255,7 +255,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -270,7 +270,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						       more_res);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -281,7 +281,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -292,7 +292,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -303,7 +303,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -314,7 +314,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						       event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -325,7 +325,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						      event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -336,7 +336,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -347,7 +347,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						       event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -358,7 +358,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -369,7 +369,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -380,7 +380,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -391,7 +391,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -403,7 +403,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 								  event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -414,7 +414,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -425,7 +425,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -436,7 +436,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							   event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -447,7 +447,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						    event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -464,7 +464,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						      event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -475,7 +475,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						      event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -494,7 +494,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						  event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -505,7 +505,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -517,7 +517,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							    event_len);
 		else
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d\n",
+					      "%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -527,14 +527,14 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 #endif /* CONFIG_NRF700X_STA_MODE */
 	default:
 		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No callback registered for event %d\n",
+				      "%s: No callback registered for event %d",
 				      __func__,
 				      umac_hdr->cmd_evnt);
 		break;
 	}
 
 	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event %d processed\n",
+			      "%s: Event %d processed",
 			      __func__,
 			      event_num);
 
@@ -558,7 +558,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (!umac_head) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -566,7 +566,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	event = ((struct nrf_wifi_umac_head *)umac_head)->cmd;
 
 	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event %d received from UMAC\n",
+			      "%s: Event %d received from UMAC",
 			      __func__,
 			      event);
 
@@ -578,7 +578,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 			sizeof(struct nrf_wifi_rx_buff));
 		if (!config) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to allocate memory (RX)\n",
+					      "%s: Failed to allocate memory (RX)",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			break;
@@ -592,7 +592,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					 config);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to enqueue RX buffer\n",
+					      "%s: Failed to enqueue RX buffer",
 					      __func__);
 			nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
 					       config);
@@ -613,7 +613,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					sizeof(struct nrf_wifi_tx_buff_done));
 		if (!config) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to allocate memory (TX)\n",
+					      "%s: Failed to allocate memory (TX)",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			break;
@@ -627,7 +627,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 			config);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to enqueue TX buffer\n",
+					      "%s: Failed to enqueue TX buffer",
 					      __func__);
 			nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
 					       config);
@@ -668,7 +668,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 out:
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed for event = %d\n",
+				      "%s: Failed for event = %d",
 				      __func__,
 				      event);
 	}
@@ -698,7 +698,7 @@ nrf_wifi_fmac_data_events_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: umac_process_data_event failed\n",
+					      "%s: umac_process_data_event failed",
 					      __func__);
 			goto out;
 		}
@@ -725,7 +725,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 
 	if (!event) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -734,7 +734,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 
 	if (rf_test_event->rf_test_info.rfevent[0] != def_dev_ctx->rf_test_type) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid event type (%d) recd for RF test type (%d)\n",
+				      "%s: Invalid event type (%d) recd for RF test type (%d)",
 				      __func__,
 				      rf_test_event->rf_test_info.rfevent[0],
 				      def_dev_ctx->rf_test_type);
@@ -762,10 +762,10 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 
 		if (rf_test_get_temperature.readTemperatureStatus) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Temperature reading failed\n");
+			"Temperature reading failed");
 		} else {
 			nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-			"The temperature is = %d degree celsius\n",
+			"The temperature is = %d degree celsius",
 			rf_test_get_temperature.temperature);
 		}
 		break;
@@ -775,7 +775,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 			sizeof(rf_get_rf_rssi));
 
 		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-		"RF RSSI value is = %d\n",
+		"RF RSSI value is = %d",
 		rf_get_rf_rssi.agc_status_val);
 		break;
 	case NRF_WIFI_RF_TEST_EVENT_XO_CALIB:
@@ -784,7 +784,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 			sizeof(xo_calib_params));
 
 		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-		"XO value configured is = %d\n",
+		"XO value configured is = %d",
 		xo_calib_params.xo_val);
 		break;
 	case NRF_WIFI_RF_TEST_XO_TUNE:
@@ -793,7 +793,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 			sizeof(rf_get_xo_value_params));
 
 		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-		"Best XO value is = %d\n",
+		"Best XO value is = %d",
 		rf_get_xo_value_params.xo_value);
 		break;
 	default:
@@ -819,14 +819,14 @@ static enum nrf_wifi_status umac_event_stats_process(struct nrf_wifi_fmac_dev_ct
 
 	if (!event) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
 
 	if (!fmac_dev_ctx->stats_req) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Stats recd when req was not sent!\n",
+				      "%s: Stats recd when req was not sent!",
 				      __func__);
 		goto out;
 	}
@@ -892,7 +892,7 @@ static enum nrf_wifi_status umac_process_sys_events(struct nrf_wifi_fmac_dev_ctx
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 	default:
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unknown event recd: %d\n",
+				      "%s: Unknown event recd: %d",
 				      __func__,
 				      ((struct nrf_wifi_sys_head *)sys_head)->cmd_event);
 		break;
@@ -921,7 +921,7 @@ enum nrf_wifi_status nrf_wifi_fmac_event_callback(void *mac_dev_ctx,
 	umac_msg_type = umac_hdr->cmd_evnt;
 
 	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event type %d recd\n",
+			      "%s: Event type %d recd",
 			      __func__,
 			      rpu_msg->type);
 
@@ -938,7 +938,7 @@ enum nrf_wifi_status nrf_wifi_fmac_event_callback(void *mac_dev_ctx,
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: umac_event_ctrl_process failed\n",
+					      "%s: umac_event_ctrl_process failed",
 					      __func__);
 			goto out;
 		}

--- a/nrf_wifi/fw_if/umac_if/src/fmac_ap.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_ap.c
@@ -29,7 +29,7 @@ enum nrf_wifi_status sap_client_ps_get_frames(struct nrf_wifi_fmac_dev_ctx *fmac
 
 	if (!fmac_dev_ctx || !config) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid params\n",
+				      "%s: Invalid params",
 				      __func__);
 		goto out;
 	}
@@ -44,7 +44,7 @@ enum nrf_wifi_status sap_client_ps_get_frames(struct nrf_wifi_fmac_dev_ctx *fmac
 
 	if (id == -1) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid Peer_ID, Mac Addr =%pM\n",
+				      "%s: Invalid Peer_ID, Mac Addr =%pM",
 				      __func__,
 				      config->mac_addr);
 
@@ -96,7 +96,7 @@ enum nrf_wifi_status sap_client_update_pmmode(struct nrf_wifi_fmac_dev_ctx *fmac
 
 	if (!fmac_dev_ctx || !config) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid params\n",
+				      "%s: Invalid params",
 				      __func__);
 		goto out;
 	}
@@ -112,7 +112,7 @@ enum nrf_wifi_status sap_client_update_pmmode(struct nrf_wifi_fmac_dev_ctx *fmac
 
 	if (id == -1) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid Peer_ID, Mac address = %pM\n",
+				      "%s: Invalid Peer_ID, Mac address = %pM",
 				      __func__,
 				      config->mac_addr);
 

--- a/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
@@ -206,7 +206,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC processor reset failed\n",
+					      "%s: LMAC processor reset failed",
 					      __func__);
 
 			goto out;
@@ -222,12 +222,12 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC patch load failed\n",
+					      "%s: LMAC patch load failed",
 					      __func__);
 			goto out;
 		} else {
 			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC patches loaded\n",
+					      "%s: LMAC patches loaded",
 					      __func__);
 		}
 
@@ -237,7 +237,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to boot LMAC with patch\n",
+					      "%s: Failed to boot LMAC with patch",
 					      __func__);
 			goto out;
 		}
@@ -247,12 +247,12 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC ROM boot check failed\n",
+					      "%s: LMAC ROM boot check failed",
 					      __func__);
 			goto out;
 		} else {
 			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC boot check passed\n",
+					      "%s: LMAC boot check passed",
 					      __func__);
 		}
 	} else {
@@ -262,7 +262,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC ROM boot failed\n",
+					      "%s: LMAC ROM boot failed",
 					      __func__);
 			goto out;
 		}
@@ -272,12 +272,12 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC ROM boot check failed\n",
+					      "%s: LMAC ROM boot check failed",
 					      __func__);
 			goto out;
 		} else {
 			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC boot check passed\n",
+					      "%s: LMAC boot check passed",
 					      __func__);
 		}
 	}
@@ -289,7 +289,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC processor reset failed\n",
+					      "%s: UMAC processor reset failed",
 					      __func__);
 
 			goto out;
@@ -305,12 +305,12 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC patch load failed\n",
+					      "%s: UMAC patch load failed",
 					      __func__);
 			goto out;
 		} else {
 			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC patches loaded\n",
+					      "%s: UMAC patches loaded",
 					      __func__);
 		}
 
@@ -320,7 +320,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to boot UMAC with patch\n",
+					      "%s: Failed to boot UMAC with patch",
 					      __func__);
 			goto out;
 		}
@@ -330,12 +330,12 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC ROM boot check failed\n",
+					      "%s: UMAC ROM boot check failed",
 					      __func__);
 			goto out;
 		} else {
 			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC boot check passed\n",
+					      "%s: UMAC boot check passed",
 					      __func__);
 		}
 	} else {
@@ -345,7 +345,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC ROM boot failed\n",
+					      "%s: UMAC ROM boot failed",
 					      __func__);
 			goto out;
 		}
@@ -355,12 +355,12 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC ROM boot check failed\n",
+					      "%s: UMAC ROM boot check failed",
 					      __func__);
 			goto out;
 		} else {
 			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC boot check passed\n",
+					      "%s: UMAC boot check passed",
 					      __func__);
 		}
 	}
@@ -394,7 +394,7 @@ struct nrf_wifi_fmac_dev_ctx *nrf_wifi_fmac_dev_add(struct nrf_wifi_fmac_priv *f
 
 	if (!fmac_dev_ctx) {
 		nrf_wifi_osal_log_err(fpriv->opriv,
-				      "%s: Unable to allocate fmac_dev_ctx\n",
+				      "%s: Unable to allocate fmac_dev_ctx",
 				      __func__);
 		goto out;
 	}
@@ -407,7 +407,7 @@ struct nrf_wifi_fmac_dev_ctx *nrf_wifi_fmac_dev_add(struct nrf_wifi_fmac_priv *f
 
 	if (!fmac_dev_ctx->hal_dev_ctx) {
 		nrf_wifi_osal_log_err(fpriv->opriv,
-				      "%s: nrf_wifi_hal_dev_add failed\n",
+				      "%s: nrf_wifi_hal_dev_add failed",
 				      __func__);
 
 		nrf_wifi_osal_mem_free(fpriv->opriv,
@@ -448,7 +448,7 @@ enum nrf_wifi_status nrf_wifi_fmac_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 	    (stats_type == RPU_STATS_TYPE_PHY)) {
 		if (fmac_dev_ctx->stats_req == true) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Stats request already pending\n",
+					      "%s: Stats request already pending",
 					      __func__);
 			goto out;
 		}
@@ -475,7 +475,7 @@ enum nrf_wifi_status nrf_wifi_fmac_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 
 		if (count == NRF_WIFI_FMAC_STATS_RECV_TIMEOUT) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Timed out\n",
+					      "%s: Timed out",
 					      __func__);
 			goto out;
 		}
@@ -510,7 +510,7 @@ enum nrf_wifi_status nrf_wifi_fmac_ver_get(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to read UMAC ver\n",
+				      "%s: Unable to read UMAC ver",
 				      __func__);
 		goto out;
 	}
@@ -553,7 +553,7 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 
 	if (!fmac_dev_ctx || !mac_addr || (vif_idx >= MAX_NUM_VIFS)) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -569,7 +569,7 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU OTP information failed\n",
+				      "%s: Fetching of RPU OTP information failed",
 				      __func__);
 		goto out;
 	}
@@ -587,7 +587,7 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 
 	if (otp_info.flags & otp_mac_addr_flag_mask) {
 		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-				       "%s: MAC addr not programmed in OTP\n",
+				       "%s: MAC addr not programmed in OTP",
 				       __func__);
 
 	} else {
@@ -599,7 +599,7 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 		if (!nrf_wifi_utils_is_mac_addr_valid(fmac_dev_ctx->fpriv->opriv,
 						      (const char *)mac_addr)) {
 			nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s:  Invalid OTP MAC addr: %02X%02X%02X%02X%02X%02X\n",
+					       "%s:  Invalid OTP MAC addr: %02X%02X%02X%02X%02X%02X",
 					       __func__,
 					       (*(mac_addr + 0)),
 					       (*(mac_addr + 1)),
@@ -633,7 +633,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 
 	if (!fmac_dev_ctx || !rf_params) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -649,7 +649,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU OTP information failed\n",
+				      "%s: Fetching of RPU OTP information failed",
 				      __func__);
 		goto out;
 	}
@@ -658,7 +658,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 						  &ft_prog_ver);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of FT program version failed\n",
+				      "%s: Fetching of FT program version failed",
 				      __func__);
 		goto out;
 	}
@@ -675,7 +675,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 
 	if (ret == -1) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Initialization of RF params with default values failed\n",
+				      "%s: Initialization of RF params with default values failed",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -750,7 +750,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (!fmac_dev_ctx || !reg_info) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -760,7 +760,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (!set_reg_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -801,7 +801,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (!fmac_dev_ctx || !reg_info) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto err;
 	}
@@ -811,7 +811,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (!get_reg_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory\n",
+				      "%s: Unable to allocate memory",
 				      __func__);
 		goto err;
 	}
@@ -825,7 +825,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to get regulatory information\n",	__func__);
+				      "%s: Failed to get regulatory information",	__func__);
 		goto err;
 	}
 
@@ -838,7 +838,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	if (!fmac_dev_ctx->alpha2_valid) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to get regulatory information\n",
+				      "%s: Failed to get regulatory information",
 				      __func__);
 		goto err;
 	}
@@ -871,7 +871,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_tx_rate(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (!umac_cmd) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+				      "%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -902,7 +902,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_host_rpu_ps_ctrl_state(void *dev_ctx,
 
 	if (!fmac_dev_ctx || !rpu_ps_ctrl_state) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -913,7 +913,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_host_rpu_ps_ctrl_state(void *dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU PS state failed\n",
+				      "%s: Fetching of RPU PS state failed",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/fw_if/umac_if/src/fmac_vif.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_vif.c
@@ -26,7 +26,7 @@ int nrf_wifi_fmac_vif_check_if_limit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	case NRF_WIFI_IFTYPE_P2P_CLIENT:
 		if (def_dev_ctx->num_sta >= MAX_NUM_STAS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Maximum STA Interface type exceeded\n",
+					      "%s: Maximum STA Interface type exceeded",
 					      __func__);
 			return -1;
 		}
@@ -35,14 +35,14 @@ int nrf_wifi_fmac_vif_check_if_limit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	case NRF_WIFI_IFTYPE_P2P_GO:
 		if (def_dev_ctx->num_ap >= MAX_NUM_APS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Maximum AP Interface type exceeded\n",
+					      "%s: Maximum AP Interface type exceeded",
 					      __func__);
 			return -1;
 		}
 		break;
 	default:
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Interface type not supported\n",
+				      "%s: Interface type not supported",
 				      __func__);
 		return -1;
 	}
@@ -69,7 +69,7 @@ void nrf_wifi_fmac_vif_incr_if_type(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		break;
 	default:
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s:Unsupported VIF type\n",
+				      "%s:Unsupported VIF type",
 				      __func__);
 	}
 }
@@ -93,7 +93,7 @@ void nrf_wifi_fmac_vif_decr_if_type(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		break;
 	default:
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s:Unsupported VIF type\n",
+				      "%s:Unsupported VIF type",
 				      __func__);
 	}
 }

--- a/nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -51,7 +51,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init_rt(struct nrf_wifi_fmac_dev_ct
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC init failed\n",
+				      "%s: UMAC init failed",
 				      __func__);
 		goto out;
 	}
@@ -67,7 +67,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init_rt(struct nrf_wifi_fmac_dev_ct
 
 	if (!fmac_dev_ctx->fw_init_done) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC init timed out\n",
+				      "%s: UMAC init timed out",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -105,7 +105,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (!fmac_dev_ctx) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid device context\n",
+				      "%s: Invalid device context",
 				      __func__);
 		goto out;
 	}
@@ -114,7 +114,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_hal_dev_init failed\n",
+				      "%s: nrf_wifi_hal_dev_init failed",
 				      __func__);
 		goto out;
 	}
@@ -131,7 +131,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_fw_init failed\n",
+				      "%s: nrf_wifi_fmac_fw_init failed",
 				      __func__);
 		goto out;
 	}
@@ -161,7 +161,7 @@ struct nrf_wifi_fmac_priv *nrf_wifi_fmac_init_rt(void)
 
 	if (!fpriv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate fpriv\n",
+				      "%s: Unable to allocate fpriv",
 				      __func__);
 		goto out;
 	}
@@ -183,7 +183,7 @@ struct nrf_wifi_fmac_priv *nrf_wifi_fmac_init_rt(void)
 
 	if (!fpriv->hpriv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to do HAL init\n",
+				      "%s: Unable to do HAL init",
 				      __func__);
 		nrf_wifi_osal_mem_free(opriv,
 				       fpriv);
@@ -228,7 +228,7 @@ enum nrf_wifi_status wait_for_radio_cmd_status(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (count == timeout) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out (%d secs)\n",
+				      "%s: Timed out (%d secs)",
 				      __func__,
 					 timeout / 1000);
 		goto out;
@@ -238,7 +238,7 @@ enum nrf_wifi_status wait_for_radio_cmd_status(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (radio_cmd_status != NRF_WIFI_UMAC_CMD_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Radio test command failed with status %d\n",
+				      "%s: Radio test command failed with status %d",
 				      __func__,
 				      radio_cmd_status);
 		goto out;
@@ -282,7 +282,7 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_init(struct nrf_wifi_fmac_dev_ctx 
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to init radio test\n",
+				      "%s: Unable to init radio test",
 				      __func__);
 		goto out;
 	}
@@ -312,7 +312,7 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_prog_tx(struct nrf_wifi_fmac_dev_c
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to program radio test TX\n",
+				      "%s: Unable to program radio test TX",
 				      __func__);
 		goto out;
 	}
@@ -363,7 +363,7 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_prog_rx(struct nrf_wifi_fmac_dev_c
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to program radio test RX\n",
+				      "%s: Unable to program radio test RX",
 				      __func__);
 		goto out;
 	}
@@ -412,7 +412,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ctx *
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_test_cap failed\n",
+				      "%s: umac_cmd_prog_rf_test_cap failed",
 				      __func__);
 
 		goto out;
@@ -427,7 +427,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ctx *
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out\n",
+				      "%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -472,7 +472,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_ctx 
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_test_tx_tone failed\n",
+				      "%s: umac_cmd_prog_rf_test_tx_tone failed",
 				      __func__);
 
 		goto out;
@@ -487,7 +487,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_ctx 
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out\n",
+				      "%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -528,7 +528,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_dpd(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_test_dpd failed\n",
+				      "%s: umac_cmd_prog_rf_test_dpd failed",
 				      __func__);
 
 		goto out;
@@ -543,7 +543,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_dpd(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out\n",
+				      "%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -582,7 +582,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_temp(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_get_temperature failed\n",
+				      "%s: umac_cmd_prog_rf_get_temperature failed",
 				      __func__);
 
 		goto out;
@@ -597,7 +597,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_temp(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out\n",
+				      "%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -637,7 +637,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_rf_rssi(struct nrf_wifi_fmac_dev_ctx *
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_get_rf_rssi failed\n",
+				      "%s: umac_cmd_prog_rf_get_rf_rssi failed",
 				      __func__);
 
 		goto out;
@@ -652,7 +652,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_rf_rssi(struct nrf_wifi_fmac_dev_ctx *
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out\n",
+				      "%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -694,7 +694,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_xo_val(struct nrf_wifi_fmac_dev_ctx *fmac
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_set_xo_val failed\n",
+				      "%s: umac_cmd_prog_set_xo_val failed",
 				      __func__);
 
 		goto out;
@@ -709,7 +709,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_xo_val(struct nrf_wifi_fmac_dev_ctx *fmac
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out\n",
+				      "%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -748,7 +748,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_compute_xo(struct nrf_wifi_fmac_dev_c
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_get_xo_value failed\n",
+				      "%s: umac_cmd_prog_rf_get_xo_value failed",
 				      __func__);
 
 		goto out;
@@ -763,7 +763,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_compute_xo(struct nrf_wifi_fmac_dev_c
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out\n",
+				      "%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;

--- a/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -66,7 +66,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_map_desc_to_pool failed\n",
+				      "%s: nrf_wifi_fmac_map_desc_to_pool failed",
 				      __func__);
 		goto out;
 	}
@@ -78,7 +78,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 	if (cmd_type == NRF_WIFI_FMAC_RX_CMD_TYPE_INIT) {
 		if (rx_buf_info->mapped) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Init RX command called for already mapped RX buffer(%d)\n",
+					      "%s: Init RX command called for already mapped RX buffer(%d)",
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -90,7 +90,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 
 		if (!nwb) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No space for allocating RX buffer\n",
+					      "%s: No space for allocating RX buffer",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
@@ -109,7 +109,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 
 		if (!phy_addr) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_hal_buf_map_rx failed\n",
+					      "%s: nrf_wifi_hal_buf_map_rx failed",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
@@ -137,7 +137,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 		 */
 		if (!rx_buf_info->mapped) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Deinit RX command called for unmapped RX buffer(%d)\n",
+					      "%s: Deinit RX command called for unmapped RX buffer(%d)",
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -151,7 +151,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 
 		if (!nwb_data) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_hal_buf_unmap_rx failed\n",
+					      "%s: nrf_wifi_hal_buf_unmap_rx failed",
 					      __func__);
 			goto out;
 		}
@@ -163,7 +163,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 		status = NRF_WIFI_STATUS_SUCCESS;
 	} else {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unknown cmd_type (%d)\n",
+				      "%s: Unknown cmd_type (%d)",
 				      __func__,
 				      cmd_type);
 		goto out;
@@ -189,7 +189,7 @@ void nrf_wifi_fmac_rx_tasklet(void *data)
 
 	if (!config) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No RX config available\n",
+				      "%s: No RX config available",
 				      __func__);
 		goto out;
 	}
@@ -199,7 +199,7 @@ void nrf_wifi_fmac_rx_tasklet(void *data)
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_rx_event_process failed\n",
+				      "%s: nrf_wifi_fmac_rx_event_process failed",
 				      __func__);
 		goto out;
 	}
@@ -247,7 +247,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 
 		if (desc_id >= def_priv->num_rx_bufs) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Invalid desc_id %d\n",
+					      "%s: Invalid desc_id %d",
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -260,7 +260,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_fmac_map_desc_to_pool failed\n",
+					      "%s: nrf_wifi_fmac_map_desc_to_pool failed",
 					      __func__);
 			goto out;
 		}
@@ -272,7 +272,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 
 		if (!nwb_data) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_hal_buf_unmap_rx failed\n",
+					      "%s: nrf_wifi_hal_buf_unmap_rx failed",
 					      __func__);
 			goto out;
 		}
@@ -332,7 +332,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 				break;
 			default:
 				nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-						      "%s: Invalid pkt_type=%d\n",
+						      "%s: Invalid pkt_type=%d",
 						      __func__,
 						      (config->rx_buff_info[i].pkt_type));
 				status = NRF_WIFI_STATUS_FAIL;
@@ -353,7 +353,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 						nwb);
 		} else {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Invalid frame type recd %d\n",
+					      "%s: Invalid frame type recd %d",
 					      __func__,
 					      config->rx_pkt_type);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -366,7 +366,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_fmac_rx_cmd_send failed\n",
+					      "%s: nrf_wifi_fmac_rx_cmd_send failed",
 					      __func__);
 			goto out;
 		}

--- a/nrf_wifi/fw_if/umac_if/src/tx.c
+++ b/nrf_wifi/fw_if/umac_if/src/tx.c
@@ -571,7 +571,7 @@ enum nrf_wifi_status tx_cmd_prep_callbk_fn(void *callbk_data,
 
 	if (tx_buf_info->mapped) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Init_TX cmd called for already mapped TX buffer(%d)\n",
+				      "%s: Init_TX cmd called for already mapped TX buffer(%d)",
 				      __func__,
 				      desc_id);
 
@@ -594,7 +594,7 @@ enum nrf_wifi_status tx_cmd_prep_callbk_fn(void *callbk_data,
 
 	if (!phy_addr) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_hal_buf_map_tx failed\n",
+				      "%s: nrf_wifi_hal_buf_map_tx failed",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -645,7 +645,7 @@ enum nrf_wifi_status tx_cmd_prepare(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (txq_len == 0) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: txq_len = %d\n",
+				      "%s: txq_len = %d",
 				      __func__,
 				      txq_len);
 		goto err;
@@ -706,7 +706,7 @@ enum nrf_wifi_status tx_cmd_prepare(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: build_mac80211_hdr failed\n",
+				      "%s: build_mac80211_hdr failed",
 				      __func__);
 		goto err;
 	}
@@ -764,7 +764,7 @@ enum nrf_wifi_status tx_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: tx_cmd_prepare failed\n",
+				      "%s: tx_cmd_prepare failed",
 				      __func__);
 
 		goto out;
@@ -795,7 +795,7 @@ enum nrf_wifi_status tx_pending_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 
 	if (!fmac_dev_ctx) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid params\n",
+				      "%s: Invalid params",
 				      __func__);
 		goto out;
 	}
@@ -832,7 +832,7 @@ enum nrf_wifi_status tx_enqueue(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (!fmac_dev_ctx || !nwb) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid params\n",
+				      "%s: Invalid params",
 				      __func__);
 		goto out;
 	}
@@ -1049,7 +1049,7 @@ enum nrf_wifi_status tx_done_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (desc > def_priv->num_tx_tokens) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "Invalid desc\n");
+				      "Invalid desc");
 		goto out;
 	}
 
@@ -1065,7 +1065,7 @@ enum nrf_wifi_status tx_done_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 		if (!tx_buf_info->mapped) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Deinit_TX cmd called for unmapped TX buf(%d)\n",
+					      "%s: Deinit_TX cmd called for unmapped TX buf(%d)",
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -1077,7 +1077,7 @@ enum nrf_wifi_status tx_done_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 		if (!virt_addr) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_hal_buf_unmap_tx failed\n",
+					      "%s: nrf_wifi_hal_buf_unmap_tx failed",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
@@ -1147,7 +1147,7 @@ static void tx_done_tasklet_fn(unsigned long data)
 
 	if (!config) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: TX done event Q is empty\n",
+				      "%s: TX done event Q is empty",
 				      __func__);
 		return;
 	}
@@ -1172,7 +1172,7 @@ enum nrf_wifi_status (nrf_wifi_fmac_tx_done_event_process)(
 
 	if (!config) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 
 		goto out;
@@ -1190,7 +1190,7 @@ enum nrf_wifi_status (nrf_wifi_fmac_tx_done_event_process)(
 out:
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed\n",
+				      "%s: Failed",
 				      __func__);
 	}
 
@@ -1279,7 +1279,7 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	if (!def_dev_ctx->tx_config.send_pkt_coalesce_count_p) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate send_pkt_coalesce_count_p\n",
+				      "%s: Unable to allocate send_pkt_coalesce_count_p",
 				      __func__);
 		goto out;
 	}
@@ -1291,7 +1291,7 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 			if (!def_dev_ctx->tx_config.data_pending_txq[j][i]) {
 				nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-						      "%s: Unable to allocate data_pending_txq\n",
+						      "%s: Unable to allocate data_pending_txq",
 						      __func__);
 				goto coal_q_free;
 			}
@@ -1309,7 +1309,7 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	if (!def_dev_ctx->tx_config.pkt_info_p) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate pkt_info_p\n",
+				      "%s: Unable to allocate pkt_info_p",
 				      __func__);
 		goto tx_q_free;
 	}
@@ -1319,7 +1319,7 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 		if (!def_dev_ctx->tx_config.pkt_info_p[i].pkt) {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Unable to allocate pkt list\n",
+					      "%s: Unable to allocate pkt list",
 					      __func__);
 			goto tx_q_setup_free;
 		}
@@ -1336,7 +1336,7 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	if (!def_dev_ctx->tx_config.buf_pool_bmp_p) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate buf_pool_bmp_p\n",
+				      "%s: Unable to allocate buf_pool_bmp_p",
 				      __func__);
 		goto tx_pkt_info_free;
 	}
@@ -1354,7 +1354,7 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	if (!def_dev_ctx->tx_config.tx_lock) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate TX lock\n",
+				      "%s: Unable to allocate TX lock",
 				      __func__);
 		goto tx_buff_map_free;
 	}
@@ -1366,7 +1366,7 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	if (!def_dev_ctx->tx_config.wakeup_client_q) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate Wakeup Client List\n",
+				      "%s: Unable to allocate Wakeup Client List",
 				      __func__);
 		goto tx_spin_lock_free;
 	}
@@ -1378,14 +1378,14 @@ enum nrf_wifi_status tx_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 								    NRF_WIFI_TASKLET_TYPE_TX_DONE);
 	if (!def_dev_ctx->tx_done_tasklet) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate tx_done_tasklet\n",
+				      "%s: Unable to allocate tx_done_tasklet",
 				      __func__);
 		goto wakeup_client_q_free;
 	}
 	def_dev_ctx->tx_config.tx_done_tasklet_event_q = nrf_wifi_utils_q_alloc(fpriv->opriv);
 	if (!def_dev_ctx->tx_config.tx_done_tasklet_event_q) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate tx_done_tasklet_event_q\n",
+				      "%s: Unable to allocate tx_done_tasklet_event_q",
 				      __func__);
 		goto tx_done_tasklet_free;
 	}
@@ -1549,7 +1549,7 @@ enum nrf_wifi_status nrf_wifi_fmac_start_xmit(void *dev_ctx,
 
 	if (peer_id == -1) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Got packet for unknown PEER\n",
+				      "%s: Got packet for unknown PEER",
 				      __func__);
 
 		goto out;
@@ -1572,7 +1572,7 @@ enum nrf_wifi_status nrf_wifi_fmac_start_xmit(void *dev_ctx,
 
 	if (tx_status == NRF_WIFI_FMAC_TX_STATUS_FAIL) {
 		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to send packet\n",
+				      "%s: Failed to send packet",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/hw_if/hal/src/hal_api.c
+++ b/nrf_wifi/hw_if/hal/src/hal_api.c
@@ -31,7 +31,7 @@ nrf_wifi_hal_rpu_pktram_buf_map_init(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed\n",
+				      "%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		goto out;
 	}
@@ -70,7 +70,7 @@ unsigned long nrf_wifi_hal_buf_map_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (rx_buf_info->mapped) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for already mapped RX buffer\n",
+				      "%s: Called for already mapped RX buffer",
 				      __func__);
 		goto out;
 	}
@@ -80,7 +80,7 @@ unsigned long nrf_wifi_hal_buf_map_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (buf_len != hal_dev_ctx->hpriv->cfg_params.rx_buf_pool[pool_id].buf_sz) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid buf_len (%d) for pool_id (%d)\n",
+				      "%s: Invalid buf_len (%d) for pool_id (%d)",
 				      __func__,
 				      buf_len,
 				      pool_id);
@@ -106,7 +106,7 @@ unsigned long nrf_wifi_hal_buf_map_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (!rx_buf_info->phy_addr) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: DMA map failed\n",
+				      "%s: DMA map failed",
 				      __func__);
 		goto out;
 	}
@@ -134,7 +134,7 @@ unsigned long nrf_wifi_hal_buf_unmap_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	if (!rx_buf_info->mapped) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for unmapped RX buffer\n",
+				      "%s: Called for unmapped RX buffer",
 				      __func__);
 		goto out;
 	}
@@ -149,7 +149,7 @@ unsigned long nrf_wifi_hal_buf_unmap_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 	if (data_len) {
 		if (!unmapped_addr) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: DMA unmap failed\n",
+					      "%s: DMA unmap failed",
 					      __func__);
 			goto out;
 		}
@@ -190,7 +190,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (tx_buf_info->mapped) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for already mapped TX buffer\n",
+				      "%s: Called for already mapped TX buffer",
 				      __func__);
 		goto out;
 	}
@@ -200,7 +200,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	if (buf_len > (hal_dev_ctx->hpriv->cfg_params.max_tx_frm_sz -
 		       hal_dev_ctx->hpriv->cfg_params.tx_buf_headroom_sz)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid TX buf_len (%d) for (%d)\n",
+				      "%s: Invalid TX buf_len (%d) for (%d)",
 				      __func__,
 				      buf_len,
 				      desc_id);
@@ -223,7 +223,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	rpu_addr = RPU_MEM_PKT_BASE + (bounce_buf_addr - hal_dev_ctx->addr_rpu_pktram_base);
 
 	nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-	       "%s: bounce_buf_addr: 0x%lx, rpu_addr: 0x%lx, buf_len: %d off:%d\n",
+	       "%s: bounce_buf_addr: 0x%lx, rpu_addr: 0x%lx, buf_len: %d off:%d",
 	       __func__,
 	       bounce_buf_addr,
 	       rpu_addr,
@@ -244,7 +244,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (!tx_buf_info->phy_addr) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: DMA map failed\n",
+				      "%s: DMA map failed",
 				      __func__);
 		goto out;
 	}
@@ -270,7 +270,7 @@ unsigned long nrf_wifi_hal_buf_unmap_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	if (!tx_buf_info->mapped) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for unmapped TX buffer\n",
+				      "%s: Called for unmapped TX buffer",
 				      __func__);
 		goto out;
 	}
@@ -282,7 +282,7 @@ unsigned long nrf_wifi_hal_buf_unmap_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	if (!unmapped_addr) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: DMA unmap failed\n",
+				      "%s: DMA unmap failed",
 				      __func__);
 		goto out;
 	}
@@ -313,7 +313,7 @@ enum nrf_wifi_status hal_rpu_ps_wake(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 
 	if (!hal_dev_ctx) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		return status;
 	}
@@ -367,7 +367,7 @@ enum nrf_wifi_status hal_rpu_ps_wake(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
 				      "%s: RPU is not ready for more than %d sec,"
-				      "reg_val = 0x%X rpu_ps_state_mask = 0x%X\n",
+				      "reg_val = 0x%X rpu_ps_state_mask = 0x%X",
 				      __func__,
 				      RPU_PS_WAKE_TIMEOUT_S,
 				      reg_val,
@@ -415,7 +415,7 @@ static enum nrf_wifi_status hal_rpu_ps_init(struct nrf_wifi_hal_dev_ctx *hal_dev
 
 	if (!hal_dev_ctx->rpu_ps_lock) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Unable to allocate lock\n",
+				      "%s: Unable to allocate lock",
 				      __func__);
 		goto out;
 	}
@@ -427,7 +427,7 @@ static enum nrf_wifi_status hal_rpu_ps_init(struct nrf_wifi_hal_dev_ctx *hal_dev
 
 	if (!hal_dev_ctx->rpu_ps_timer) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Unable to allocate timer\n",
+				      "%s: Unable to allocate timer",
 				      __func__);
 		nrf_wifi_osal_spinlock_free(hal_dev_ctx->hpriv->opriv,
 					    hal_dev_ctx->rpu_ps_lock);
@@ -475,7 +475,7 @@ enum nrf_wifi_status nrf_wifi_hal_get_rpu_ps_state(
 
 	if (!hal_dev_ctx) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -501,7 +501,7 @@ static bool hal_rpu_hpq_is_empty(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Read from dequeue address failed, val (0x%X)\n",
+				      "%s: Read from dequeue address failed, val (0x%X)",
 				      __func__,
 				      val);
 		return true;
@@ -525,7 +525,7 @@ static enum nrf_wifi_status hal_rpu_ready(struct nrf_wifi_hal_dev_ctx *hal_dev_c
 		avl_buf_q = &hal_dev_ctx->rpu_info.hpqm_info.cmd_avl_queue;
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid msg type %d\n",
+				      "%s: Invalid msg type %d",
 				      __func__,
 				      msg_type);
 
@@ -556,7 +556,7 @@ static enum nrf_wifi_status hal_rpu_ready_wait(struct nrf_wifi_hal_dev_ctx *hal_
 		if (nrf_wifi_osal_time_elapsed_us(hal_dev_ctx->hpriv->opriv,
 						  start_time_us) >= MAX_HAL_RPU_READY_WAIT) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Timed out waiting (msg_type = %d)\n",
+					      "%s: Timed out waiting (msg_type = %d)",
 					      __func__,
 					      msg_type);
 			goto out;
@@ -579,7 +579,7 @@ static enum nrf_wifi_status hal_rpu_msg_trigger(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to MCU cmd register failed\n",
+				      "%s: Writing to MCU cmd register failed",
 				      __func__);
 		goto out;
 	}
@@ -600,7 +600,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 
 	if (queue_id >= MAX_NUM_OF_RX_QUEUES) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid queue_id (%d)\n",
+				      "%s: Invalid queue_id (%d)",
 				      __func__,
 				      queue_id);
 		goto out;
@@ -613,7 +613,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 		busy_queue = &hal_dev_ctx->rpu_info.hpqm_info.rx_buf_busy_queue[queue_id];
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid msg_type (%d)\n",
+				      "%s: Invalid msg_type (%d)",
 				      __func__,
 				      msg_type);
 		goto out;
@@ -628,7 +628,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Queueing of message to RPU failed\n",
+				      "%s: Queueing of message to RPU failed",
 				      __func__);
 		goto out;
 	}
@@ -639,7 +639,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Posting command to RPU failed\n",
+					      "%s: Posting command to RPU failed",
 					      __func__);
 			goto out;
 		}
@@ -660,7 +660,7 @@ static enum nrf_wifi_status hal_rpu_msg_get_addr(struct nrf_wifi_hal_dev_ctx *ha
 		avl_queue = &hal_dev_ctx->rpu_info.hpqm_info.cmd_avl_queue;
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid msg_type (%d)\n",
+				      "%s: Invalid msg_type (%d)",
 				      __func__,
 				      msg_type);
 		goto out;
@@ -672,7 +672,7 @@ static enum nrf_wifi_status hal_rpu_msg_get_addr(struct nrf_wifi_hal_dev_ctx *ha
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Dequeue of address failed msg_addr 0x%X\n",
+				      "%s: Dequeue of address failed msg_addr 0x%X",
 				      __func__,
 				      *msg_addr);
 		*msg_addr = 0;
@@ -700,7 +700,7 @@ static enum nrf_wifi_status hal_rpu_msg_write(struct nrf_wifi_hal_dev_ctx *hal_d
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Getting address (0x%X) to post message failed\n",
+				      "%s: Getting address (0x%X) to post message failed",
 				      __func__,
 				      msg_addr);
 		goto out;
@@ -714,7 +714,7 @@ static enum nrf_wifi_status hal_rpu_msg_write(struct nrf_wifi_hal_dev_ctx *hal_d
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Copying information to RPU failed\n",
+				      "%s: Copying information to RPU failed",
 				      __func__);
 		goto out;
 	}
@@ -727,7 +727,7 @@ static enum nrf_wifi_status hal_rpu_msg_write(struct nrf_wifi_hal_dev_ctx *hal_d
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Posting command to RPU failed\n",
+				      "%s: Posting command to RPU failed",
 				      __func__);
 		goto out;
 	}
@@ -749,7 +749,7 @@ static enum nrf_wifi_status hal_rpu_cmd_process_queue(struct nrf_wifi_hal_dev_ct
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Timeout waiting to get free cmd buff from RPU\n",
+					      "%s: Timeout waiting to get free cmd buff from RPU",
 					      __func__);
 			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 					       cmd);
@@ -764,7 +764,7 @@ static enum nrf_wifi_status hal_rpu_cmd_process_queue(struct nrf_wifi_hal_dev_ct
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing command to RPU failed\n",
+					      "%s: Writing command to RPU failed",
 					      __func__);
 			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 					       cmd);
@@ -808,7 +808,7 @@ static enum nrf_wifi_status hal_rpu_cmd_queue(struct nrf_wifi_hal_dev_ctx *hal_d
 
 			if (!hal_msg) {
 				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Unable to alloc buff for frag HAL cmd\n",
+						      "%s: Unable to alloc buff for frag HAL cmd",
 						      __func__);
 				status = NRF_WIFI_STATUS_FAIL;
 				goto out;
@@ -827,7 +827,7 @@ static enum nrf_wifi_status hal_rpu_cmd_queue(struct nrf_wifi_hal_dev_ctx *hal_d
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
 				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Unable to queue frag HAL cmd\n",
+						      "%s: Unable to queue frag HAL cmd",
 						      __func__);
 				goto out;
 			}
@@ -841,7 +841,7 @@ static enum nrf_wifi_status hal_rpu_cmd_queue(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (!hal_msg) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to allocate buffer for HAL command\n",
+					      "%s: Unable to allocate buffer for HAL command",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
@@ -860,7 +860,7 @@ static enum nrf_wifi_status hal_rpu_cmd_queue(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to queue fragmented command\n",
+					      "%s: Unable to queue fragmented command",
 					      __func__);
 			goto out;
 		}
@@ -890,7 +890,7 @@ enum nrf_wifi_status nrf_wifi_hal_ctrl_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Queueing of command failed\n",
+				      "%s: Queueing of command failed",
 				      __func__);
 		goto out;
 	}
@@ -930,7 +930,7 @@ enum nrf_wifi_status nrf_wifi_hal_data_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 		max_cmd_size = RPU_DATA_CMD_SIZE_MAX_TX;
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid data command type %d\n",
+				      "%s: Invalid data command type %d",
 				      __func__,
 				      cmd_type);
 	}
@@ -952,7 +952,7 @@ enum nrf_wifi_status nrf_wifi_hal_data_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Copying data cmd(%d) to RPU failed\n",
+				      "%s: Copying data cmd(%d) to RPU failed",
 				      __func__,
 				      cmd_type);
 		goto out;
@@ -966,7 +966,7 @@ enum nrf_wifi_status nrf_wifi_hal_data_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Posting RX buf info to RPU failed\n",
+				      "%s: Posting RX buf info to RPU failed",
 				      __func__);
 		goto out;
 	}
@@ -990,7 +990,7 @@ static void event_tasklet_fn(unsigned long data)
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Event queue processing failed\n",
+				      "%s: Event queue processing failed",
 				      __func__);
 	}
 }
@@ -1030,7 +1030,7 @@ enum nrf_wifi_status hal_rpu_eventq_process(struct nrf_wifi_hal_dev_ctx *hal_dev
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Interrupt callback failed\n",
+					      "%s: Interrupt callback failed",
 					      __func__);
 		}
 
@@ -1100,7 +1100,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate hal_dev_ctx\n",
+				      "%s: Unable to allocate hal_dev_ctx",
 				      __func__);
 		goto err;
 	}
@@ -1115,7 +1115,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx->cmd_q) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate command queue\n",
+				      "%s: Unable to allocate command queue",
 				      __func__);
 		goto hal_dev_free;
 	}
@@ -1124,7 +1124,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx->event_q) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate event queue\n",
+				      "%s: Unable to allocate event queue",
 				      __func__);
 		goto cmd_q_free;
 	}
@@ -1133,7 +1133,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx->lock_hal) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate HAL lock\n", __func__);
+				      "%s: Unable to allocate HAL lock", __func__);
 		hal_dev_ctx = NULL;
 		goto event_q_free;
 	}
@@ -1145,7 +1145,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx->lock_rx) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate HAL lock\n",
+				      "%s: Unable to allocate HAL lock",
 				      __func__);
 		goto lock_hal_free;
 	}
@@ -1158,7 +1158,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx->event_tasklet) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate event_tasklet\n",
+				      "%s: Unable to allocate event_tasklet",
 				      __func__);
 		goto lock_rx_free;
 	}
@@ -1173,7 +1173,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: hal_rpu_ps_init failed\n",
+				      "%s: hal_rpu_ps_init failed",
 				      __func__);
 		goto tasklet_free;
 	}
@@ -1184,7 +1184,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx->bal_dev_ctx) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: nrf_wifi_bal_dev_add failed\n",
+				      "%s: nrf_wifi_bal_dev_add failed",
 				      __func__);
 		goto tasklet_free;
 	}
@@ -1193,7 +1193,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: hal_rpu_irq_enable failed\n",
+				      "%s: hal_rpu_irq_enable failed",
 				      __func__);
 		goto bal_dev_free;
 	}
@@ -1209,7 +1209,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 		if (!hal_dev_ctx->rx_buf_info[i]) {
 			nrf_wifi_osal_log_err(hpriv->opriv,
-					      "%s: No space for RX buf info[%d]\n",
+					      "%s: No space for RX buf info[%d]",
 					      __func__,
 					      i);
 			goto bal_dev_free;
@@ -1224,7 +1224,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (!hal_dev_ctx->tx_buf_info) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: No space for TX buf info\n",
+				      "%s: No space for TX buf info",
 				      __func__);
 		goto rx_buf_free;
 	}
@@ -1234,7 +1234,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Buffer map init failed\n",
+				      "%s: Buffer map init failed",
 				      __func__);
 #ifdef CONFIG_NRF700X_DATA_TX
 		goto tx_buf_free;
@@ -1341,7 +1341,7 @@ enum nrf_wifi_status nrf_wifi_hal_dev_init(struct nrf_wifi_hal_dev_ctx *hal_dev_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: nrf_wifi_bal_dev_init failed\n",
+				      "%s: nrf_wifi_bal_dev_init failed",
 				      __func__);
 		goto out;
 	}
@@ -1356,7 +1356,7 @@ enum nrf_wifi_status nrf_wifi_hal_dev_init(struct nrf_wifi_hal_dev_ctx *hal_dev_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Failed to get the HPQ info\n",
+				      "%s: Failed to get the HPQ info",
 				      __func__);
 		goto out;
 	}
@@ -1368,7 +1368,7 @@ enum nrf_wifi_status nrf_wifi_hal_dev_init(struct nrf_wifi_hal_dev_ctx *hal_dev_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading the RX cmd base failed\n",
+				      "%s: Reading the RX cmd base failed",
 				      __func__);
 		goto out;
 	}
@@ -1470,7 +1470,7 @@ static int nrf_wifi_hal_poll_reg(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Read from address (0x%X) failed, val (0x%X)\n",
+					      "%s: Read from address (0x%X) failed, val (0x%X)",
 					      __func__,
 					      reg_addr,
 					      val);
@@ -1487,7 +1487,7 @@ static int nrf_wifi_hal_poll_reg(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (count == 0) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Timed out polling on (0x%X)\n",
+				      "%s: Timed out polling on (0x%X)",
 				      __func__,
 				      reg_addr);
 
@@ -1508,7 +1508,7 @@ enum nrf_wifi_status nrf_wifi_hal_proc_reset(struct nrf_wifi_hal_dev_ctx *hal_de
 	if ((rpu_proc != RPU_PROC_TYPE_MCU_LMAC) &&
 	    (rpu_proc != RPU_PROC_TYPE_MCU_UMAC)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Unsupported RPU processor(%d)\n",
+				      "%s: Unsupported RPU processor(%d)",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -1527,7 +1527,7 @@ enum nrf_wifi_status nrf_wifi_hal_proc_reset(struct nrf_wifi_hal_dev_ctx *hal_de
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Pulsed soft reset of MCU failed for (%d) processor\n",
+				      "%s: Pulsed soft reset of MCU failed for (%d) processor",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -1551,7 +1551,7 @@ enum nrf_wifi_status nrf_wifi_hal_proc_reset(struct nrf_wifi_hal_dev_ctx *hal_de
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: MCU (%d) failed to come out of reset\n",
+				      "%s: MCU (%d) failed to come out of reset",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -1595,7 +1595,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_chk_boot(struct nrf_wifi_hal_dev_ctx *hal_d
 		exp_val = NRF_WIFI_UMAC_BOOT_SIG;
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid RPU processor (%d)\n",
+				      "%s: Invalid RPU processor (%d)",
 				      __func__,
 				      rpu_proc);
 	}
@@ -1608,7 +1608,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_chk_boot(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Reading of boot signature failed for RPU(%d)\n",
+					      "%s: Reading of boot signature failed for RPU(%d)",
 					      __func__,
 					      rpu_proc);
 		}
@@ -1628,7 +1628,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_chk_boot(struct nrf_wifi_hal_dev_ctx *hal_d
 	if (i == 1000) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
 				      "%s: Boot_sig check failed for RPU(%d), "
-				      "Expected: 0x%X, Actual: 0x%X\n",
+				      "Expected: 0x%X, Actual: 0x%X",
 				      __func__,
 				      rpu_proc,
 				      exp_val,
@@ -1659,7 +1659,7 @@ nrf_wifi_hal_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (!hpriv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate memory for hpriv\n",
+				      "%s: Unable to allocate memory for hpriv",
 				      __func__);
 		goto out;
 	}
@@ -1680,7 +1680,7 @@ nrf_wifi_hal_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: pal_rpu_addr_offset_get failed\n",
+				      "%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		goto out;
 	}
@@ -1693,7 +1693,7 @@ nrf_wifi_hal_init(struct nrf_wifi_osal_priv *opriv,
 
 	if (!hpriv->bpriv) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Failed\n",
+				      "%s: Failed",
 				      __func__);
 		nrf_wifi_osal_mem_free(opriv,
 				       hpriv);
@@ -1721,7 +1721,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_info_get(struct nrf_wifi_hal_dev_ctx *hal_
 
 	if (!hal_dev_ctx || !otp_info) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1733,7 +1733,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_info_get(struct nrf_wifi_hal_dev_ctx *hal_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: OTP info get failed\n",
+				      "%s: OTP info get failed",
 				      __func__);
 		goto out;
 	}
@@ -1745,7 +1745,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_info_get(struct nrf_wifi_hal_dev_ctx *hal_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: OTP flags get failed\n",
+				      "%s: OTP flags get failed",
 				      __func__);
 		goto out;
 	}
@@ -1761,7 +1761,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_ft_prog_ver_get(struct nrf_wifi_hal_dev_ct
 
 	if (!hal_dev_ctx || !ft_prog_ver) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters\n",
+				      "%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1773,7 +1773,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_ft_prog_ver_get(struct nrf_wifi_hal_dev_ct
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: FT program version get failed\n",
+				      "%s: FT program version get failed",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/hw_if/hal/src/hal_fw_patch_loader.c
+++ b/nrf_wifi/hw_if/hal/src/hal_fw_patch_loader.c
@@ -50,7 +50,7 @@ static enum nrf_wifi_status hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal_d
 									patch_chunk_size);
 		if (!patch_data_ram) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				"%s: Failed to allocate memory for patch %s-%s: chunk %d/%d, size: %d\n",
+				"%s: Failed to allocate memory for patch %s-%s: chunk %d/%d, size: %d",
 				__func__,
 				rpu_proc_to_str(rpu_proc),
 				patch_id_str,
@@ -68,7 +68,7 @@ static enum nrf_wifi_status hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal_d
 
 
 		nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-			"%s: Copying patch %s-%s: chunk %d/%d, size: %d\n",
+			"%s: Copying patch %s-%s: chunk %d/%d, size: %d",
 			__func__,
 			rpu_proc_to_str(rpu_proc),
 			patch_id_str,
@@ -83,7 +83,7 @@ static enum nrf_wifi_status hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				"%s: Copying patch %s-%s: chunk %d/%d, size: %d failed\n",
+				"%s: Copying patch %s-%s: chunk %d/%d, size: %d failed",
 				__func__,
 				rpu_proc_to_str(rpu_proc),
 				patch_id_str,
@@ -120,7 +120,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (!fw_pri_patch_data) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Primary patch missing for RPU (%d)\n",
+				      "%s: Primary patch missing for RPU (%d)",
 				      __func__,
 				      rpu_proc);
 		status = NRF_WIFI_STATUS_FAIL;
@@ -129,7 +129,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (!fw_sec_patch_data) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Secondary patch missing for RPU (%d)\n",
+				      "%s: Secondary patch missing for RPU (%d)",
 				      __func__,
 				      rpu_proc);
 		status = NRF_WIFI_STATUS_FAIL;
@@ -150,7 +150,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal
 		break;
 	default:
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid RPU processor type[%d]\n",
+				      "%s: Invalid RPU processor type[%d]",
 				      __func__,
 				      rpu_proc);
 
@@ -236,7 +236,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 		}
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid RPU processor type %d\n",
+				      "%s: Invalid RPU processor type %d",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -253,7 +253,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Clearing of FW pass signature failed for RPU(%d)\n",
+				      "%s: Clearing of FW pass signature failed for RPU(%d)",
 				      __func__,
 				      rpu_proc);
 
@@ -274,7 +274,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to Boot exception 0 reg for RPU processor(%d) failed\n",
+				      "%s: Writing to Boot exception 0 reg for RPU processor(%d) failed",
 				      __func__,
 				      rpu_proc);
 
@@ -288,7 +288,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to Boot exception 1 reg for RPU processor(%d) failed\n",
+				      "%s: Writing to Boot exception 1 reg for RPU processor(%d) failed",
 				      __func__,
 				      rpu_proc);
 
@@ -302,7 +302,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to Boot exception 2 reg for RPU processor(%d) failed\n",
+				      "%s: Writing to Boot exception 2 reg for RPU processor(%d) failed",
 				      __func__,
 				      rpu_proc);
 
@@ -316,7 +316,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to Boot exception 3 reg for RPU processor(%d) failed\n",
+				      "%s: Writing to Boot exception 3 reg for RPU processor(%d) failed",
 				      __func__,
 				      rpu_proc);
 
@@ -330,7 +330,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU processor(%d) run failed\n",
+				      "%s: RPU processor(%d) run failed",
 				      __func__,
 				      rpu_proc);
 

--- a/nrf_wifi/hw_if/hal/src/hal_interrupt.c
+++ b/nrf_wifi/hw_if/hal/src/hal_interrupt.c
@@ -30,7 +30,7 @@ enum nrf_wifi_status hal_rpu_irq_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading from Root interrupt register failed\n",
+				      "%s: Reading from Root interrupt register failed",
 				      __func__);
 		goto out;
 	}
@@ -43,7 +43,7 @@ enum nrf_wifi_status hal_rpu_irq_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Enabling Root interrupt failed\n",
+				      "%s: Enabling Root interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -57,7 +57,7 @@ enum nrf_wifi_status hal_rpu_irq_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s:Enabling MCU interrupt failed\n",
+				      "%s:Enabling MCU interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -78,7 +78,7 @@ enum nrf_wifi_status hal_rpu_irq_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading from Root interrupt register failed\n",
+				      "%s: Reading from Root interrupt register failed",
 				      __func__);
 		goto out;
 	}
@@ -91,7 +91,7 @@ enum nrf_wifi_status hal_rpu_irq_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Disabling Root interrupt failed\n",
+				      "%s: Disabling Root interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -104,7 +104,7 @@ enum nrf_wifi_status hal_rpu_irq_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Disabling MCU interrupt failed\n",
+				      "%s: Disabling MCU interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -141,7 +141,7 @@ static bool hal_rpu_irq_wdog_chk(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading from interrupt status register failed\n",
+				      "%s: Reading from interrupt status register failed",
 				      __func__);
 		goto out;
 	}
@@ -166,7 +166,7 @@ static enum nrf_wifi_status hal_rpu_irq_wdog_ack(struct nrf_wifi_hal_dev_ctx *ha
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Acknowledging watchdog interrupt failed\n",
+				      "%s: Acknowledging watchdog interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -188,7 +188,7 @@ static enum nrf_wifi_status hal_rpu_event_free(struct nrf_wifi_hal_dev_ctx *hal_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Enqueueing of event failed\n",
+				      "%s: Enqueueing of event failed",
 				      __func__);
 		goto out;
 	}
@@ -225,7 +225,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Reading of the event failed\n",
+					      "%s: Reading of the event failed",
 					      __func__);
 			goto out;
 		}
@@ -240,7 +240,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (!hal_dev_ctx->event_data) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to alloc buff for event data\n",
+					      "%s: Unable to alloc buff for event data",
 					      __func__);
 			goto out;
 		} else {
@@ -261,7 +261,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
 				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Reading of first fragment of event failed\n",
+						      "%s: Reading of first fragment of event failed",
 						      __func__);
 				nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 						       hal_dev_ctx->event_data);
@@ -276,7 +276,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 				if (status != NRF_WIFI_STATUS_SUCCESS) {
 					nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							      "%s: Freeing up of the event failed\n",
+							      "%s: Freeing up of the event failed",
 							      __func__);
 					nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 							       hal_dev_ctx->event_data);
@@ -302,7 +302,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 				if (status != NRF_WIFI_STATUS_SUCCESS) {
 					nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							      "%s: Reading of large event failed\n",
+							      "%s: Reading of large event failed",
 							      __func__);
 					nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 							       hal_dev_ctx->event_data);
@@ -323,7 +323,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 				if (status != NRF_WIFI_STATUS_SUCCESS) {
 					nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							      "%s: Freeing up of the event failed\n",
+							      "%s: Freeing up of the event failed",
 							      __func__);
 					nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 							       hal_dev_ctx->event_data);
@@ -350,7 +350,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
 				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Reading of large event failed\n",
+						      "%s: Reading of large event failed",
 						      __func__);
 				nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 						       hal_dev_ctx->event_data);
@@ -366,7 +366,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
 				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Freeing up of the event failed\n",
+						      "%s: Freeing up of the event failed",
 						      __func__);
 				nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 						       hal_dev_ctx->event_data);
@@ -388,7 +388,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (!event) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to alloc HAL msg for event\n",
+					      "%s: Unable to alloc HAL msg for event",
 					      __func__);
 			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 					       hal_dev_ctx->event_data);
@@ -409,7 +409,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to queue event\n",
+					      "%s: Unable to queue event",
 					      __func__);
 			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
 					       event);
@@ -449,7 +449,7 @@ static unsigned int hal_rpu_event_get_all(struct nrf_wifi_hal_dev_ctx *hal_dev_c
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Failed to get event addr\n",
+					      "%s: Failed to get event addr",
 					      __func__);
 			goto out;
 		}
@@ -468,7 +468,7 @@ static unsigned int hal_rpu_event_get_all(struct nrf_wifi_hal_dev_ctx *hal_dev_c
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Failed to queue event\n",
+					      "%s: Failed to queue event",
 					      __func__);
 			goto out;
 		}
@@ -511,13 +511,13 @@ enum nrf_wifi_status hal_rpu_irq_process(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 		if (hal_rpu_irq_wdog_chk(hal_dev_ctx)) {
 			/* TODO: Perform RPU recovery */
 			nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-					      "Received watchdog interrupt\n");
+					      "Received watchdog interrupt");
 
 			status = hal_rpu_irq_wdog_ack(hal_dev_ctx);
 
 			if (status == NRF_WIFI_STATUS_FAIL) {
 				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: hal_rpu_irq_wdog_ack failed\n",
+						      "%s: hal_rpu_irq_wdog_ack failed",
 						      __func__);
 				goto out;
 			}
@@ -528,7 +528,7 @@ enum nrf_wifi_status hal_rpu_irq_process(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: hal_rpu_irq_ack failed\n",
+				      "%s: hal_rpu_irq_ack failed",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/hw_if/hal/src/hal_mem.c
+++ b/nrf_wifi/hw_if/hal/src/hal_mem.c
@@ -93,7 +93,7 @@ static enum nrf_wifi_status rpu_mem_read_ram(struct nrf_wifi_hal_dev_ctx *hal_de
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed\n",
+				      "%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		return status;
 	}
@@ -107,7 +107,7 @@ static enum nrf_wifi_status rpu_mem_read_ram(struct nrf_wifi_hal_dev_ctx *hal_de
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed\n",
+				      "%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}
@@ -149,7 +149,7 @@ static enum nrf_wifi_status rpu_mem_write_ram(struct nrf_wifi_hal_dev_ctx *hal_d
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed\n",
+				      "%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		return status;
 	}
@@ -163,7 +163,7 @@ static enum nrf_wifi_status rpu_mem_write_ram(struct nrf_wifi_hal_dev_ctx *hal_d
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed\n",
+				      "%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}
@@ -205,14 +205,14 @@ static enum nrf_wifi_status rpu_mem_write_core(struct nrf_wifi_hal_dev_ctx *hal_
 	if (!hal_rpu_is_mem_core_indirect(hal_dev_ctx->curr_proc,
 				 core_addr_val)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address\n",
+				      "%s: Invalid memory address",
 				      __func__);
 		goto out;
 	}
 
 	if (core_addr_val % 4 != 0) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Address not multiple of 4 bytes\n",
+				      "%s: Address not multiple of 4 bytes",
 				      __func__);
 		goto out;
 	}
@@ -237,7 +237,7 @@ static enum nrf_wifi_status rpu_mem_write_core(struct nrf_wifi_hal_dev_ctx *hal_
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to address reg failed\n",
+				      "%s: Writing to address reg failed",
 				      __func__);
 		goto out;
 	}
@@ -251,7 +251,7 @@ static enum nrf_wifi_status rpu_mem_write_core(struct nrf_wifi_hal_dev_ctx *hal_
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing to data reg failed\n",
+					      "%s: Writing to data reg failed",
 					      __func__);
 			goto out;
 		}
@@ -297,7 +297,7 @@ static enum nrf_wifi_status rpu_mem_write_bev(struct nrf_wifi_hal_dev_ctx *hal_d
 	    (bev_addr_val > RPU_ADDR_BEV_END) ||
 	    (bev_addr_val % 4 != 0)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Address not in range or not a multiple of 4 bytes\n",
+				      "%s: Address not in range or not a multiple of 4 bytes",
 				      __func__);
 		goto out;
 	}
@@ -318,7 +318,7 @@ static enum nrf_wifi_status rpu_mem_write_bev(struct nrf_wifi_hal_dev_ctx *hal_d
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing to BEV reg failed\n",
+					      "%s: Writing to BEV reg failed",
 					      __func__);
 			goto out;
 		}
@@ -342,14 +342,14 @@ enum nrf_wifi_status hal_rpu_mem_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (!src_addr) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params\n",
+				      "%s: Invalid params",
 				      __func__);
 		goto out;
 	}
 
 	if (!hal_rpu_is_mem_readable(hal_dev_ctx->curr_proc, rpu_mem_addr_val)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address 0x%X\n",
+				      "%s: Invalid memory address 0x%X",
 				      __func__,
 				      rpu_mem_addr_val);
 		goto out;
@@ -377,7 +377,7 @@ enum nrf_wifi_status hal_rpu_mem_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (!src_addr) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params\n",
+				      "%s: Invalid params",
 				      __func__);
 		return status;
 	}
@@ -385,7 +385,7 @@ enum nrf_wifi_status hal_rpu_mem_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	if (!hal_rpu_is_mem_writable(hal_dev_ctx->curr_proc,
 				     rpu_mem_addr_val)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address 0x%X\n",
+				      "%s: Invalid memory address 0x%X",
 				      __func__,
 				      rpu_mem_addr_val);
 		return status;
@@ -410,7 +410,7 @@ enum nrf_wifi_status hal_rpu_mem_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 					   len);
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address 0x%X\n",
+				      "%s: Invalid memory address 0x%X",
 				      __func__,
 				      rpu_mem_addr_val);
 		goto out;
@@ -450,7 +450,7 @@ enum nrf_wifi_status hal_rpu_mem_clr(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 		end_addr = region->end;
 	} else {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-			"%s: Invalid mem_type(%d)\n",
+			"%s: Invalid mem_type(%d)",
 			__func__,
 			mem_type);
 		goto out;
@@ -466,7 +466,7 @@ enum nrf_wifi_status hal_rpu_mem_clr(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: hal_rpu_mem_write failed\n",
+					      "%s: hal_rpu_mem_write failed",
 					      __func__);
 			goto out;
 		}

--- a/nrf_wifi/hw_if/hal/src/hal_reg.c
+++ b/nrf_wifi/hw_if/hal/src/hal_reg.c
@@ -45,7 +45,7 @@ enum nrf_wifi_status hal_rpu_reg_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	if ((val == NULL) ||
 	    !hal_rpu_is_reg(rpu_reg_addr)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params, val = %p, rpu_reg (0x%x)\n",
+				      "%s: Invalid params, val = %p, rpu_reg (0x%x)",
 				      __func__,
 				      val,
 				      rpu_reg_addr);
@@ -59,7 +59,7 @@ enum nrf_wifi_status hal_rpu_reg_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed\n",
+				      "%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		return status;
 	}
@@ -73,7 +73,7 @@ enum nrf_wifi_status hal_rpu_reg_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed\n",
+				      "%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}
@@ -84,7 +84,7 @@ enum nrf_wifi_status hal_rpu_reg_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (*val == 0xFFFFFFFF) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Error !! Value read at addr_offset = %lx is = %X\n",
+				      "%s: Error !! Value read at addr_offset = %lx is = %X",
 				      __func__,
 				      addr_offset,
 				      *val);
@@ -120,7 +120,7 @@ enum nrf_wifi_status hal_rpu_reg_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (!hal_rpu_is_reg(rpu_reg_addr)) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params, rpu_reg_addr (0x%X)\n",
+				      "%s: Invalid params, rpu_reg_addr (0x%X)",
 				      __func__,
 				      rpu_reg_addr);
 		return status;
@@ -133,7 +133,7 @@ enum nrf_wifi_status hal_rpu_reg_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_get_region_offset failed\n",
+				      "%s: pal_rpu_get_region_offset failed",
 				      __func__);
 		return status;
 	}
@@ -147,7 +147,7 @@ enum nrf_wifi_status hal_rpu_reg_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed\n",
+				      "%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/hw_if/hal/src/hpqm.c
+++ b/nrf_wifi/hw_if/hal/src/hpqm.c
@@ -25,7 +25,7 @@ enum nrf_wifi_status hal_rpu_hpq_enqueue(struct nrf_wifi_hal_dev_ctx *hal_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_ctx->hpriv->opriv,
-				      "%s: Writing to enqueue address failed\n",
+				      "%s: Writing to enqueue address failed",
 				      __func__);
 		goto out;
 	}
@@ -47,7 +47,7 @@ enum nrf_wifi_status hal_rpu_hpq_dequeue(struct nrf_wifi_hal_dev_ctx *hal_ctx,
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(hal_ctx->hpriv->opriv,
-				      "%s: Dequeue failed, val (0x%X)\n",
+				      "%s: Dequeue failed, val (0x%X)",
 				      __func__,
 				      *val);
 		goto out;
@@ -61,7 +61,7 @@ enum nrf_wifi_status hal_rpu_hpq_dequeue(struct nrf_wifi_hal_dev_ctx *hal_ctx,
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
 			nrf_wifi_osal_log_err(hal_ctx->hpriv->opriv,
-					      "%s: Writing to dequeue address failed, val (0x%X)\n",
+					      "%s: Writing to dequeue address failed, val (0x%X)",
 					      __func__,
 					      *val);
 			goto out;

--- a/nrf_wifi/hw_if/hal/src/pal.c
+++ b/nrf_wifi/hw_if/hal/src/pal.c
@@ -54,7 +54,7 @@ enum nrf_wifi_status pal_rpu_addr_offset_get(struct nrf_wifi_osal_priv *opriv,
 		region_offset = SOC_MMAP_ADDR_OFFSETS_MCU[proc];
 	} else {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Invalid rpu_addr 0x%X\n",
+				      "%s: Invalid rpu_addr 0x%X",
 				      __func__,
 				      rpu_addr);
 		goto out;
@@ -90,7 +90,7 @@ char *pal_ops_get_fw_loc(struct nrf_wifi_osal_priv *opriv,
 			fw_loc = NRF_WIFI_FW_LMAC_PATCH_LOC_SEC;
 		} else {
 			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid LMAC FW sub-type = %d\n",
+					      "%s: Invalid LMAC FW sub-type = %d",
 					      __func__,
 					      fw_subtype);
 			goto out;
@@ -103,7 +103,7 @@ char *pal_ops_get_fw_loc(struct nrf_wifi_osal_priv *opriv,
 			fw_loc = NRF_WIFI_FW_UMAC_PATCH_LOC_SEC;
 		} else {
 			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid UMAC FW sub-type = %d\n",
+					      "%s: Invalid UMAC FW sub-type = %d",
 					      __func__,
 					      fw_subtype);
 			goto out;
@@ -111,7 +111,7 @@ char *pal_ops_get_fw_loc(struct nrf_wifi_osal_priv *opriv,
 		break;
 	default:
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Invalid FW type = %d\n",
+				      "%s: Invalid FW type = %d",
 				      __func__,
 				      fw_type);
 		goto out;

--- a/nrf_wifi/utils/src/list.c
+++ b/nrf_wifi/utils/src/list.c
@@ -20,7 +20,7 @@ void *nrf_wifi_utils_list_alloc(struct nrf_wifi_osal_priv *opriv)
 
 	if (!list) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate list\n",
+				      "%s: Unable to allocate list",
 				      __func__);
 		goto out;
 	}
@@ -52,7 +52,7 @@ enum nrf_wifi_status nrf_wifi_utils_list_add_tail(struct nrf_wifi_osal_priv *opr
 
 	if (!list_node) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate list node\n",
+				      "%s: Unable to allocate list node",
 				      __func__);
 		return NRF_WIFI_STATUS_FAIL;
 	}
@@ -78,7 +78,7 @@ enum nrf_wifi_status nrf_wifi_utils_list_add_head(struct nrf_wifi_osal_priv *opr
 
 	if (!list_node) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate list node\n",
+				      "%s: Unable to allocate list node",
 				      __func__);
 		return NRF_WIFI_STATUS_FAIL;
 	}

--- a/nrf_wifi/utils/src/util.c
+++ b/nrf_wifi/utils/src/util.c
@@ -29,7 +29,7 @@ int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
 
 	if (len / 2 > hex_arr_sz) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: String length (%d) greater than array size (%d)\n",
+				      "%s: String length (%d) greater than array size (%d)",
 				      __func__,
 				      len,
 				      hex_arr_sz);
@@ -38,7 +38,7 @@ int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
 
 	if (len % 2) {
 		nrf_wifi_osal_log_err(opriv,
-				      "%s:String length = %d, is not a multiple of 2\n",
+				      "%s:String length = %d, is not a multiple of 2",
 				      __func__,
 				      len);
 		goto out;
@@ -50,7 +50,7 @@ int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
 
 		if ((ch < '0' || ch > '9') && (ch < 'a' || ch > 'f')) {
 			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid hex character in string %d\n",
+					      "%s: Invalid hex character in string %d",
 					      __func__,
 					      ch);
 			goto out;
@@ -111,7 +111,7 @@ int nrf_wifi_utils_chan_to_freq(struct nrf_wifi_osal_priv *opriv,
 			freq = 2484;
 		} else {
 			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid channel value %d\n",
+					      "%s: Invalid channel value %d",
 					      __func__,
 					      chan);
 			goto out;
@@ -128,7 +128,7 @@ int nrf_wifi_utils_chan_to_freq(struct nrf_wifi_osal_priv *opriv,
 		break;
 	default:
 		nrf_wifi_osal_log_err(opriv,
-				      "%s: Invalid band value %d\n",
+				      "%s: Invalid band value %d",
 				      __func__,
 				      band);
 		goto out;


### PR DESCRIPTION
The functions nrf_wifi_osal_log_err, nrf_wifi_osal_log_info and nrf_wifi_osal_log_dbg use log macros, which already adds newline. No need to add "\n" in end of these function calls. Remove "\n" from these function calls.