### PR TITLE
nrf_wifi: Header file inclusion cleanup

### DIFF
--- a/nrf_wifi/utils/src/list.c
+++ b/nrf_wifi/utils/src/list.c
@@ -10,7 +10,7 @@
  */
 
 
-#include "list.h"
+#include <list.h>
 
 void *nrf_wifi_utils_list_alloc(struct nrf_wifi_osal_priv *opriv)
 {

--- a/nrf_wifi/utils/src/queue.c
+++ b/nrf_wifi/utils/src/queue.c
@@ -9,8 +9,8 @@
  * for the Wi-Fi driver.
  */
 
-#include "list.h"
-#include "queue.h"
+#include <list.h>
+#include <queue.h>
 
 void *nrf_wifi_utils_q_alloc(struct nrf_wifi_osal_priv *opriv)
 {


### PR DESCRIPTION
Header file inclusion cleanup.
Nonlocal header files in <> instead of "".