### PR TITLE
nrf_wifi: Fix name of DFS channel kconfig option

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -199,7 +199,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #ifdef CONFIG_NRF700X_RPU_EXTEND_TWT_SP
 	 umac_cmd_data->feature_flags |= TWT_EXTEND_SP_EDCA;
 #endif
-#ifdef CONFIG_NRF700X_SCAN_DISABLE_DFS_CHANNELS
+#ifdef CONFIG_WIFI_NRF700X_SCAN_DISABLE_DFS_CHANNELS
 	umac_cmd_data->feature_flags |= DISABLE_DFS_CHANNELS;
 #endif /* CONFIG_NRF700X_SCAN_DISABLE_DFS_CHANNELS */
 


### PR DESCRIPTION
The 'WIFI' is missing in the name of DFS channel
kconfig option. So it was not enabling the DISABLE_DFS_CHANNELS flag.