### PR TITLE
nrf_wifi: Fix codeowners for FW patches

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,5 +49,6 @@ doc/*                                     @b-gent
 /lc3/                                     @koffes @alexsven
 /nrf_fuel_gauge/                          @nordic-auko @aasinclair
 /nrf_wifi/                                @krish2718 @sachinthegreen @rado17 @rlubos
+/nrf_wifi/fw_bins/                        @udaynordic @rajb9 @srkanordic
 /nrf_wifi/fw_if/umac_if/inc/fw/           @udaynordic @rajb9 @srkanordic
 /nrf_wifi/hw_if/hal/inc/fw/               @udaynordic @rajb9 @srkanordic


### PR DESCRIPTION
Without this entry, the default entry is being used which doesn't have RPU owners.