### PR TITLE
test-spec: restore `mpsl` triggers for `CI-thread-test` label

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -78,6 +78,8 @@
   - "nrf_802154/**/*"
 
 "CI-thread-test":
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
   - "nrf_802154/driver/**/*"
   - "nrf_802154/serialization/**/*"
   - "nrf_802154/sl/**/*"


### PR DESCRIPTION
Removing these triggers has not been approved by Thread team.