### PR TITLE
nrf_wifi: Softap support

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
@@ -247,6 +247,32 @@ struct nrf_wifi_fmac_callbk_fns {
 	/** Callback function to be called when rssi is to be processed from the received frame. */
 	void (*process_rssi_from_rx)(void *os_vif_ctx,
 				     signed short signal);
+#ifndef HOST_CFG80211_SUPPORT
+        void (*get_wiphy_callbk_fn)(void *os_vif_ctx,
+                            struct nrf_wifi_event_get_wiphy *get_wiphy_event,
+                            unsigned int event_len);
+
+        void (*get_reg_callbk_fn)(void *os_vif_ctx,
+                                  struct nrf_wifi_reg *get_reg_event,
+                                  unsigned int event_len);
+
+        void (*set_reg_callbk_fn)(void *os_vif_ctx,
+                                  struct nrf_wifi_reg *set_reg_event,
+                                  unsigned int event_len);
+
+        void (*wpa_supp_set_if_callbk_fn)(void *os_vif_ctx,
+                                 struct nrf_wifi_umac_event_set_interface *set_if_event,
+                                 unsigned int event_len);
+#ifdef notyet
+        void (*get_key_callbk_fn)(void *os_vif_ctx,
+                              struct nrf_wifi_umac_event_get_key *get_key_resp,
+                              unsigned int event_len);
+
+        void (*reg_change_callbk_fn)(void *os_vif_ctx,
+                        struct nrf_wifi_event_regulatory_change *reg_chng,
+                        unsigned int event_len);
+#endif
+#endif
 #endif /* CONFIG_NRF700X_STA_MODE */
 };
 

--- a/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -3477,4 +3477,31 @@ struct nrf_wifi_umac_event_cmd_status {
 	unsigned int cmd_status;
 } __NRF_WIFI_PKD;
 
+/**
+* struct nrf_wifi_umac_cmd_set_channel - Set channel configuration.
+* @umac_hdr: UMAC command header. Refer &struct nrf_wifi_umac_hdr.
+* @valid_fields: Indicate which of the following structure parameters are valid.
+* @freq_params: Information related to channel parameters
+*
+* This structure represents the command to set the wireless channel configuration.
+*/
+struct nrf_wifi_umac_cmd_set_channel {
+        struct nrf_wifi_umac_hdr umac_hdr;
+#define NRF_WIFI_CMD_SET_CHANNEL_FREQ_PARAMS_VALID (1 << 0)
+        unsigned int valid_fields;
+        struct freq_params freq_params;
+} __NRF_WIFI_PKD;
+struct nrf_wifi_event_send_beacon_hint {
+        struct nrf_wifi_umac_hdr umac_hdr;
+        struct nrf_wifi_event_channel channel_before;
+        struct nrf_wifi_event_channel channel_after;
+} __NRF_WIFI_PKD;
+#define NRF_WIFI_EVNT_WIPHY_SELF_MANAGED (1 << 0)
+struct nrf_wifi_event_regulatory_change {
+        struct nrf_wifi_umac_hdr umac_hdr;
+        unsigned short nrf_wifi_flags;
+        signed int intr;
+        signed char regulatory_type;
+        unsigned char nrf_wifi_alpha2[NRF_WIFI_COUNTRY_CODE_LEN];
+} __NRF_WIFI_PKD;
 #endif /* __HOST_RPU_UMAC_IF_H */

--- a/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/nrf_wifi/fw_if/umac_if/src/event.c
@@ -247,7 +247,6 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 
 		vif_ctx->ifflags = true;
 		break;
-#ifdef CONFIG_NRF700X_STA_MODE
 	case NRF_WIFI_UMAC_EVENT_TWT_SLEEP:
 		if (callbk_fns->twt_sleep_callbk_fn)
 			callbk_fns->twt_sleep_callbk_fn(vif_ctx->os_vif_ctx,
@@ -524,7 +523,6 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	case NRF_WIFI_UMAC_EVENT_REG_CHANGE:
 		/* TODO: Inform the user space about the regulatory change */
 		break;
-#endif /* CONFIG_NRF700X_STA_MODE */
 	default:
 		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
 				      "%s: No callback registered for event %d",


### PR DESCRIPTION
Event processing for supporting softap with cfg80211 as part of umac. Command and event added to interface file as required for softap mode.

[DNM: For sharing to QA]