### PR TITLE
CI: Don't run sdk-sidewalk tests on SDC updates

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -176,8 +176,6 @@
       - "!crypto/*.rst"
 
 "CI-sidewalk-test":
-  - "softdevice_controller/include/**/*"
-  - "softdevice_controller/lib/**/*"
   - any:
       - "crypto/**/*"
       - "!crypto/doc/**/*"


### PR DESCRIPTION
We have sufficient coverage by building and running other tests.