### PR TITLE
nrf_wifi: Disbale DFS channels in scan

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
@@ -797,6 +797,7 @@ enum op_band {
 };
 
 #define TWT_EXTEND_SP_EDCA  0x1
+#define DISABLE_DFS_CHANNELS 0x2
 
 /**
  * @brief This structure defines the command responsible for initializing the UMAC.

--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -188,6 +188,10 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #ifdef CONFIG_NRF700X_RPU_EXTEND_TWT_SP
 	 umac_cmd_data->feature_flags |= TWT_EXTEND_SP_EDCA;
 #endif
+#ifdef CONFIG_NRF700X_SCAN_DISABLE_DFS_CHANNELS
+	umac_cmd_data->feature_flags |= DISABLE_DFS_CHANNELS;
+#endif /* CONFIG_NRF700X_SCAN_DISABLE_DFS_CHANNELS */
+
 	if (!beamforming) {
 		umac_cmd_data->disable_beamforming = 1;
 	}


### PR DESCRIPTION
[SHEL-1780] By default UMAC can scan all channles including DFS channels. Disable DFS channels in scan operation only if requested by user.

[SHEL-1780]: https://nordicsemi.atlassian.net/browse/SHEL-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ