### PR TITLE
mpsl: Use kconfig to determine library path

### DIFF
--- a/mpsl/CMakeLists.txt
+++ b/mpsl/CMakeLists.txt
@@ -5,27 +5,14 @@
 #
 
 if (CONFIG_MPSL_BUILD_TYPE_LIB)
+  add_subdirectory(fem)
+  set(MPSL_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CONFIG_MPSL_LIB_DIR}/${CONFIG_MPSL_LIB_FLOAT_ABI_DIR}")
 
-add_subdirectory(fem)
+  if(NOT EXISTS "${MPSL_LIB_DIR}/libmpsl.a")
+    message(FATAL_ERROR "This combination of SoC and floating point ABI is not supported by the MPSL lib.")
+  endif()
 
-if (CONFIG_SOC_SERIES_NRF54HX OR CONFIG_SOC_SERIES_NRF54LX)
-  nrfxlib_calculate_lib_path(MPSL_LIB_DIR SOC_MODE
-    BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-    SOFT_FLOAT_FALLBACK
-  )
-else ()
-  nrfxlib_calculate_lib_path(MPSL_LIB_DIR
-    BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-    SOFT_FLOAT_FALLBACK
-  )
-endif ()
-
-if(NOT MPSL_LIB_DIR)
-  message(WARNING "This combination of SoC and floating point ABI is not supported by the MPSL lib.")
-endif()
-
-zephyr_include_directories(include)
-zephyr_include_directories(include/protocol)
-zephyr_link_libraries(${MPSL_LIB_DIR}/libmpsl.a)
-
+  zephyr_include_directories(include)
+  zephyr_include_directories(include/protocol)
+  zephyr_link_libraries(${MPSL_LIB_DIR}/libmpsl.a)
 endif()

--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -27,4 +27,24 @@ config MPSL_BUILD_TYPE_LIB
 
 endchoice
 
-endif
+if MPSL_BUILD_TYPE_LIB
+config MPSL_LIB_DIR
+	string
+	default "cortex-m4" if SOC_SERIES_NRF52X
+	default "cortex-m33+nodsp" if SOC_COMPATIBLE_NRF5340_CPUNET
+	default "nrf54h20_cpurad" if SOC_NRF54H20_CPURAD
+	default "nrf54l15_cpuapp" if SOC_SERIES_NRF54LX
+	default "bsim_nrfxx" if SOC_SERIES_BSIM_NRFXX
+	help
+	  Hidden helper option to calculate the library path
+
+config MPSL_LIB_FLOAT_ABI_DIR
+	string
+	default "hard-float" if FPU && FP_HARDABI
+	default "softfp-float" if FPU && FP_SOFTABI
+	default "soft-float"
+	help
+	  Hidden helper option to calculate the library path
+
+endif # MPSL_BUILD_TYPE_LIB
+endif # MPSL

--- a/mpsl/fem/CMakeLists.txt
+++ b/mpsl/fem/CMakeLists.txt
@@ -4,17 +4,7 @@
 #
 
 function(mpsl_fem_append_lib fem_lib_name)
-    if (CONFIG_SOC_SERIES_NRF54HX OR CONFIG_SOC_SERIES_NRF54LX)
-      nrfxlib_calculate_lib_path(LIB_DIR SOC_MODE
-        BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${fem_lib_name}
-        SOFT_FLOAT_FALLBACK
-      )
-    else ()
-      nrfxlib_calculate_lib_path(LIB_DIR
-        BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${fem_lib_name}
-        SOFT_FLOAT_FALLBACK
-      )
-    endif()
+    set(LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${fem_lib_name}/lib/${CONFIG_MPSL_LIB_DIR}/${CONFIG_MPSL_LIB_FLOAT_ABI_DIR}")
 
     if(LIB_DIR)
       zephyr_include_directories(${fem_lib_name}/include)
@@ -26,7 +16,7 @@ FILE(GLOB subdirlist RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE
 
 # call mpsl_fem_append_lib for each subdirectory
 FOREACH(subdir ${subdirlist})
-  IF(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${subdir})
+  IF((IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}) AND NOT (${subdir} STREQUAL "include"))
     mpsl_fem_append_lib(${subdir})
   ENDIF()
 ENDFOREACH()

--- a/softdevice_controller/CMakeLists.txt
+++ b/softdevice_controller/CMakeLists.txt
@@ -12,22 +12,7 @@ if (CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE)
 endif()
 
 if(CONFIG_BT_LL_SOFTDEVICE AND CONFIG_BT_LL_SOFTDEVICE_BUILD_TYPE_LIB)
-  if (CONFIG_SOC_SERIES_NRF54HX OR CONFIG_SOC_SERIES_NRF54LX)
-    nrfxlib_calculate_lib_path(SOFTDEVICE_CONTROLLER_LIB_DIR SOC_MODE
-      BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-      SOFT_FLOAT_FALLBACK
-    )
-  else()
-    nrfxlib_calculate_lib_path(SOFTDEVICE_CONTROLLER_LIB_DIR
-      BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-      SOFT_FLOAT_FALLBACK
-    )
-  endif()
-
-  if(NOT SOFTDEVICE_CONTROLLER_LIB_DIR)
-    message(WARNING "This combination of SoC and floating point ABI is not"
-      "supported by the SoftDevice Controller lib.")
-  endif()
+  set(SOFTDEVICE_CONTROLLER_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CONFIG_MPSL_LIB_DIR}/${CONFIG_MPSL_LIB_FLOAT_ABI_DIR}")
 
   if(CONFIG_BT_LL_SOFTDEVICE_PERIPHERAL)
     set(softdevice_controller_variant peripheral)
@@ -41,5 +26,11 @@ if(CONFIG_BT_LL_SOFTDEVICE AND CONFIG_BT_LL_SOFTDEVICE_BUILD_TYPE_LIB)
 
   set(SOFTDEVICE_CONTROLLER_LIB
     ${SOFTDEVICE_CONTROLLER_LIB_DIR}/libsoftdevice_controller_${softdevice_controller_variant}.a)
+
+  if(NOT EXISTS ${SOFTDEVICE_CONTROLLER_LIB})
+    message(FATAL_ERROR "This combination of SoC and floating point ABI is not"
+      "supported by the SoftDevice Controller lib.")
+  endif()
+
   zephyr_link_libraries(${SOFTDEVICE_CONTROLLER_LIB})
 endif()


### PR DESCRIPTION
Instead of using SOC and ARCH configs to determine the library paths, use mpsl-specific kconfigs. We will then be able to change the paths independently of which value various upstream configs have.

This also makes it simpler to use the same library for different socs, or different libraries for the same cpu core variant.