### PR TITLE
test-spec: introduce specific ble-sample label

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -36,6 +36,12 @@
   - "mpsl/include/**/*"
   - "mpsl/lib/**/*"
 
+"CI-ble-samples-test":
+  - "softdevice_controller/include/**/*"
+  - "softdevice_controller/lib/**/*"
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+
 "CI-mesh-test": null
 
 "CI-zigbee-test":


### PR DESCRIPTION
Add CI-ble-samples-test label and test spec for ble sample CI. It has different test scope than BLE CI