### PR TITLE
nrf_wifi: Fix TX de-init crash

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
@@ -433,11 +433,10 @@ out:
 
 void nrf_wifi_fmac_dev_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 {
-	nrf_wifi_hal_lock_rx(fmac_dev_ctx->hal_dev_ctx);
+	nrf_wifi_hal_dev_deinit(fmac_dev_ctx->hal_dev_ctx);
 	nrf_wifi_fmac_fw_deinit(fmac_dev_ctx);
 	nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
 			       fmac_dev_ctx->tx_pwr_ceil_params);
-	nrf_wifi_hal_unlock_rx(fmac_dev_ctx->hal_dev_ctx);
 }
 
 #ifdef CONFIG_NRF_WIFI_RPU_RECOVERY

--- a/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
@@ -2256,6 +2256,10 @@ out:
 
 		def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
+		nrf_wifi_fmac_vif_update_if_type(fmac_dev_ctx,
+						 if_idx,
+						 vif_info->iftype);
+
 		def_dev_ctx->vif_ctx[if_idx]->if_type = vif_info->iftype;
 	}
 

--- a/nrf_wifi/hw_if/hal/src/hal_api.c
+++ b/nrf_wifi/hw_if/hal/src/hal_api.c
@@ -1060,14 +1060,6 @@ void hal_rpu_eventq_drain(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 						hal_dev_ctx->lock_rx,
 						&flags);
 
-		if (hal_dev_ctx->hal_status != NRF_WIFI_HAL_STATUS_ENABLED) {
-			/* Ignore the interrupt if the HAL is not enabled */
-			nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-						hal_dev_ctx->lock_rx,
-						&flags);
-			goto out;
-		}
-
 		event = nrf_wifi_utils_q_dequeue(hal_dev_ctx->hpriv->opriv,
 						 hal_dev_ctx->event_q);
 
@@ -1305,8 +1297,6 @@ void nrf_wifi_hal_dev_rem(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 	nrf_wifi_osal_tasklet_kill(hal_dev_ctx->hpriv->opriv,
 				   hal_dev_ctx->event_tasklet);
 
-	hal_rpu_eventq_drain(hal_dev_ctx);
-
 	nrf_wifi_osal_tasklet_free(hal_dev_ctx->hpriv->opriv,
 				   hal_dev_ctx->event_tasklet);
 
@@ -1398,6 +1388,7 @@ void nrf_wifi_hal_dev_deinit(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
 	nrf_wifi_hal_disable(hal_dev_ctx);
 	nrf_wifi_bal_dev_deinit(hal_dev_ctx->bal_dev_ctx);
+	hal_rpu_eventq_drain(hal_dev_ctx);
 }
 
 

--- a/nrf_wifi/hw_if/hal/src/hal_api.c
+++ b/nrf_wifi/hw_if/hal/src/hal_api.c
@@ -1388,6 +1388,7 @@ enum nrf_wifi_status nrf_wifi_hal_dev_init(struct nrf_wifi_hal_dev_ctx *hal_dev_
 	}
 
 	hal_dev_ctx->rpu_info.tx_cmd_base = RPU_MEM_TX_CMD_BASE;
+	nrf_wifi_hal_enable(hal_dev_ctx);
 out:
 	return status;
 }
@@ -1395,6 +1396,7 @@ out:
 
 void nrf_wifi_hal_dev_deinit(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
+	nrf_wifi_hal_disable(hal_dev_ctx);
 	nrf_wifi_bal_dev_deinit(hal_dev_ctx->bal_dev_ctx);
 }
 


### PR DESCRIPTION
If interface is de-initialized during active traffic, then the HAL RX lock still doesn't protect the full de-initialization path, there is a race after TX de-init, lock is released and before the FMAC context is de-initialized the NULL checks elsewhere pass and can lead to crashes.

Add an atomic API that does both de-initialization and removal by taking the HAL RX lock for both operations, this way FMAC context is freed and NULL checks should avoid any crashes.

Fixes SHEL-2436.