### PR TITLE
nrf_wifi: Fix the NULL checks

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/tx.c
+++ b/nrf_wifi/fw_if/umac_if/src/tx.c
@@ -1477,19 +1477,23 @@ enum nrf_wifi_status (nrf_wifi_fmac_tx_done_event_process)(
 	struct nrf_wifi_tx_buff_done *config)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
-	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	struct nrf_wifi_fmac_dev_ctx_def *def_dev_ctx = NULL;
 
-	if (!fmac_dev_ctx) {
-		goto out;
-	}
-
-	if (!config) {
+	if (!fmac_dev_ctx || !config) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 				      "%s: Invalid parameters",
 				      __func__);
-
 		goto out;
 	}
+
+	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
+	if (!def_dev_ctx || !def_dev_ctx->tx_config.tx_lock) {
+		/* This is a valid case when the TX_DONE event is received
+		 * during the driver deinit, so, silently ignore the failure.
+		 */
+		return NRF_WIFI_STATUS_SUCCESS;
+	}
+
 
 	nrf_wifi_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
 				    def_dev_ctx->tx_config.tx_lock);


### PR DESCRIPTION
Fix the NULL checks causing crash during de-init.

Fixes SHEL-2463.