### PR TITLE
ci: use refactored manifest-PR action

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -1,13 +1,15 @@
-name: Automatically create manifest PR
+name: handle manifest PR
 on:
   pull_request_target:
     types: [opened, synchronize, closed]
     branches:
       - main
 
-
 jobs:
-  call_workflow:
-    uses: nordicbuilder/action-manifest-pr/.github/workflows/auto-manifest-pr.yml@main
-    secrets:
-       NB_TOKEN: ${{ secrets.NCS_GITHUB_TOKEN }}
+  call-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: handle manifest PR
+        uses: nrfconnect/action-manifest-pr@main
+        with:
+          token: ${{ secrets.NCS_GITHUB_TOKEN }}


### PR DESCRIPTION
manifest PR action was refactored a bit and moved to nrfconnect org.