### PR TITLE
nrf_wifi: Softap event handling support for cfg80211 in rpu

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
@@ -118,7 +118,6 @@ struct nrf_wifi_fmac_callbk_fns {
 					  signed short signal);
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 
-#if defined(CONFIG_NRF700X_STA_MODE) || defined(__DOXYGEN__)
 	/** Callback function to be called when an interface association state changes. */
 	enum nrf_wifi_status (*if_carr_state_chg_callbk_fn)(void *os_vif_ctx,
 							    enum nrf_wifi_fmac_if_carr_state cs);
@@ -127,6 +126,22 @@ struct nrf_wifi_fmac_callbk_fns {
 	void (*rx_frm_callbk_fn)(void *os_vif_ctx,
 				 void *frm);
 
+	/** Callback function to be called when a get interface response is received. */
+	void (*get_interface_callbk_fn)(void *os_vif_ctx,
+				     struct nrf_wifi_interface_info *info,
+				     unsigned int event_len);
+
+	/** Callback function to be called when a get regulatory response is received. */
+	void (*event_get_reg)(void *if_priv,
+		struct nrf_wifi_reg *get_reg,
+		unsigned int event_len);
+
+	/** Callback function to be called when a get wiphy response is received. */
+	void (*event_get_wiphy)(void *if_priv,
+		struct nrf_wifi_event_get_wiphy *get_wiphy,
+		unsigned int event_len);
+
+#if defined(CONFIG_NRF700X_STA_MODE) || defined(__DOXYGEN__)
 	/** Callback function to be called when an authentication response is received. */
 	void (*auth_resp_callbk_fn)(void *os_vif_ctx,
 				    struct nrf_wifi_umac_event_mlme *auth_resp_event,
@@ -198,9 +213,6 @@ struct nrf_wifi_fmac_callbk_fns {
 				     unsigned int event_len);
 
 	/** Callback function to be called when a get interface response is received. */
-	void (*get_interface_callbk_fn)(void *os_vif_ctx,
-				     struct nrf_wifi_interface_info *info,
-				     unsigned int event_len);
 
 	/** Callback function to be called when a management TX status is received. */
 	void (*mgmt_tx_status)(void *if_priv,
@@ -217,20 +229,9 @@ struct nrf_wifi_fmac_callbk_fns {
 		struct nrf_wifi_umac_cmd_teardown_twt *twt_teardown_event_info,
 		unsigned int event_len);
 
-	/** Callback function to be called when a get wiphy response is received. */
-	void (*event_get_wiphy)(void *if_priv,
-		struct nrf_wifi_event_get_wiphy *get_wiphy,
-		unsigned int event_len);
-
 	/** Callback function to be called when a TWT sleep response is received. */
 	void (*twt_sleep_callbk_fn)(void *if_priv,
 		struct nrf_wifi_umac_event_twt_sleep *twt_sleep_event_info,
-		unsigned int event_len);
-
-	/** Callback function to be called when a get regulatory response is received. */
-	void (*event_get_reg)(void *if_priv,
-		struct nrf_wifi_reg *get_reg,
-		unsigned int event_len);
 
 	/** Callback function to be called when a get power save information
 	 * response is received.
@@ -247,6 +248,13 @@ struct nrf_wifi_fmac_callbk_fns {
 	/** Callback function to be called when rssi is to be processed from the received frame. */
 	void (*process_rssi_from_rx)(void *os_vif_ctx,
 				     signed short signal);
+#endif /* CONFIG_NRF700X_STA_MODE */
+#ifndef HOST_CFG80211_SUPPORT
+#if defined(CONFIG_NRF700X_AP_MODE) || defined(__DOXYGEN__)
+        void (*set_reg_callbk_fn)(void *os_vif_ctx,
+                                  struct nrf_wifi_reg *set_reg_event,
+                                  unsigned int event_len);
+#endif /* CONFIG_NRF700X_AP_MODE */
 #endif /* CONFIG_NRF700X_STA_MODE */
 };
 

--- a/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/nrf_wifi/fw_if/umac_if/src/event.c
@@ -251,6 +251,54 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 		}
 		vif_ctx->ifflags = true;
 		break;
+#ifndef HOST_CFG80211_SUPPORT
+#if defined(CONFIG_NRF700X_AP_MODE)
+	case NRF_WIFI_UMAC_EVENT_NEW_INTERFACE:
+		if (callbk_fns->get_interface_callbk_fn)
+			callbk_fns->get_interface_callbk_fn(vif_ctx->os_vif_ctx,
+						     event_data,
+						     event_len);
+		else
+			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+					      "%s: No callback registered for event %d",
+					      __func__,
+					      umac_hdr->cmd_evnt);
+		break;
+	case NRF_WIFI_UMAC_EVENT_NEW_WIPHY:
+		if (callbk_fns->event_get_wiphy)
+			callbk_fns->event_get_wiphy(vif_ctx->os_vif_ctx,
+						    event_data,
+						    event_len);
+		else
+			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+					      "%s: No callback registered for event %d",
+					      __func__,
+					      umac_hdr->cmd_evnt);
+		break;
+	case NRF_WIFI_UMAC_EVENT_FRAME:
+		if (callbk_fns->mgmt_rx_callbk_fn)
+			callbk_fns->mgmt_rx_callbk_fn(vif_ctx->os_vif_ctx,
+						      event_data,
+						      event_len);
+		else
+			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+					      "%s: No callback registered for event %d",
+					      __func__,
+					      umac_hdr->cmd_evnt);
+		break;
+	case NRF_WIFI_UMAC_EVENT_FRAME_TX_STATUS:
+		if (callbk_fns->mgmt_tx_status)
+			callbk_fns->mgmt_tx_status(vif_ctx->os_vif_ctx,
+							event_data,
+							event_len);
+		else
+			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+					      "%s: No callback registered for event %d",
+					      __func__,
+					      umac_hdr->cmd_evnt);
+		break;
+#endif
+#endif
 #ifdef CONFIG_NRF700X_STA_MODE
 	case NRF_WIFI_UMAC_EVENT_TWT_SLEEP:
 		if (callbk_fns->twt_sleep_callbk_fn)


### PR DESCRIPTION
Event need to be processed for softap mode in cfg80211 in rpu(cfg80211 is part of rpu).

This will override drft PR https://github.com/nrfconnect/sdk-nrfxlib/pull/1143/files