### PR TITLE
mpsl: Kconfig: Replace nRF54H20 PDK with DK

### DIFF
--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -11,7 +11,7 @@ config MPSL
 	select NRF_802154_MULTIPROTOCOL_SUPPORT if NRF_802154_RADIO_DRIVER
 	select MULTITHREADING_LOCK
 	depends on (SOC_SERIES_BSIM_NRFXX || SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET ||\
-				SOC_NRF54H20_ENGA_CPURAD || SOC_SERIES_NRF54LX)
+				SOC_NRF54H20_CPURAD || SOC_SERIES_NRF54LX)
 	help
 	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,
 	  providing services for single and multi-protocol implementations.


### PR DESCRIPTION
nRF54H20 PDK is superseded by nRF54H20 DK and will no longer be supported, so instead of the SOC_NRF54H20_ENGA_CPURAD option that no longer exists, SOC_NRF54H20_CPURAD needs to be used.