### PR TITLE
doc: add link to Bluetooth specification page

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -93,6 +93,8 @@
 
 .. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/specs/core-specification-5-4/
 
+.. _`Bluetooth Specifications and Documents`: https://www.bluetooth.com/specifications/specs/
+
 .. _`Appropriate Language Mapping Table`: https://www.bluetooth.com/language-mapping/Appropriate-Language-Mapping-Table
 
 .. _`nRF Connect for Desktop`: https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop


### PR DESCRIPTION
Add a link to the bluetooth specification and documents page. This will later be used in the isochronous channels documentation.