### PR TITLE
nrf_wifi: Create dedicated memory pools for Wi-Fi

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
@@ -86,7 +86,7 @@ static void nrf_wifi_fmac_deinit_tx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 
 	tx_deinit(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_free(def_dev_ctx->tx_buf_info);
+	nrf_wifi_osal_data_mem_free(def_dev_ctx->tx_buf_info);
 }
 
 #endif /* CONFIG_NRF700X_DATA_TX */
@@ -182,7 +182,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_deinit_rx(struct nrf_wifi_fmac_dev_ctx
 		}
 	}
 
-	nrf_wifi_osal_mem_free(def_dev_ctx->rx_buf_info);
+	nrf_wifi_osal_data_mem_free(def_dev_ctx->rx_buf_info);
 
 	def_dev_ctx->rx_buf_info = NULL;
 out:

--- a/nrf_wifi/os_if/inc/osal_api.h
+++ b/nrf_wifi/os_if/inc/osal_api.h
@@ -66,6 +66,20 @@ void *nrf_wifi_osal_mem_alloc(size_t size);
  */
 void *nrf_wifi_osal_mem_zalloc(size_t size);
 
+
+/**
+ * @brief Allocated zero-initialized memory for data.
+ *
+ * @size: Size of the memory to be allocated in bytes.
+ *
+ * Allocates memory of @size bytes, zeroes it out and returns a pointer to the
+ * start of the memory allocated.
+ *
+ * @return: Pointer to start of allocated memory or NULL.
+ */
+void *nrf_wifi_osal_data_mem_zalloc(size_t size);
+
+
 /**
  * @brief Free previously allocated memory.
  * @param buf Pointer to the memory to be freed.
@@ -76,6 +90,20 @@ void *nrf_wifi_osal_mem_zalloc(size_t size);
  * @return None.
  */
 void nrf_wifi_osal_mem_free(void *buf);
+
+
+/**
+ * @brief Free previously allocated memory for data.
+ *
+ * @buf: Pointer to the memory to be freed.
+ *
+ * Free up memory which has been allocated using @nrf_wifi_osal_mem_alloc or
+ * @nrf_wifi_osal_mem_zalloc.
+ *
+ * @return: None.
+ */
+void nrf_wifi_osal_data_mem_free(void *buf);
+
 
 /**
  * @brief Copy contents from one memory location to another.

--- a/nrf_wifi/os_if/inc/osal_ops.h
+++ b/nrf_wifi/os_if/inc/osal_ops.h
@@ -34,7 +34,7 @@ struct nrf_wifi_osal_ops {
 	void *(*mem_alloc)(size_t size);
 
 	/**
-	 * @brief Allocate zero-initialized memory.
+	 * @brief Allocate zero-initialized memory for control messages.
 	 *
 	 * @param size The size of the memory to allocate.
 	 * @return A pointer to the start of the allocated memory.
@@ -47,6 +47,21 @@ struct nrf_wifi_osal_ops {
 	 * @param buf A pointer to the memory to free.
 	 */
 	void (*mem_free)(void *buf);
+
+	/**
+	 * @brief Allocate zero-initialized memory for data.
+	 *
+	 * @param size The size of the memory to allocate.
+	 * @return A pointer to the start of the allocated memory.
+	 */
+	void *(*data_mem_zalloc)(size_t size);
+
+	/**
+	 * @brief Free allocated memory.
+	 *
+	 * @param buf A pointer to the memory to free.
+	 */
+	void (*data_mem_free)(void *buf);
 
 	/**
 	 * @brief Copy memory.

--- a/nrf_wifi/os_if/src/osal.c
+++ b/nrf_wifi/os_if/src/osal.c
@@ -37,9 +37,21 @@ void *nrf_wifi_osal_mem_zalloc(size_t size)
 }
 
 
+void *nrf_wifi_osal_data_mem_zalloc(size_t size)
+{
+	return opriv->ops->data_mem_zalloc(size);
+}
+
+
 void nrf_wifi_osal_mem_free(void *buf)
 {
 	os_ops->mem_free(buf);
+}
+
+
+void nrf_wifi_osal_data_mem_free(void *buf)
+{
+	opriv->ops->data_mem_free(buf);
 }
 
 


### PR DESCRIPTION
Create dedicated memory pools for Wi-Fi data and
management paths. Introduce corresponding memory
allocation/deallocation calls.