### PR TITLE
Revert "ci: Add a new Wi-Fi QA required label"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,3 @@
 "doc-required":
   - "doc/**/*"
   - "**/*.rst"
-
-"wifi-qa-required":
-  - "nrf_wifi/**/*"


### PR DESCRIPTION
This reverts commit 1d318c52025ae9fb61c720d6f6823670ac58e8a7.

The process on how to use the label is not streamlined yet, so, for now reverting this till it's sorted.