### PR TITLE
nrf_wifi: Add lockup recovery stats

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
@@ -358,6 +358,23 @@ enum nrf_wifi_status nrf_wifi_fmac_set_packet_filter(void *dev_ctx, unsigned cha
 						     unsigned short buffer_size);
 #endif /* CONFIG_NRF700X_RAW_DATA_RX || CONFIG_NRF700X_PROMISC_DATA_RX */
 
+
+/**
+ * @brief Issue a request to get stats from the RPU.
+ * @param fmac_dev_ctx Pointer to the UMAC IF context for a RPU WLAN device.
+ * @param op_mode RPU operation mode.
+ * @param stats Pointer to memory where the stats are to be copied.
+ *
+ * This function is used to send a command to
+ * instruct the firmware to return the current RPU Lockup recovery statistics. The RPU will
+ * send the event with the current statistics.
+ *
+ * @return Command execution status
+ */
+enum nrf_wifi_status nrf_wifi_fmac_dbg_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
+						      enum rpu_op_mode op_mode,
+						      struct rpu_op_stats *stats);
+
 /**
  * @}
  */

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
@@ -72,4 +72,10 @@ enum nrf_wifi_status umac_cmd_prog_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 					     int stat_type);
 
+enum nrf_wifi_status umac_cmd_prog_debug_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
+#ifdef CONFIG_NRF700X_RADIO_TEST
+						   int op_mode,
+#endif /* CONFIG_NRF700X_RADIO_TEST */
+						   int stat_type);
+
 #endif /* __FMAC_CMD_H__ */

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
@@ -39,6 +39,17 @@ struct rpu_host_stats {
 };
 
 /**
+ * @brief Structure to hold firmware debug statistics.
+ *
+ */
+struct rpu_fw_debug_stats{
+	/** RPU hardware lockup event detection count */
+	unsigned int rpu_hw_lockup_count;
+	/** RPU hardware lockup recovery completed count */
+	unsigned int rpu_hw_lockup_recovery_done;
+};
+
+/**
  * @brief - Structure to hold per device host and firmware statistics.
  *
  */
@@ -47,6 +58,8 @@ struct rpu_op_stats {
 	struct rpu_host_stats host;
 	/** Firmware statistics. */
 	struct rpu_fw_stats fw;
+	/** Firmware debug statistics */
+	struct rpu_fw_debug_stats fw_debug;
 };
 
 /**
@@ -176,6 +189,8 @@ struct nrf_wifi_fmac_dev_ctx {
 	struct nrf_wifi_event_regulatory_change *reg_change;
 	/** TX power ceiling parameters */
 	struct nrf_wifi_tx_pwr_ceil_params *tx_pwr_ceil_params;
+	/** Firmware debug statistics */
+	struct rpu_fw_debug_stats *fw_debug;
 	/** Data pointer to mode specific parameters */
 	char priv[];
 };

--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -539,3 +539,44 @@ enum nrf_wifi_status umac_cmd_prog_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 out:
 	return status;
 }
+
+enum nrf_wifi_status umac_cmd_prog_debug_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
+#ifdef CONFIG_NRF700X_RADIO_TEST
+                                                   int op_mode,
+#endif /* CONFIG_NRF700X_RADIO_TEST */
+                                                   int stats_type)
+{
+        enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+        struct host_rpu_msg *umac_cmd = NULL;
+        struct nrf_wifi_cmd_get_stats *umac_cmd_data = NULL;
+        int len = 0;
+
+        len = sizeof(*umac_cmd_data);
+
+        umac_cmd = umac_cmd_alloc(fmac_dev_ctx,
+                                  NRF_WIFI_HOST_RPU_MSG_TYPE_SYSTEM,
+                                  len);
+
+        if (!umac_cmd) {
+                nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+                                      "%s: umac_cmd_alloc failed",
+                                      __func__);
+                goto out;
+        }
+
+        umac_cmd_data = (struct nrf_wifi_cmd_get_stats *)(umac_cmd->msg);
+
+        umac_cmd_data->sys_head.cmd_event = NRF_WIFI_CMD_GET_DEBUG_STATS;
+        umac_cmd_data->sys_head.len = len;
+        umac_cmd_data->stats_type = stats_type;
+#ifdef CONFIG_NRF700X_RADIO_TEST
+        umac_cmd_data->op_mode = op_mode;
+#endif /* CONFIG_NRF700X_RADIO_TEST */
+
+        status = nrf_wifi_hal_ctrl_cmd_send(fmac_dev_ctx->hal_dev_ctx,
+                                            umac_cmd,
+                                            (sizeof(*umac_cmd) + len));
+
+out:
+        return status;
+}


### PR DESCRIPTION
Include all lockup recovery stats
under lmac which can be display in
host debug rpu stats.
[[SHEL-2078]](https://nordicsemi.atlassian.net/browse/SHEL-2078)

[SHEL-2078]: https://nordicsemi.atlassian.net/browse/SHEL-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ