### PR TITLE
ci: Fix missing Wi-Fi tests

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -116,6 +116,7 @@
   - "nrf_802154/driver/**/*"
   - "nrf_802154/serialization/**/*"
   - "nrf_802154/sl/**/*"
+  - "nrf_wifi/**/*"
   - any:
       - "crypto/**/*"
       - "!crypto/doc/**/*"
@@ -170,6 +171,7 @@
       - "!crypto/*.rst"
 
 "CI-wifi":
+  - "nrf_wifi/**/*"
   - any:
       - "crypto/**/*"
       - "!crypto/doc/**/*"


### PR DESCRIPTION
These were missed when the driver is restructured and moved to nrfxlib.