### PR TITLE
crypto: Ensure correct CryptoCell libs for bootloaders

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -29,7 +29,7 @@ config NRF_CC310_BL
 	bool "nrf_cc310_bl HW crypto library for nRF devices with CryptoCell CC310."
 	select NRFXLIB_CRYPTO
 	select FPU # The cc310_bl lib uses floating point registers.
-	depends on !NORDIC_SECURITY_BACKEND
+	depends on IS_SECURE_BOOTLOADER || MCUBOOT
 	help
 	  This configuration is only available for direct use of nrf_cc3xx_bl
 	  To use, link with nrfxlib_crypto in CMake.
@@ -43,6 +43,7 @@ endif
 menuconfig NRF_CC3XX_PLATFORM
 	bool "nrf_cc3xx_platform HW crypto library for nRF devices with CryptoCell CC3xx."
 	depends on CRYPTOCELL_USABLE && !BUILD_WITH_TFM
+	depends on !IS_SECURE_BOOTLOADER
 	select NRFXLIB_CRYPTO if !BUILD_WITH_TFM
 	help
 	  This configuration is only available for direct use of nrf_cc3xx_platform


### PR DESCRIPTION
- Ensure that nrf_cc310_bl is only enabled in NSIB and MCUboot
- Disable nrf_cc3xx_platform for NSIB

ref: NCSDK-25144