### PR TITLE
CODEOWNERS: Use @ncs-dragoon as code owners for MPSL and SDC

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,11 +33,11 @@ doc/*                                     @b-gent
 # All subfolders
 /.github/                                 @thst-nordic
 /.github/test-spec.yml                    @nrfconnect/ncs-test-leads
-/softdevice_controller/                   @rugeGerritsen
+/softdevice_controller/                   @nrfconnect/ncs-dragoon
 /nrf_modem/                               @rlubos @lemrey
 /crypto/                                  @frkv @tejlmand
 /gzll/                                    @leewkb4567
-/mpsl/                                    @rugeGerritsen
+/mpsl/                                    @nrfconnect/ncs-dragoon
 /nfc/                                     @anangl @grochu @KAGA164
 /nrf_802154/                              @ankuns @jciupis @ahasztag
 /nrf_security/                            @frkv @tejlmand


### PR DESCRIPTION
This makes it easier to add and remove code owners for these areas. These folders are well known by the entire team.