### PR TITLE
nrf_wifi: doc: Add a prefix

### DIFF
--- a/nrf_wifi/README.rst
+++ b/nrf_wifi/README.rst
@@ -1,7 +1,7 @@
 .. _nrf_wifi_api:
 
-Low-level API documentation
-***************************
+nRF70 low-level API documentation
+*********************************
 
 The nRF70 Series Wi-Fi driver provides a low-level API for use cases where the application needs to access the nRF70 Series device directly.
 This is typically intended for customers who want to use the nRF70 Series device on a different platform than Zephyr.


### PR DESCRIPTION
In the ToC a prefix helps disambiguate.