### PR TITLE
nrf_wi: Fix TX power issue

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
@@ -400,13 +400,8 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init(struct nrf_wifi_fmac_dev_ctx *fmac_d
 		goto out;
 	}
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			             &phy_rf_params,
-			             0xFF,
-			             sizeof(phy_rf_params));
-
 	status = nrf_wifi_fmac_rf_params_get(fmac_dev_ctx,
-						&phy_rf_params);
+					     &phy_rf_params);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 					"%s: RF parameters get failed",

--- a/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
@@ -667,7 +667,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 				      __func__);
 		goto out;
 	}
-	
+
 	ret = nrf_wifi_phy_rf_params_init(fmac_dev_ctx->fpriv->opriv,
 				    	  phy_rf_params,
 				    	  package_info,
@@ -959,9 +959,9 @@ int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 	unsigned int rf_param_offset = BAND_2G_LW_ED_BKF_DSSS_OFST - NRF_WIFI_RF_PARAMS_CONF_SIZE;
 	/* Initilaize reserved bytes */
 	nrf_wifi_osal_mem_set(opriv,
-			      &prf->reserved,
+			      prf,
 			      0x0,
-			      sizeof(prf->reserved));	
+			      sizeof(prf));
 	/* Initialize PD adjust values for MCS7. Currently these 4 bytes are not being used */
 	prf->pd_adjust_val.pd_adjt_lb_chan = PD_ADJUST_VAL;
 	prf->pd_adjust_val.pd_adjt_hb_low_chan = PD_ADJUST_VAL;
@@ -980,11 +980,6 @@ int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 	prf->rx_gain_offset.rx_gain_hb_mid_chan = RX_GAIN_OFFSET_HB_MID_CHAN;
 	prf->rx_gain_offset.rx_gain_hb_high_chan = RX_GAIN_OFFSET_HB_HIGH_CHAN;
 
-	nrf_wifi_osal_mem_set(opriv,
-			      &prf->temp_volt_backoff.reserved,
-			      0x0,
-			      sizeof(prf->temp_volt_backoff.reserved));	
-
 	if (package_info == CSP_PACKAGE_INFO) {
 		prf->xo_offset.xo_freq_offset = CSP_XO_VAL;
 		/* TX power ceiling */
@@ -998,6 +993,7 @@ int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 		prf->max_pwr_ceil.max_hb_mid_chan_mcs0_pwr = CSP_MAX_TX_PWR_HB_MID_CHAN_MCS0;
 		prf->max_pwr_ceil.max_hb_high_chan_mcs0_pwr = CSP_MAX_TX_PWR_HB_HIGH_CHAN_MCS0;
 
+#ifndef CONFIG_NRF700X_RADIO_TEST
 		/* Max-Min chip temperature, VT backoffs configuration */
 		prf->temp_volt_backoff.max_chip_temp = CSP_MAX_CHIP_TEMP;
 		prf->temp_volt_backoff.min_chip_temp = CSP_MIN_CHIP_TEMP;
@@ -1009,6 +1005,7 @@ int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 		prf->temp_volt_backoff.hb_vbt_lt_vlow =	CSP_HB_VBT_LT_VLOW;
 		prf->temp_volt_backoff.lb_vbt_lt_low = CSP_LB_VBT_LT_LOW;
 		prf->temp_volt_backoff.hb_vbt_lt_low = CSP_HB_VBT_LT_LOW;
+#endif /* CONFIG_NRF700X_RADIO_TEST */
 	}
 	else {
 		/** If nothing is written to OTP field corresponding to package info byte
@@ -1030,6 +1027,7 @@ int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 		prf->max_pwr_ceil.max_hb_mid_chan_mcs0_pwr = QFN_MAX_TX_PWR_HB_MID_CHAN_MCS0;
 		prf->max_pwr_ceil.max_hb_high_chan_mcs0_pwr = QFN_MAX_TX_PWR_HB_HIGH_CHAN_MCS0;
 
+#ifndef CONFIG_NRF700X_RADIO_TEST
 		/* Max-Min chip temperature, VT backoffs configuration */
 		prf->temp_volt_backoff.max_chip_temp = QFN_MAX_CHIP_TEMP;
 		prf->temp_volt_backoff.min_chip_temp = QFN_MIN_CHIP_TEMP;
@@ -1041,6 +1039,7 @@ int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 		prf->temp_volt_backoff.hb_vbt_lt_vlow =	QFN_HB_VBT_LT_VLOW;
 		prf->temp_volt_backoff.lb_vbt_lt_low = QFN_LB_VBT_LT_LOW;
 		prf->temp_volt_backoff.hb_vbt_lt_low = QFN_HB_VBT_LT_LOW;
+#endif /* CONFIG_NRF700X_RADIO_TEST */
 	}
 
 	ret = nrf_wifi_utils_hex_str_to_val(opriv,

--- a/nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -156,11 +156,6 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 		goto out;
 	}
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-                              &phy_rf_params,
-		              0xFF,
-		              sizeof(phy_rf_params));
-
 	status = nrf_wifi_fmac_rf_params_get(fmac_dev_ctx,
 		                             &phy_rf_params);
 


### PR DESCRIPTION
[SHEL-2533]: The problem of TX output power disparity has been resolved, which occurs when the default power is set without utilizing the TX power command, and the power is explicitly set using the TX power command through the Radio test application.

[SHEL-2533]: https://nordicsemi.atlassian.net/browse/SHEL-2533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ