### PR TITLE
nrf_wifi: Rename occurrences of bt*/ble* to sr*/SR*

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
@@ -192,17 +192,17 @@ enum nrf_wifi_status nrf_wifi_fmac_get_host_rpu_ps_ctrl_state(void *fmac_dev_ctx
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 #endif /* CONFIG_NRF700X_UTIL */
 /**
- * @brief Configure Bluetooth coexistence parameters in RPU.
+ * @brief Configure SR coexistence parameters in RPU.
  * @param fmac_dev_ctx Pointer to the UMAC IF context for a RPU WLAN device.
- * @param cmd Bluetooth coexistence parameters which will be configured in RPU.
+ * @param cmd SR coexistence parameters which will be configured in RPU.
  * @param cmd_len Command length.
  *
  * This function is used to send a command to RPU to configure
- *	    Bluetooth coexistence parameters in RPU.
+ *	    SR coexistence parameters in RPU.
  *
  * @return Command execution status
  */
-enum nrf_wifi_status nrf_wifi_fmac_conf_btcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
+enum nrf_wifi_status nrf_wifi_fmac_conf_srcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					       void *cmd, unsigned int cmd_len);
 
 

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
@@ -42,7 +42,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 enum nrf_wifi_status umac_cmd_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx);
 
-enum nrf_wifi_status umac_cmd_btcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
+enum nrf_wifi_status umac_cmd_srcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	void *cmd, unsigned int cmd_len);
 
 enum nrf_wifi_status umac_cmd_he_ltf_gi(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,

--- a/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
@@ -139,8 +139,8 @@ enum nrf_wifi_sys_commands {
 	NRF_WIFI_CMD_PWR,
 	/** RPU De-initialization */
 	NRF_WIFI_CMD_DEINIT,
-	/** Command for WIFI & Bluetooth coexistence */
-	NRF_WIFI_CMD_BTCOEX,
+	/** Command for WIFI & SR coexistence */
+	NRF_WIFI_CMD_SRCOEX,
 	/** Command to start RF test */
 	NRF_WIFI_CMD_RF_TEST,
 	/** Configure HE_GI & HE_LTF */
@@ -180,7 +180,7 @@ enum nrf_wifi_sys_events {
 	NRF_WIFI_EVENT_DEINIT_DONE,
 	/** Response to NRF_WIFI_CMD_RF_TEST */
 	NRF_WIFI_EVENT_RF_TEST,
-	/** Response to NRF_WIFI_CMD_BTCOEX. */
+	/** Response to NRF_WIFI_CMD_SRCOEX. */
 	NRF_WIFI_EVENT_COEX_CONFIG,
 	/** Response to NRF_WIFI_CMD_UMAC_INT_STATS */
 	NRF_WIFI_EVENT_INT_UMAC_STATS,
@@ -978,8 +978,8 @@ struct rpu_conf_params {
 	unsigned int tx_pkt_gap_us;
 	/** Configure WLAN antenna switch(0-separate/1-shared) */
 	unsigned char wlan_ant_switch_ctrl;
-	/** Switch to control the BLE antenna or shared WiFi antenna */
-	unsigned char ble_ant_switch_ctrl;
+	/** Switch to control the SR antenna or shared WiFi antenna */
+	unsigned char sr_ant_switch_ctrl;
 	/** Resource unit (RU) size (26,52,106 or 242) */
 	unsigned char ru_tone;
 	/** Location of resource unit (RU) in 20 MHz spectrum */
@@ -1302,10 +1302,10 @@ struct coex_wlan_switch_ctrl {
 
 /**
  * @brief The structure represents the command used to configure the Wi-Fi side shared switch
- *  for Bluetooth coexistence (btcoex).
+ *  for SR coexistence.
  *
  */
-struct nrf_wifi_cmd_btcoex {
+struct nrf_wifi_cmd_srcoex {
 	/** UMAC header, @ref nrf_wifi_sys_head */
 	struct nrf_wifi_sys_head sys_head;
 	/** Switch configuration data */

--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -233,7 +233,7 @@ out:
 }
 
 
-enum nrf_wifi_status umac_cmd_btcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
+enum nrf_wifi_status umac_cmd_srcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				void *cmd, unsigned int cmd_len)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
@@ -256,7 +256,7 @@ enum nrf_wifi_status umac_cmd_btcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	umac_cmd_data = (struct nrf_wifi_cmd_coex_config *)(umac_cmd->msg);
 
-	umac_cmd_data->sys_head.cmd_event = NRF_WIFI_CMD_BTCOEX;
+	umac_cmd_data->sys_head.cmd_event = NRF_WIFI_CMD_SRCOEX;
 	umac_cmd_data->sys_head.len = len;
 	umac_cmd_data->coex_config_info.len = cmd_len;
 

--- a/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
@@ -527,12 +527,12 @@ enum nrf_wifi_status nrf_wifi_fmac_conf_ltf_gi(struct nrf_wifi_fmac_dev_ctx *fma
 	return status;
 }
 
-enum nrf_wifi_status nrf_wifi_fmac_conf_btcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
+enum nrf_wifi_status nrf_wifi_fmac_conf_srcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					       void *cmd, unsigned int cmd_len)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
-	status = umac_cmd_btcoex(fmac_dev_ctx, cmd, cmd_len);
+	status = umac_cmd_srcoex(fmac_dev_ctx, cmd, cmd_len);
 
 	return status;
 }

--- a/nrf_wifi/hw_if/hal/inc/fw/rpu_if.h
+++ b/nrf_wifi/hw_if/hal/inc/fw/rpu_if.h
@@ -439,47 +439,4 @@ struct host_rpu_msg_hdr {
 	unsigned int resubmit;
 } __NRF_WIFI_PKD;
 
-#define BT_INIT 0x1
-#define BT_MODE 0x2
-#define BT_CTRL 0x4
-
-/*! BT coexistence module enable or disable */
-
-#define BT_COEX_DISABLE 0
-#define BT_COEX_ENABLE 1
-
-/* External BT mode  master or slave */
-
-#define SLAVE 0
-#define MASTER 1
-
-struct pta_ext_params {
-	/*! Set polarity to 1 if  BT_TX_RX active high indicates Tx. Set polarity to 0 if BT_TX_RX
-	 * active high indicates Rx.
-	 */
-	unsigned char tx_rx_pol;
-
-	/*! BT_ACTIVE signal lead time period. This is with reference to time instance at which
-	 *BT slot boundary starts if BT supports classic only mode and BT activity starts if BT
-	 *supports BLE or dual mode
-	 */
-	unsigned int lead_time;
-
-	/*! Time instance at which BT_STATUS is sampled by PTA to get the BT_PTI information. This
-	 *is done anywhere between BT_ACTIVE_ASSERT time and BT_STATUS priority signalling time
-	 *period ends.This is with reference to BT_ACTIVE assert time.
-	 */
-	unsigned int pti_samp_time;
-
-	/*! Time instance at which BT_STATUS is sampled by PTA to get BT_TX_RX information.
-	 *This is done by PTA after the end of time period T2.  This is with reference to BT_ACTIVE
-	 *assert time.
-	 */
-	unsigned int tx_rx_samp_time;
-
-	/*! Time instance at which PTA takes arbitration decision and posts WLAN_DENY to BT. This
-	 * is with reference to BT_ACTIVE assert time.
-	 */
-	unsigned int dec_time;
-} __NRF_WIFI_PKD;
 #endif /* __RPU_IF_H__ */


### PR DESCRIPTION
SHEL-2395: Rename all occurrences of ble*/BLE*/bt*/BT* to sr*/SR* to have generic names in common code, to support coexistence with Short Range radios.