### PR TITLE
nrf_wifi: Fix defined in monitor mode support

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
@@ -340,7 +340,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_channel(void *dev_ctx,
 
 #endif /* CONFIG_NRF700X_RAW_DATA_TX || CONFIG_NRF700X_RAW_DATA_RX */
 
-#if defined(CONFIG_NRF700X_RAW_DATA_RX) || (CONFIG_NRF700X_PROMISC_DATA_RX)
+#if defined(CONFIG_NRF700X_RAW_DATA_RX) || defined(CONFIG_NRF700X_PROMISC_DATA_RX)
 /**
  * @brief Set packet filter settings
  * @param dev_ctx Pointer to the UMAC IF context for a RPU WLAN device.


### PR DESCRIPTION
In the monitor mode support defined is missing.
Add defined into condition.