### PR TITLE
ci: Add a new Wi-Fi QA required label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,6 @@
 "doc-required":
   - "doc/**/*"
   - "**/*.rst"
+
+"wifi-qa-required":
+  - "nrf_wifi/**/*"


### PR DESCRIPTION
This should be automatically added for nrf Wi-Fi related changes. This is used to enforce a mandatory QA upvote even though it is ready to be merged.