### PR TITLE
doc: Add ref label for AGNSS data type enum API

### DIFF
--- a/nrf_modem/doc/api.rst
+++ b/nrf_modem/doc/api.rst
@@ -268,6 +268,8 @@ A-GNSS data request bitmask values
    :project: nrfxlib
    :members:
 
+.. _agnss_data_type_enum_api:
+
 A-GNSS data type enumerator
 ===========================
 


### PR DESCRIPTION
Add ref label for AGNSS data type enum API
This helps to fix the link in [PR 14859](https://github.com/nrfconnect/sdk-nrf/pull/14859/files#diff-478a3860a34e7a4faf66f620bee86e14a1fd4b71e4e179908370313fa5703506R135).