### PR TITLE
nrf_wifi: Fix issues SHEL-2514 and SHEL-2528

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/nrf_wifi/fw_if/umac_if/src/event.c
@@ -894,7 +894,7 @@ nrf_wifi_fmac_if_mode_set_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		if ((mode_event->op_mode & NRF_WIFI_STA_MODE)
 			== NRF_WIFI_STA_MODE) {
 			mode_event->op_mode ^= NRF_WIFI_STA_MODE;
-			vif->if_type = NRF_WIFI_STA_MODE;
+			vif->if_type = NRF_WIFI_IFTYPE_STATION;
 			config->peers[MAX_PEERS].peer_id = -1;
 			config->peers[MAX_PEERS].if_idx = -1;
 


### PR DESCRIPTION
This change sets the if_type varibale to the proper enum value for station mode.

Fixes SHEL-2514, SHEL-2528