### PR TITLE
nrf_wifi: Add regulatory channel attributes

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
@@ -105,6 +105,16 @@ struct nrf_wifi_fmac_otp_info {
 	unsigned int flags;
 };
 
+/* Maximum number of channels supported in a regulatory
+ * currently set to 42 as hardware supports 2.4GHz and 5GHz.
+ * In 2.4 GHz band maximum 14 channels and
+ * in 5 GHz band maximum 28 channels are supported.
+ * Maximum number of channels will change if more number
+ * of channels are enabled in different bands or
+ * different bands are supported in hardware.
+ */
+#define MAX_NUM_REG_CHANELS 42
+
 /**
  * @brief Structure to hold Regulatory parameter data.
  *
@@ -114,6 +124,10 @@ struct nrf_wifi_fmac_reg_info {
 	unsigned char alpha2[NRF_WIFI_COUNTRY_CODE_LEN];
 	 /** Forcefully set regulatory. */
 	bool force;
+	/** Regulatory channels count*/
+	unsigned int reg_chan_count;
+	/** Regulatory channel attributes */
+	struct nrf_wifi_get_reg_chn_info reg_chan_info[MAX_NUM_REG_CHANELS];
 };
 
 /**
@@ -154,6 +168,10 @@ struct nrf_wifi_fmac_dev_ctx {
 	bool alpha2_valid;
 	/** Alpha2 country code, last byte is reserved for null character. */
 	unsigned char alpha2[3];
+	/** Regulatory channels count*/
+	unsigned int reg_chan_count;
+	/** Regulatory channel attributes */
+	struct nrf_wifi_get_reg_chn_info *reg_chan_info;
 	/** Data pointer to mode specific parameters */
 	char priv[];
 };

--- a/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
@@ -815,6 +815,9 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	get_reg_cmd->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_GET_REG;
 	get_reg_cmd->umac_hdr.ids.valid_fields = 0;
 
+	fmac_dev_ctx->alpha2_valid = false;
+	fmac_dev_ctx->reg_chan_info = reg_info->reg_chan_info;
+
 	status = umac_cmd_cfg(fmac_dev_ctx,
 			      get_reg_cmd,
 			      sizeof(*get_reg_cmd));
@@ -824,8 +827,6 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 				      "%s: Failed to get regulatory information",	__func__);
 		goto err;
 	}
-
-	fmac_dev_ctx->alpha2_valid = false;
 
 	do {
 		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
@@ -843,6 +844,8 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 		   reg_info->alpha2,
 	       fmac_dev_ctx->alpha2,
 	       sizeof(reg_info->alpha2));
+
+	reg_info->reg_chan_count = fmac_dev_ctx->reg_chan_count;
 
 	return NRF_WIFI_STATUS_SUCCESS;
 err:


### PR DESCRIPTION
Regulatory channel attributes to be provided along with regulatory country code.