### PR TITLE
nrf_wifi: Fix the receive address API to get proper BSSID

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/fmac_util.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_util.c
@@ -327,6 +327,10 @@ unsigned char *nrf_wifi_util_get_ra(struct nrf_wifi_fmac_vif_ctx *vif,
 #ifdef CONFIG_NRF700X_RAW_DATA_TX
 	    || (vif->if_type == NRF_WIFI_STA_TX_INJECTOR)
 #endif /* CONFIG_NRF700X_RAW_DATA_TX */
+#ifdef CONFIG_NRF700X_PROMISC_DATA_RX
+	    || (vif->if_type == NRF_WIFI_STA_PROMISC)
+	    || (vif->if_type == NRF_WIFI_STA_PROMISC_TX_INJECTOR)
+#endif
 	    ) {
 		return vif->bssid;
 	}

--- a/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -376,7 +376,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 			nrf_wifi_osal_nbuf_free(fmac_dev_ctx->fpriv->opriv,
 						nwb);
 		}
-#ifdef CONFIG_NRF700X_RAW_DATA_RX
+#if defined(CONFIG_NRF700X_RAW_DATA_RX) || defined(CONFIG_NRF700X_PROMISC_DATA_RX)
 		else if (config->rx_pkt_type == NRF_WIFI_RAW_RX_PKT) {
 			raw_rx_hdr.frequency = config->frequency;
 			raw_rx_hdr.signal = config->signal;
@@ -388,7 +388,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 								      &raw_rx_hdr,
 								      true);
 		}
-#endif /* CONFIG_NRF700X_RAW_DATA_RX */
+#endif /* CONFIG_NRF700X_RAW_DATA_RX || CONFIG_NRF700X_PROMISC_DATA_RX */
 		else {
 			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
 					      "%s: Invalid frame type received %d",


### PR DESCRIPTION
If operating mode is set to station with promiscuous sub-mode enabled, the interface type check for BSSID for recieve address mapping in the transmit path is missed. This causes a wdevID of 255 to be sent to UMAC causing a UMAC crash.

Also, CONFIG check for sniffer callback is missed and added.

Fixes SHEL-2564