### PR TITLE
ci: Manifest-PR action to add sub-PR title to manifest PR

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -14,3 +14,4 @@ jobs:
         uses: nrfconnect/action-manifest-pr@main
         with:
           token: ${{ secrets.NCS_GITHUB_TOKEN }}
+          manifest-pr-title-details: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
This commit will ensure that manifest-PRs generated from nrfxlib-PRs will contain the nrfxlib-PR title in the manifest-PR.

This will make it easier to browse through manifest-PRs in sdk-nrf.