### PR TITLE
nrf_wifi: Fix synchronization b/w down vs. RX

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -180,6 +180,13 @@ void nrf_wifi_fmac_rx_tasklet(void *data)
 	struct nrf_wifi_rx_buff *config = NULL;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
+	enum NRF_WIFI_HAL_STATUS hal_status;
+
+	nrf_wifi_hal_lock_rx(fmac_dev_ctx->hal_dev_ctx);
+	hal_status = nrf_wifi_hal_status_unlocked(fmac_dev_ctx->hal_dev_ctx);
+	if (hal_status != NRF_WIFI_HAL_STATUS_ENABLED) {
+		goto out;
+	}
 
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
@@ -206,6 +213,7 @@ void nrf_wifi_fmac_rx_tasklet(void *data)
 out:
 	nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
 			       config);
+	nrf_wifi_hal_unlock_rx(fmac_dev_ctx->hal_dev_ctx);
 }
 #endif /* CONFIG_NRF700X_RX_WQ_ENABLED */
 

--- a/nrf_wifi/hw_if/hal/inc/hal_api.h
+++ b/nrf_wifi/hw_if/hal/inc/hal_api.h
@@ -79,6 +79,12 @@ void nrf_wifi_hal_lock_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx);
 
 void nrf_wifi_hal_unlock_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx);
 
+void nrf_wifi_hal_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx);
+void nrf_wifi_hal_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx);
+enum NRF_WIFI_HAL_STATUS nrf_wifi_hal_status_unlocked(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx);
+
+
+
 /**
  * nrf_wifi_hal_ctrl_cmd_send() - Sends a control command to the RPU.
  * @hal_ctx: Pointer to HAL context.

--- a/nrf_wifi/hw_if/hal/inc/hal_structs.h
+++ b/nrf_wifi/hw_if/hal/inc/hal_structs.h
@@ -70,6 +70,11 @@ enum RPU_PS_STATE {
 };
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
+enum NRF_WIFI_HAL_STATUS {
+	NRF_WIFI_HAL_STATUS_ENABLED,
+	NRF_WIFI_HAL_STATUS_DISABLED,
+};
+
 
 struct nrf_wifi_hal_cfg_params {
 	unsigned int max_cmd_size;
@@ -232,6 +237,7 @@ struct nrf_wifi_hal_dev_ctx {
 	unsigned int event_data_len;
 	unsigned int event_data_pending;
 	unsigned int event_resubmit;
+	enum NRF_WIFI_HAL_STATUS hal_status;
 };
 
 


### PR DESCRIPTION
During interface down we de-initialize the FMAC FW (different from FMAC de-init, which is never called in Zephyr), we have a lock to synchronize the states with interrupt (RX or TX_DONE), but this doesn't avoid the interrupt handlers to be executed later causing crashes as the code doesn't have proper NULL checks.

Add a HAL status that can be used to silently ignore the interrupts if the HAL is disabled to fix crashes. This status is also protected by the same lock used to synchronize these two events.

Fixes SHEL-2359.