### PR TITLE
nrf_wifi: Replace RF parameter string with a structure definition.

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/default/fmac_api.h
+++ b/nrf_wifi/fw_if/umac_if/inc/default/fmac_api.h
@@ -909,7 +909,6 @@ void nrf_wifi_fmac_dev_rem(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
 /**
  * @brief Initializes a RPU instance.
  * @param fmac_dev_ctx Pointer to the context of the RPU instance to be removed.
- * @param rf_params_usr RF parameters (if any) to be passed to the RPU.
  * @param sleep_type Type of RPU sleep.
  * @param phy_calib PHY calibration flags to be passed to the RPU.
  * @param op_band Operating band of the RPU.
@@ -927,7 +926,6 @@ void nrf_wifi_fmac_dev_rem(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
  * @retval	NRF_WIFI_STATUS_FAIL On failure to execute command
  */
 enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
-					    unsigned char *rf_params_usr,
 #if defined(CONFIG_NRF_WIFI_LOW_POWER) || defined(__DOXYGEN__)
 					    int sleep_type,
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
@@ -253,7 +253,7 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
  */
 enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 					struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
-					unsigned char *rf_params,
+					struct nrf_wifi_phy_rf_params *rf_params,
 					struct nrf_wifi_tx_pwr_ceil_params *tx_pwr_ceil_params);
 
 /**
@@ -292,6 +292,22 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
  */
 enum nrf_wifi_status nrf_wifi_fmac_get_power_save_info(void *fmac_dev_ctx,
 						       unsigned char if_idx);
+
+/**
+ * @brief Initialize RF parameters.
+ * @param opriv Pointer to the OSAL context.
+ * @param prf Pointer to the RF parameter structure.
+ * @param package_info Package information, QFN, CSP etc.
+ * @param str String of RF params
+ *
+ * This function is used to initialize the RF parameter structure
+ * with the XO, power ceiling info, voltage and temperature based
+ * backoffs etc.
+ */
+int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
+				struct nrf_wifi_phy_rf_params *prf,
+				unsigned char package_info,
+				unsigned char *str);
 
 /**
  * @brief Set the current mode of operation

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
@@ -28,7 +28,7 @@ enum nrf_wifi_status umac_cmd_cfg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #ifndef CONFIG_NRF700X_RADIO_TEST
-				   unsigned char *rf_params,
+				   struct nrf_wifi_phy_rf_params *rf_params,
 				   bool rf_params_valid,
 				   struct nrf_wifi_data_config_params *config,
 #endif /* !CONFIG_NRF700X_RADIO_TEST */

--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -88,7 +88,7 @@ out:
 
 enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #ifndef CONFIG_NRF700X_RADIO_TEST
-				   unsigned char *rf_params,
+				   struct nrf_wifi_phy_rf_params *rf_params,
 				   bool rf_params_valid,
 				   struct nrf_wifi_data_config_params *config,
 #endif /* !CONFIG_NRF700X_RADIO_TEST */

--- a/nrf_wifi/hw_if/hal/inc/fw/phy_rf_params.h
+++ b/nrf_wifi/hw_if/hal/inc/fw/phy_rf_params.h
@@ -16,30 +16,12 @@
 #define NRF_WIFI_RF_PARAMS_CONF_SIZE 42
 
 #ifdef CONFIG_NRF700X_RADIO_TEST
-#define NRF_WIFI_DEF_RF_PARAMS "0000000000002A0000000003030303544040343430383430000000004307000000000000000000000000007077003F032424001000002800323500000C0008087D8105010071630300EED501001F6F00003B350100F52E0000E35E0000B7B6000066EFFEFFB5F60000896200007A840200E28FFCFF080808080408120100000000A1A10178000000080050003B020726181818181A120A140E0600"
+#define NRF_WIFI_DEF_RF_PARAMS "007077003F032424001000002800323500000C0008087D8105010071630300EED501001F6F00003B350100F52E0000E35E0000B7B6000066EFFEFFB5F60000896200007A840200E28FFCFF080808080408120100000000A1A10178000000080050003B020726181818181A120A140E0600"
 #define MAX_TX_PWR_SYS_TEST 30
 #define MAX_TX_PWR_RADIO_TEST 24
 #else
-#define NRF_WIFI_DEF_RF_PARAMS "0000000000002A0000000003030303544040343430383430000000004307FC00F8FCFCF800FC00000000007077003F032424001000002800323500000CF008087D8105010071630300EED501001F6F00003B350100F52E0000E35E0000B7B6000066EFFEFFB5F60000896200007A840200E28FFCFF080808080408120100000000A1A10178000000080050003B020726181818181A120A140E0600"
+#define NRF_WIFI_DEF_RF_PARAMS "007077003F032424001000002800323500000CF008087D8105010071630300EED501001F6F00003B350100F52E0000E35E0000B7B6000066EFFEFFB5F60000896200007A840200E28FFCFF080808080408120100000000A1A10178000000080050003B020726181818181A120A140E0600"
 #endif
-
-#define NRF_WIFI_RF_PARAMS_OFF_RESV_1 0
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_X0 6
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_PDADJM7 7
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_PDADJM0 11
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_PWR2G 15
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_PWR2GM0M7 16
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_PWR5GM7 18
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_PWR5GM0 21
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_RXGNOFF 24
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_MAX_TEMP 28
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_MIN_TEMP 29
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_TXP_BOFF_2GH 30
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_TXP_BOFF_2GL 31
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_TXP_BOFF_5GH 32
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_TXP_BOFF_5GL 33
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_TXP_BOFF_V 34
-#define NRF_WIFI_RF_PARAMS_OFF_CALIB_RESV_2 37
 
 
 #define NRF_WIFI_PHY_CALIB_FLAG_RXDC 1
@@ -47,7 +29,7 @@
 #define NRF_WIFI_PHY_CALIB_FLAG_TXPOW 0
 #define NRF_WIFI_PHY_CALIB_FLAG_TXIQ 8
 #define NRF_WIFI_PHY_CALIB_FLAG_RXIQ 16
-#define NRF_WIFI_PHY_CALIB_FLAG_DPD  32
+#define NRF_WIFI_PHY_CALIB_FLAG_DPD 32
 
 #define NRF_WIFI_PHY_SCAN_CALIB_FLAG_RXDC (1<<16)
 #define NRF_WIFI_PHY_SCAN_CALIB_FLAG_TXDC (2<<16)
@@ -85,10 +67,272 @@
 /* Battery voltage changes base calibrations and voltage thresholds */
 #define NRF_WIFI_DEF_PHY_VBAT_CALIB (NRF_WIFI_PHY_CALIB_FLAG_DPD)
 #define NRF_WIFI_VBAT_VERYLOW (8) /* Corresponds to (2.5+8*0.07)=3.06V */
-#define NRF_WIFI_VBAT_LOW  (12)  /* Correspond to (2.5+12*0.07)=3.34V */
+#define NRF_WIFI_VBAT_LOW (12)  /* Correspond to (2.5+12*0.07)=3.34V */
 #define NRF_WIFI_VBAT_HIGH (14) /* Correspond to (2.5+14*0.07)=3.48V */
 
+/* Package independent params */
 
+/** Power detector adjustment value. */
+#define PD_ADJUST_VAL 0
+
+/** RX gain adjustment value for both 2.4GHz and 5 GHz bands */
+#define RX_GAIN_OFFSET_LB_CHAN 0
+#define RX_GAIN_OFFSET_HB_LOW_CHAN 0
+#define RX_GAIN_OFFSET_HB_MID_CHAN 0
+#define RX_GAIN_OFFSET_HB_HIGH_CHAN 0
+
+/** Systematic error between set power and measured power in dBm */
+#define SYSTEM_OFFSET_LB 3
+#define SYSTEM_OFFSET_HB_CHAN_LOW 3
+#define SYSTEM_OFFSET_HB_CHAN_MID 3
+#define SYSTEM_OFFSET_HB_CHAN_HIGH 3
+
+/** End of package independent params */
+
+
+/** QFN Package dependent params */
+
+/** XO adjustment value */
+#define QFN_XO_VAL 0x2A
+
+/** Max TX power allowed for DSSS and OFDM in 2.4GHz band */
+#define QFN_MAX_TX_PWR_DSSS 0x54
+#define QFN_MAX_TX_PWR_LB_MCS7 0x40
+#define QFN_MAX_TX_PWR_LB_MCS0 0x40
+
+/** Max TX power allowed for MCS7 for channels in the range,
+ * 36 to 64, 96 to 132 and 136 to 177
+ */
+#define QFN_MAX_TX_PWR_HB_LOW_CHAN_MCS7 0x34
+#define QFN_MAX_TX_PWR_HB_MID_CHAN_MCS7 0x34
+#define QFN_MAX_TX_PWR_HB_HIGH_CHAN_MCS7 0x30
+
+/** Max TX power allowed for MCS0 for channels in the range,
+ * 36 to 64, 96 to 132 and 136 to 177
+ */
+#define QFN_MAX_TX_PWR_HB_LOW_CHAN_MCS0 0x38
+#define QFN_MAX_TX_PWR_HB_MID_CHAN_MCS0 0x34
+#define QFN_MAX_TX_PWR_HB_HIGH_CHAN_MCS0 0x30
+
+/** Max chip temperature at which the TX power backoff to be applied. */
+#define QFN_MAX_CHIP_TEMP 0x43
+
+/** Min chip temperature at which the TX power backoff to be applied. */
+#define QFN_MIN_CHIP_TEMP 0x07
+
+/** TX power backoff values to be applied in 2.4GHz and 5GHz band when
+ * chip temperature crosses MAX_CHIP_TEMP. The resolution is in 0.25dB.
+ * To get 1 dB backoff configure -4(0xFC)
+ */
+#define QFN_LB_MAX_PWR_BKF_HI_TEMP 0xFC
+#define QFN_LB_MAX_PWR_BKF_LOW_TEMP 0x00
+#define QFN_HB_MAX_PWR_BKF_HI_TEMP 0xF8
+#define QFN_HB_MAX_PWR_BKF_LOW_TEMP 0xFC
+
+/** TX power backoff values to be applied in 2.4GHz and 5GHz band when
+ * the voltage is less than NRF_WIFI_VBAT_VERYLOW
+ */
+#define QFN_LB_VBT_LT_VLOW 0xFC
+#define QFN_HB_VBT_LT_VLOW 0xF8
+
+/** TX power backoff values to be applied in 2.4GHz and 5GHz band when
+ * the voltage is less than NRF_WIFI_VBAT_LOW
+ */
+#define QFN_LB_VBT_LT_LOW 0x00
+#define QFN_HB_VBT_LT_LOW 0xFC
+
+
+/** CSP Package dependent params */
+
+/** XO adjustment value */
+#define CSP_XO_VAL 0x2A
+
+/** Max TX power allowed for DSSS and OFDM in 2.4GHz band */
+#define CSP_MAX_TX_PWR_DSSS 0x54
+#define CSP_MAX_TX_PWR_LB_MCS7 0x40
+#define CSP_MAX_TX_PWR_LB_MCS0 0x40
+
+/** Max TX power allowed for MCS7 for channels in the range,
+ * 36 to 64, 96 to 132 and 136 to 177
+ */
+#define CSP_MAX_TX_PWR_HB_LOW_CHAN_MCS7 0x34
+#define CSP_MAX_TX_PWR_HB_MID_CHAN_MCS7 0x34
+#define CSP_MAX_TX_PWR_HB_HIGH_CHAN_MCS7 0x30
+
+/** Max TX power allowed for MCS0 for channels in the range,
+ * 36 to 64, 96 to 132 and 136 to 177
+ */
+#define CSP_MAX_TX_PWR_HB_LOW_CHAN_MCS0 0x38
+#define CSP_MAX_TX_PWR_HB_MID_CHAN_MCS0 0x34
+#define CSP_MAX_TX_PWR_HB_HIGH_CHAN_MCS0 0x30
+
+/** Max chip temperature at which the TX power backoff to be applied. */
+#define CSP_MAX_CHIP_TEMP 0x43
+
+/** Min chip temperature at which the TX power backoff to be applied. */
+#define CSP_MIN_CHIP_TEMP 0x07
+
+/** TX power backoff values to be applied in 2.4GHz and 5GHz band when
+ * chip temperature crosses MAX_CHIP_TEMP. The resolution is in 0.25dB.
+ * To get 1 dB backoff configure -4(0xFC)
+ */
+#define CSP_LB_MAX_PWR_BKF_HI_TEMP 0xFC
+#define CSP_LB_MAX_PWR_BKF_LOW_TEMP 0x00
+#define CSP_HB_MAX_PWR_BKF_HI_TEMP 0xF8
+#define CSP_HB_MAX_PWR_BKF_LOW_TEMP 0xFC
+
+/** TX power backoff values to be applied in 2.4GHz and 5GHz band when
+ * the voltage is less than NRF_WIFI_VBAT_VERYLOW
+ */
+#define CSP_LB_VBT_LT_VLOW 0xFC
+#define CSP_HB_VBT_LT_VLOW 0xF8
+
+/** TX power backoff values to be applied in 2.4GHz and 5GHz band when
+ * the voltage is less than NRF_WIFI_VBAT_LOW
+ */
+#define CSP_LB_VBT_LT_LOW 0x00
+#define CSP_HB_VBT_LT_LOW 0xFC
+
+
+/** XO adjustment value */
+struct nrf_wifi_xo_freq_offset {
+	unsigned char xo_freq_offset;
+} __NRF_WIFI_PKD;
+
+/** Power detector adjustment factor for MCS7 */
+struct nrf_wifi_pd_adst_val {
+	/** PD adjustment value corresponding to Channel 7 */
+	signed char pd_adjt_lb_chan;
+	/** PD adjustment value corresponding to Channel 36 */
+	signed char pd_adjt_hb_low_chan;
+	/** PD adjustment value corresponding to Channel 100 */
+	signed char pd_adjt_hb_mid_chan;
+	/** PD adjustment value corresponding to Channel 165 */
+	signed char pd_adjt_hb_high_chan;
+} __NRF_WIFI_PKD;
+
+/** TX power systematic offset is the difference between set power
+ *  and the measured power
+ */
+struct nrf_wifi_tx_pwr_systm_offset {
+	/** Systematic adjustment value corresponding to Channel 7 */
+	signed char syst_off_lb_chan;
+	/** Systematic adjustment value corresponding to Channel 36 */
+	signed char syst_off_hb_low_chan;
+	/** Systematic adjustment value corresponding to Channel 100 */
+	signed char syst_off_hb_mid_chan;
+	/** Systematic adjustment value corresponding to Channel 165 */
+	signed char syst_off_hb_high_chan;
+} __NRF_WIFI_PKD;
+
+/** Max TX power value for which both EVM and SEM pass */
+struct nrf_wifi_tx_pwr_ceil {
+	/** Max output power for 11b for channel 7 */
+	signed char max_dsss_pwr;
+	/** Max output power for MCS7 for channel 7 */
+	signed char max_lb_mcs7_pwr;
+	/** Max output power for MCS0 for channel 7 */
+	signed char max_lb_mcs0_pwr;
+	/** Max output power for MCS7 for channel 36 */
+	signed char max_hb_low_chan_mcs7_pwr;
+	/** Max output power for MCS7 for channel 100 */
+	signed char max_hb_mid_chan_mcs7_pwr;
+	/** Max output power for MCS7 for channel 165 */
+	signed char max_hb_high_chan_mcs7_pwr;
+	/** Max output power for MCS0 for channel 36 */
+	signed char max_hb_low_chan_mcs0_pwr;
+	/** Max output power for MCS0 for channel 100 */
+	signed char max_hb_mid_chan_mcs0_pwr;
+	/** Max output power for MCS0 for channel 165 */
+	signed char max_hb_high_chan_mcs0_pwr;
+} __NRF_WIFI_PKD;
+
+/** RX gain adjustment offsets */
+struct nrf_wifi_rx_gain_offset {
+	/** Channel 7 */
+	signed char rx_gain_lb_chan;
+	/** Channel 36 */
+	signed char rx_gain_hb_low_chan;
+	/** Channel 100 */
+	signed char rx_gain_hb_mid_chan;
+	/** Channel 165 */
+	signed char rx_gain_hb_high_chan;
+} __NRF_WIFI_PKD;
+
+/** Voltage and temperature dependent backoffs */
+struct nrf_wifi_temp_volt_depend_params {
+	/** Maximum chip temperature in centigrade */
+	signed char max_chip_temp;
+	/** Minimum chip temperature in centigrade */
+	signed char min_chip_temp;
+	/** TX power backoff at high temperature in 2.4GHz */
+	signed char lb_max_pwr_bkf_hi_temp;
+	/** TX power backoff at low temperature in 2.4GHz */
+	signed char lb_max_pwr_bkf_low_temp;
+	/** TX power backoff at high temperature in 5GHz */
+	signed char hb_max_pwr_bkf_hi_temp;
+	/** TX power backoff at low temperature in 5GHz */
+	signed char hb_max_pwr_bkf_low_temp;
+	/** Voltage back off value in LowBand when VBAT< VBAT_VERYLOW */
+	signed char lb_vbt_lt_vlow;
+	/** Voltage back off value in HighBand when VBAT< VBAT_VERYLOW */
+	signed char hb_vbt_lt_vlow;
+	/** Voltage back off value in LowBand when VBAT< VBAT_LOW */
+	signed char lb_vbt_lt_low;
+	/** Voltage back off value in HighBand when VBAT< VBAT_LOW */
+	signed char hb_vbt_lt_low;
+	/** Reserved bytes */
+	signed char reserved[4];
+} __NRF_WIFI_PKD;
+
+/** The top-level structure holds substructures,
+ * each containing information related to the
+ * first 42 bytes of RF parameters.
+ */
+struct nrf_wifi_phy_rf_params {
+	unsigned char reserved[6];
+	struct nrf_wifi_xo_freq_offset xo_offset;
+	struct nrf_wifi_pd_adst_val pd_adjust_val;
+	struct nrf_wifi_tx_pwr_systm_offset syst_tx_pwr_offset;
+	struct nrf_wifi_tx_pwr_ceil max_pwr_ceil;
+	struct nrf_wifi_rx_gain_offset rx_gain_offset;
+	struct nrf_wifi_temp_volt_depend_params temp_volt_backoff;
+	unsigned char phy_params[NRF_WIFI_RF_PARAMS_SIZE - NRF_WIFI_RF_PARAMS_CONF_SIZE];
+} __NRF_WIFI_PKD;
+
+/** The byte offsets of RF parameters indicate the start offset
+ * of various RF parameters, such as XO, power detector adjust
+ * parameters, power ceiling parameters, RX gain adjustment parameters,
+ * and temperature and voltage-based power backoff values.
+ */
+enum RF_PARAMS_OFFSETS {
+	NRF_WIFI_XO_FREQ_BYTE_OFFSET = 6,
+	NRF_WIFI_PD_ADST_VAL_BYTE_OFFSET = 7,
+	NRF_WIFI_TX_PWR_SYSTM_BYTE_OFFSET = 11,
+	NRF_WIFI_TX_PWR_CEIL_BYTE_OFFSET = 15,
+	NRF_WIFI_RX_GAIN_BYTE_OFFSET = 24,
+	NRF_WIFI_VT_DEPEND_PARAMS_BYTE_OFFSET = 28
+};
+
+/** RF Params from byte starting with offset
+ * NRF_WIFI_TX_PWR_CEIL_BYTE_OFFSET contains the
+ * TX power celings based on DSSS, OFDM , Frequency
+ * band and MCS.
+ * In 5GHz band we have three subbands based on
+ * channel frequency, we have divided them in to
+ * LOW BAND, MID BAND and HIGH BAND
+ */
+enum MAX_POWER_OFFSETS {
+	NRF_WIFI_MAX_OP_PWR_DSSS_OFST,
+	NRF_WIFI_MAX_OP_PWR_2PT4GHZ_OFDM_MCS7,
+	NRF_WIFI_MAX_OP_PWR_2PT4GHZ_OFDM_MCS0,
+	NRF_WIFI_MAX_OP_PWR_5GHZ_LB_MCS7,
+	NRF_WIFI_MAX_OP_PWR_5GHZ_MID_MCS7,
+	NRF_WIFI_MAX_OP_PWR_5GHZ_HI_MCS7,
+	NRF_WIFI_MAX_OP_PWR_5GHZ_LB_MCS0,
+	NRF_WIFI_MAX_OP_PWR_5GHZ_MID_MCS0,
+	NRF_WIFI_MAX_OP_PWR_5GHZ_HI_MCS0
+};
 
 #ifdef CONFIG_NRF700X_RADIO_TEST
 enum nrf_wifi_rf_test {
@@ -118,8 +362,6 @@ enum nrf_wifi_rf_test_event {
 	NRF_WIFI_RF_TEST_EVENT_MAX,
 };
 
-
-
 /* Holds the RX capture related info */
 struct nrf_wifi_rf_test_capture_params {
 	unsigned char test;
@@ -142,12 +384,11 @@ struct nrf_wifi_rf_test_capture_params {
 	unsigned char bb_gain;
 } __NRF_WIFI_PKD;
 
-
 /* Struct to hold the events from RF test SW. */
 struct nrf_wifi_rf_test_capture_meas {
 	unsigned char test;
 
-	/*  Mean of I samples. Format: Q.11 */
+	/* Mean of I samples. Format: Q.11 */
 	signed short mean_I;
 
 	/* Mean of Q samples. Format: Q.11 */
@@ -160,12 +401,11 @@ struct nrf_wifi_rf_test_capture_meas {
 	unsigned int rms_Q;
 } __NRF_WIFI_PKD;
 
-
 /* Holds the transmit related info */
 struct nrf_wifi_rf_test_tx_params {
 	unsigned char test;
 
-	/* Desired tone frequency in MHz in steps of 1 MHz from -10 MHz to +10 MHz.*/
+	/* Desired tone frequency in MHz in steps of 1 MHz from -10 MHz to +10 MHz. */
 	signed char tone_freq;
 
 	/* Desired TX power in the range -16 dBm to +24 dBm.
@@ -173,7 +413,7 @@ struct nrf_wifi_rf_test_tx_params {
 	 */
 	signed char tx_pow;
 
-	/* Set 1 for staring tone transmission.*/
+	/* Set 1 for staring tone transmission. */
 	unsigned char enabled;
 } __NRF_WIFI_PKD;
 
@@ -186,16 +426,15 @@ struct nrf_wifi_rf_test_dpd_params {
 struct nrf_wifi_temperature_params {
 	unsigned char test;
 
-	/** current measured temperature */
+	/** Current measured temperature */
 	signed int temperature;
 
 	/** Temperature measurment status.
-	 *0: Reading successful
-	 *1: Reading failed
+	 * 0: Reading successful
+	 * 1: Reading failed
 	 */
 	unsigned int readTemperatureStatus;
 } __NRF_WIFI_PKD;
-
 
 struct nrf_wifi_rf_get_rf_rssi {
 	unsigned char test;
@@ -204,7 +443,6 @@ struct nrf_wifi_rf_get_rf_rssi {
 	unsigned char agc_status_val;
 } __NRF_WIFI_PKD;
 
-
 struct nrf_wifi_rf_test_xo_calib {
 	unsigned char test;
 
@@ -212,7 +450,6 @@ struct nrf_wifi_rf_test_xo_calib {
 	unsigned char xo_val;
 
 } __NRF_WIFI_PKD;
-
 
 struct nrf_wifi_rf_get_xo_value {
 	unsigned char test;
@@ -226,7 +463,6 @@ struct nrf_wifi_rf_get_xo_value {
 /**
  * @brief This structure defines the parameters used to control the max transmit (TX) power
  * in both frequency bands for different data rates.
- *
  */
 
 struct nrf_wifi_tx_pwr_ceil_params {

--- a/nrf_wifi/utils/src/util.c
+++ b/nrf_wifi/utils/src/util.c
@@ -12,7 +12,6 @@
 #include <util.h>
 #include "host_rpu_data_if.h"
 
-
 int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
 				  unsigned char *hex_arr,
 				  unsigned int hex_arr_sz,


### PR DESCRIPTION
[SHEL-1493]: Replace the string with a structure definition for better readability.

[SHEL-1493]: https://nordicsemi.atlassian.net/browse/SHEL-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ