### PR TITLE
nrf_rpc: Init all transports before sending group init packets

### DIFF
--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -369,11 +369,14 @@ static int transport_init(nrf_rpc_tr_receive_handler_t receive_cb)
 		}
 
 		group->data->transport_initialized = true;
+	}
+
+	for (NRF_RPC_AUTO_ARR_FOR(iter, group, &nrf_rpc_groups_array,
+				 const struct nrf_rpc_group)) {
 		err = group_init_send(group);
 		if (err) {
 			NRF_RPC_ERR("Failed to send group init packet for group id: %d strid: %s",
-				    data->src_group_id, group->strid);
-			continue;
+				    group->data->src_group_id, group->strid);
 		}
 	}
 


### PR DESCRIPTION
This commit postpones sending group init packets to after all transports have had a chance to initialize.

This ensures that the initialization of one transport don't have to wait for the group init packets being sent on another transport. This could occur if the send function of a transport would block.