### PR TITLE
nrf_modem: doc: cleanup function references

### DIFF
--- a/nrf_modem/doc/api.rst
+++ b/nrf_modem/doc/api.rst
@@ -186,7 +186,7 @@ Socket polling API
 ******************
 
 Necessary data types and defines to poll for
-events on one or more sockets using nrf_poll().
+events on one or more sockets using :c:func:`nrf_poll`.
 
 .. doxygengroup:: nrf_socket_api_poll
    :project: nrfxlib

--- a/nrf_modem/doc/fault_handling.rst
+++ b/nrf_modem/doc/fault_handling.rst
@@ -46,8 +46,8 @@ Socket APIs that require communication with the modem, return ``-1`` and set ``e
 
 Although the modem has crashed, any data which was stored by the Modem library, including data that was delivered to the Modem library by the modem, remains available until the Modem library is shut down.
 This includes incoming network data, which was received before the crash but has not been read by the application.
-The application can read that data as normal, using the :c:func:`recv` function.
-When no more data is available, the :c:func:`recv` function returns ``-1`` and sets ``errno`` to ``NRF_ESHUTDOWN``.
+The application can read that data as normal, using the :c:func:`nrf_recv` and the :c:func:`nrf_recvfrom` functions.
+When no more data is available, the :c:func:`nrf_recv` and the :c:func:`nrf_recvfrom` functions return ``-1`` and set ``errno`` to ``NRF_ESHUTDOWN``.
 
 Ongoing API calls
 *****************

--- a/nrf_modem/doc/sockets/rai.rst
+++ b/nrf_modem/doc/sockets/rai.rst
@@ -49,7 +49,7 @@ After enabling RAI, you control it using the :c:func:`nrf_setsockopt` function w
 Code examples
 *************
 
-The following code snippets illustrate some cases on how to apply RAI using the :c:func:`nrf_setsockopt()` function.
+The following code snippets illustrate some cases on how to apply RAI using the :c:func:`nrf_setsockopt` function.
 
 An example that shows how to use ``NRF_RAI_LAST`` when sending a UDP packet:
 

--- a/nrf_modem/doc/sockets/socket_options_func.rst
+++ b/nrf_modem/doc/sockets/socket_options_func.rst
@@ -20,6 +20,7 @@ Following is a list of supported functions:
 * :c:func:`nrf_connect`
 * :c:func:`nrf_bind`
 * :c:func:`nrf_listen`
+* :c:func:`nrf_accept`
 * :c:func:`nrf_send`
 * :c:func:`nrf_sendto`
 * :c:func:`nrf_recv`
@@ -34,6 +35,7 @@ Following is a list of supported functions:
 * :c:func:`nrf_freeifaddrs`
 * :c:func:`nrf_inet_pton`
 * :c:func:`nrf_inet_ntop`
+* :c:func:`nrf_setdnsaddr`
 
 The library supports up to eight networking sockets.
 
@@ -55,7 +57,7 @@ The following table shows all socket options supported by the Modem library.
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SOCKET  | NRF_SO_BINDTOPDN                | ``int``                | set        | Bind this socket to a specific PDN ID.                                                     |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_POLLCB                   | ``struct nrf_pollcb``  | set        | Set callbacks for poll() events on sockets.                                                |
+| NRF_SOL_SOCKET  | NRF_SO_POLLCB                   | ``struct nrf_pollcb``  | set        | Set callbacks for :c:func:`nrf_poll` events on sockets.                                    |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SOCKET  | NRF_SO_EXCEPTIONAL_DATA         | ``int``                | get/set    | Send data on socket as part of exceptional event.                                          |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
@@ -294,7 +296,7 @@ NRF_SO_SEC_ROLE
    * :c:macro:`NRF_SO_SEC_ROLE_SERVER` - Server role
 
    The default role is client.
-   For TLS, the choice is implicit from the usage of ``listen()``, ``accept()`` and ``connect()``.
+   For TLS, the choice is implicit from the usage of :c:func:`nrf_listen`, :c:func:`nrf_accept` and :c:func:`nrf_connect`.
 
 NRF_SO_SEC_SESSION_CACHE
    This option controls TLS session caching.

--- a/nrf_modem/doc/sockets/socket_options_func.rst
+++ b/nrf_modem/doc/sockets/socket_options_func.rst
@@ -379,21 +379,21 @@ NRF_SO_SEC_DTLS_CONN_SAVE
 
    Once the DTLS context is saved, the socket can't be used before the DTLS context is loaded with :c:macro:`NRF_SO_SEC_DTLS_CONN_LOAD`.
 
-   This option fails with nrf_errno ``NRF_EAGAIN``if an error happened during serialization of the SSL context.
+   This option fails with ``errno`` set to ``NRF_EAGAIN`` if an error happened during serialization of the SSL context.
    This can occur, for instance, when the modem cannot allocate enough memory or if the socket is busy sending or receiving data.
    In this case, the SSL context is still present in the socket, so data sending is still possible.
-   The option fails with nrf_errno ``NRF_EINVAL`` if the socket option is not supported with the current configuration, for instance because the DTLS handshake is not completed,
+   The option fails with ``errno`` set to ``NRF_EINVAL`` if the socket option is not supported with the current configuration, for instance because the DTLS handshake is not completed,
    the connection is not an DTLS v1.2 connection with renegotiation disabled, or the connection does not use an AEAD cipher suite (AES-CCM or AES-GCM).
-   The option fails with nrf_errno ``NRF_ENOMEM`` if the number of saved connections exceeds four.
+   The option fails with ``errno`` set to ``NRF_ENOMEM`` if the number of saved connections exceeds four.
 
 NRF_SO_SEC_DTLS_CONN_LOAD
    Load DTLS connection.
    This option is write-only.
    The socket option is supported from modem firmware v1.3.x, where x is greater than or equal to 5, and v2.x.x.
 
-   This option fails with nrf_errno ``NRF_EAGAIN`` if an error happened during deserialization of the SSL context.
+   This option fails with ``errno`` set to ``NRF_EAGAIN`` if an error happened during deserialization of the SSL context.
    This can occur, for instance, when the modem cannot allocate enough memory or the connection is not saved.
-   The option fails with nrf_errno ``NRF_EINVAL`` if the socket option is not supported with the current configuration.
+   The option fails with ``errno`` set to ``NRF_EINVAL`` if the socket option is not supported with the current configuration.
 
 NRF_SO_SEC_CIPHERSUITE_USED
    Get chosen TLS cipher suite.


### PR DESCRIPTION
Clean up function references.
Add nrf_accept and nrf_setdnsaddr to list of supported functions.

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>