### PR TITLE
nrf_wifi: Osal hdr clean up

### DIFF
--- a/nrf_wifi/bus_if/bal/inc/bal_ops.h
+++ b/nrf_wifi/bus_if/bal/inc/bal_ops.h
@@ -12,8 +12,6 @@
 #ifndef __BAL_OPS_H__
 #define __BAL_OPS_H__
 
-#include <stdbool.h>
-
 /**
  * struct nrf_wifi_bal_ops - Ops to be provided by a particular bus
  *                           implementation.

--- a/nrf_wifi/fw_if/umac_if/inc/default/fmac_api.h
+++ b/nrf_wifi/fw_if/umac_if/inc/default/fmac_api.h
@@ -16,8 +16,6 @@
 #ifndef __FMAC_API_H__
 #define __FMAC_API_H__
 
-#include <stdbool.h>
-
 #include "osal_api.h"
 #include "host_rpu_umac_if.h"
 #include "host_rpu_data_if.h"

--- a/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
@@ -16,8 +16,6 @@
 #ifndef __FMAC_STRUCTS_H__
 #define __FMAC_STRUCTS_H__
 
-#include <stdbool.h>
-
 #include "osal_api.h"
 #include "host_rpu_umac_if.h"
 #include "fmac_structs_common.h"

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
@@ -15,8 +15,6 @@
 #ifndef __FMAC_API_COMMON_H__
 #define __FMAC_API_COMMON_H__
 
-#include <stdbool.h>
-
 #include "osal_api.h"
 #include "hal_api.h"
 #include "host_rpu_umac_if.h"

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
@@ -16,8 +16,6 @@
 #ifndef __FMAC_STRUCTS_COMMON_H__
 #define __FMAC_STRUCTS_COMMON_H__
 
-#include <stdbool.h>
-
 #include "osal_api.h"
 #include "host_rpu_umac_if.h"
 

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_util.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_util.h
@@ -12,7 +12,6 @@
 #define __FMAC_UTIL_H__
 
 #ifndef CONFIG_NRF700X_RADIO_TEST
-#include <stdbool.h>
 #include "fmac_structs.h"
 #include "pack_def.h"
 

--- a/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -16,8 +16,6 @@
 #ifndef __FMAC_API_H__
 #define __FMAC_API_H__
 
-#include <stdbool.h>
-
 #include "osal_api.h"
 #include "host_rpu_umac_if.h"
 #include "host_rpu_data_if.h"

--- a/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_structs.h
+++ b/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_structs.h
@@ -18,8 +18,6 @@
 #ifndef __FMAC_STRUCTS_H__
 #define __FMAC_STRUCTS_H__
 
-#include <stdbool.h>
-
 #include "osal_api.h"
 #include "host_rpu_umac_if.h"
 #if !defined(__DOXYGEN__)

--- a/nrf_wifi/hw_if/hal/inc/hal_api.h
+++ b/nrf_wifi/hw_if/hal/inc/hal_api.h
@@ -13,7 +13,6 @@
 #ifndef __HAL_API_H__
 #define __HAL_API_H__
 
-#include <stdbool.h>
 #include "osal_api.h"
 #include "rpu_if.h"
 #include "bal_api.h"

--- a/nrf_wifi/hw_if/hal/inc/hal_structs.h
+++ b/nrf_wifi/hw_if/hal/inc/hal_structs.h
@@ -12,7 +12,6 @@
 #ifndef __HAL_STRUCTS_H__
 #define __HAL_STRUCTS_H__
 
-#include <stdbool.h>
 #include "lmac_if_common.h"
 #include "host_rpu_common_if.h"
 #include "osal_api.h"

--- a/nrf_wifi/os_if/inc/osal_api.h
+++ b/nrf_wifi/os_if/inc/osal_api.h
@@ -12,7 +12,6 @@
 #ifndef __OSAL_API_H__
 #define __OSAL_API_H__
 
-#include <stdarg.h>
 #include "osal_structs.h"
 
 /* Have to match zephyr/include/zephyr/logging/log_core.h */

--- a/nrf_wifi/os_if/inc/osal_ops.h
+++ b/nrf_wifi/os_if/inc/osal_ops.h
@@ -12,7 +12,6 @@
 #ifndef __OSAL_OPS_H__
 #define __OSAL_OPS_H__
 
-#include <stdarg.h>
 #include "osal_structs.h"
 
 

--- a/nrf_wifi/os_if/inc/osal_structs.h
+++ b/nrf_wifi/os_if/inc/osal_structs.h
@@ -12,7 +12,16 @@
 #ifndef __OSAL_STRUCTS_H__
 #define __OSAL_STRUCTS_H__
 
+#ifdef __ZEPHYR__
 #include <stddef.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#elif __KERNEL__
+/* For Linux, use kernel internal headers instead of C headers*/
+#include <linux/stddef.h>
+#include <linux/string.h>
+#include <linux/stdarg.h>
+#endif
 
 /**
  * enum nrf_wifi_status - The status of an operation performed by the

--- a/nrf_wifi/utils/inc/list.h
+++ b/nrf_wifi/utils/inc/list.h
@@ -12,7 +12,6 @@
 #ifndef __LIST_H__
 #define __LIST_H__
 
-#include <stddef.h>
 #include "osal_api.h"
 
 void *nrf_wifi_utils_list_alloc(struct nrf_wifi_osal_priv *opriv);

--- a/nrf_wifi/utils/inc/queue.h
+++ b/nrf_wifi/utils/inc/queue.h
@@ -12,7 +12,6 @@
 #ifndef __QUEUE_H__
 #define __QUEUE_H__
 
-#include <stddef.h>
 #include "osal_ops.h"
 
 void *nrf_wifi_utils_q_alloc(struct nrf_wifi_osal_priv *opriv);

--- a/nrf_wifi/utils/inc/util.h
+++ b/nrf_wifi/utils/inc/util.h
@@ -12,8 +12,6 @@
 #ifndef __UTIL_H__
 #define __UTIL_H__
 
-#include <stddef.h>
-#include <stdbool.h>
 #include "osal_api.h"
 #include "host_rpu_umac_if.h"
 


### PR DESCRIPTION
[CAL-3923] Make OS agnostic self-contained way
(i.e., without relying on C headers)
Purpose to fully use the Zephyr/Linux internal headers to take advantage off architecture specific
accelerators (esp. Linux).

[CAL-3923]: https://nordicsemi.atlassian.net/browse/CAL-3923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ