### PR TITLE
nrf_wifi: Support for CSP package in Host driver

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
@@ -306,7 +306,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_power_save_info(void *fmac_dev_ctx,
  */
 int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 				struct nrf_wifi_phy_rf_params *prf,
-				unsigned char package_info,
+				unsigned int package_info,
 				unsigned char *str);
 
 /**

--- a/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
@@ -621,7 +621,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 	unsigned int ft_prog_ver;
 	int ret = -1;
 	/* If package_info is not written to OTP then the default value will be 0xFF. */
-	unsigned char package_info = 0xFF;
+	unsigned int package_info = 0xFFFFFFFF;
 #if defined(CONFIG_BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP) || \
 	defined(CONFIG_BOARD_NRF7002DK_NRF5340_CPUAPP) || \
 	defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP)
@@ -661,6 +661,15 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 		goto out;
 	}
 
+	status = nrf_wifi_hal_otp_pack_info_get(fmac_dev_ctx->hal_dev_ctx,
+						&package_info);
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+				      "%s: Fetching of Package info failed",
+				      __func__);
+		goto out;
+	}
+	
 	ret = nrf_wifi_phy_rf_params_init(fmac_dev_ctx->fpriv->opriv,
 				    	  phy_rf_params,
 				    	  package_info,
@@ -849,7 +858,7 @@ err:
 
 int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 				struct nrf_wifi_phy_rf_params *prf,
-				unsigned char package_info,
+				unsigned int package_info,
 				unsigned char *str)
 {
 	int ret = -1;

--- a/nrf_wifi/hw_if/hal/inc/hal_api.h
+++ b/nrf_wifi/hw_if/hal/inc/hal_api.h
@@ -199,3 +199,6 @@ enum nrf_wifi_status nrf_wifi_hal_otp_info_get(struct nrf_wifi_hal_dev_ctx *hal_
 
 enum nrf_wifi_status nrf_wifi_hal_otp_ft_prog_ver_get(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 						      unsigned int *ft_prog_ver);
+
+enum nrf_wifi_status nrf_wifi_hal_otp_pack_info_get(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
+						    unsigned int *package_info);

--- a/nrf_wifi/hw_if/hal/src/hal_api.c
+++ b/nrf_wifi/hw_if/hal/src/hal_api.c
@@ -1807,6 +1807,33 @@ out:
 	return status;
 }
 
+enum nrf_wifi_status nrf_wifi_hal_otp_pack_info_get(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
+						    unsigned int *package_info)
+{
+	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
+
+	if (!hal_dev_ctx || !package_info) {
+		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
+				      "%s: Invalid parameters",
+				      __func__);
+		goto out;
+	}
+
+	status = hal_rpu_mem_read(hal_dev_ctx,
+				  package_info,
+				  RPU_MEM_OTP_PACKAGE_TYPE,
+				  sizeof(*package_info));
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
+				      "%s: Package info get failed",
+				      __func__);
+		goto out;
+	}
+out:
+	return status;
+}
+
 void nrf_wifi_hal_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
 	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,


### PR DESCRIPTION
[SHEL-2310]: Modify host driver to read package type from OTP. Use this package type information to pick RF parameters.

[SHEL-2310]: https://nordicsemi.atlassian.net/browse/SHEL-2310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ