### PR TITLE
ci: add workflow to create manifest PRs

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -1,0 +1,13 @@
+name: Automatically create manifest PR
+on:
+  pull_request_target:
+    types: [opened, synchronize, closed]
+    branches:
+      - main
+
+
+jobs:
+  call_workflow:
+    uses: nordicbuilder/action-manifest-pr/.github/workflows/auto-manifest-pr.yml@main
+    secrets:
+       NB_TOKEN: ${{ secrets.NCS_GITHUB_TOKEN }}


### PR DESCRIPTION
This action will create manifest PR automatically for every PR that gets created into this repo.