### PR TITLE
nrf_wifi: Add CONFIG_NRF700X_RAW_DATA_RX check in validity check API

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/fmac_util.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_util.c
@@ -353,9 +353,12 @@ enum nrf_wifi_status nrf_wifi_check_mode_validity(unsigned char mode)
 	 */
 	if ((mode ^ NRF_WIFI_STA_MODE) == 0) {
 		return NRF_WIFI_STATUS_SUCCESS;
-	} else if ((mode ^ NRF_WIFI_MONITOR_MODE) == 0) {
+	}
+#ifdef CONFIG_NRF700X_RAW_DATA_RX
+	else if ((mode ^ NRF_WIFI_MONITOR_MODE) == 0) {
 		return NRF_WIFI_STATUS_SUCCESS;
 	}
+#endif /* CONFIG_NRF700X_RAW_DATA_RX */
 	return NRF_WIFI_STATUS_FAIL;
 }
 


### PR DESCRIPTION
This change adds the CONFIG_NRF700X_RAW_DATA_RX check for monitor mode to prevent monitor mode from being configured when driver is not compiled for the same.

It addresses SHEL-2461