### PR TITLE
nrf_wifi: Fix a buffer free issue for raw tx packet transmit done

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/tx.c
+++ b/nrf_wifi/fw_if/umac_if/src/tx.c
@@ -1454,19 +1454,20 @@ enum nrf_wifi_status nrf_wifi_fmac_rawtx_done_event_process(
 
 	nrf_wifi_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
 				    def_dev_ctx->tx_config.tx_lock);
-	if (!config->status) {
-		status = tx_done_process(fmac_dev_ctx,
-					 config->desc_num);
 
-		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Process raw tx done failed",
-					      __func__);
-			goto unlock;
-		}
-	} else {
+	if (!config->status) {
 		/* Increment raw TX failure count */
 		def_dev_ctx->raw_pkt_stats.raw_pkt_send_failure += 1;
+	}
+
+	status = tx_done_process(fmac_dev_ctx,
+				 config->desc_num);
+
+	if (status != NRF_WIFI_STATUS_SUCCESS) {
+		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
+				      "%s: Process raw tx done failed",
+				      __func__);
+		goto unlock;
 	}
 unlock:
 	nrf_wifi_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,


### PR DESCRIPTION
A recent fix to update error statistics covered the txbuffer done process in an if-else check. This prevents tx buffers from being released on tx failure. place the status check to only update error statistics and remove txdone API from if check.