### PR TITLE
nrf_wifi: Remove unwanted debug message in checkin

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/tx.c
+++ b/nrf_wifi/fw_if/umac_if/src/tx.c
@@ -1438,9 +1438,6 @@ enum nrf_wifi_status nrf_wifi_fmac_rawtx_done_event_process(
 	nrf_wifi_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
 				    def_dev_ctx->tx_config.tx_lock);
 
-	nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			      "%s: tx done called",
-			      __func__);
 	status = tx_done_process(fmac_dev_ctx,
 				 config->desc_num);
 


### PR DESCRIPTION
Remove a debug log message which has come into checked in code unintentionally