### PR TITLE
nrf_wifi: Wait for regulatory change

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
+++ b/nrf_wifi/fw_if/umac_if/inc/default/fmac_structs.h
@@ -269,6 +269,9 @@ struct nrf_wifi_fmac_callbk_fns {
 					 void *frm,
 					 struct raw_rx_pkt_header *);
 #endif
+	void (*reg_change_callbk_fn)(void *os_vif_ctx,
+				     struct nrf_wifi_event_regulatory_change *reg_change,
+				     unsigned int event_len);
 };
 
 #if defined(CONFIG_NRF700X_STA_MODE) || defined(__DOXYGEN__)

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_cmd.h
@@ -17,6 +17,7 @@
 #ifdef CONFIG_NRF700X_RADIO_TEST
 #define NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT 50 /* 5s */
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
+#define NRF_WIFI_FMAC_REG_SET_TIMEOUT_MS 2000 /* 2s */
 
 struct host_rpu_msg *umac_cmd_alloc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				    int type,

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
@@ -170,6 +170,10 @@ struct nrf_wifi_fmac_dev_ctx {
 	unsigned int reg_chan_count;
 	/** Regulatory channel attributes */
 	struct nrf_wifi_get_reg_chn_info *reg_chan_info;
+	/** Regulatory set status */
+	int reg_set_status;
+	/** Regulatory change event */
+	struct nrf_wifi_event_regulatory_change *reg_change;
 	/** Data pointer to mode specific parameters */
 	char priv[];
 };

--- a/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_umac_if.h
@@ -3471,6 +3471,19 @@ struct nrf_wifi_cmd_req_set_reg {
 } __NRF_WIFI_PKD;
 
 /**
+ * @brief This structure represents the event that is generated when the regulatory domain
+ * is modified or updated. It contains the new regulatory domain information.
+ *
+ */
+struct nrf_wifi_event_regulatory_change {
+	struct nrf_wifi_umac_hdr umac_hdr;
+	unsigned short nrf_wifi_flags;
+	signed int intr;
+	signed char regulatory_type;
+	unsigned char nrf_wifi_alpha2[2];
+} __NRF_WIFI_PKD;
+
+/**
  * @brief This structure represents the status code for a command. It is used to indicate
  *  the outcome or result of executing a specific command. The status code provides valuable
  *  information about the success, failure, or any errors encountered during the execution

--- a/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/nrf_wifi/fw_if/umac_if/src/event.c
@@ -536,7 +536,15 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 					      umac_hdr->cmd_evnt);
 		break;
 	case NRF_WIFI_UMAC_EVENT_REG_CHANGE:
-		/* TODO: Inform the user space about the regulatory change */
+		if (callbk_fns->reg_change_callbk_fn)
+			callbk_fns->reg_change_callbk_fn(vif_ctx->os_vif_ctx,
+							 event_data,
+							 event_len);
+		else
+			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+					      "%s: No callback registered for event %d",
+					      __func__,
+					      umac_hdr->cmd_evnt);
 		break;
 #endif /* CONFIG_NRF700X_STA_MODE */
 	default:


### PR DESCRIPTION
When setting the regulatory wait for the change to take affect and check the status before returning to the caller.

Fixes SHEL-2458.