### PR TITLE
nrf_wifi: Set appropriate filter setting for packet length

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
@@ -2030,6 +2030,16 @@ unsigned char nrf_wifi_fmac_add_vif(void *dev_ctx,
 	vif_ctx->if_type = vif_info->iftype;
 	vif_ctx->mode = NRF_WIFI_STA_MODE;
 
+	/**
+	 * Set initial packet filter setting to filter all.
+	 * subsequent calls to set packet filter will set
+	 * packet_filter settings to appropriate value as
+	 * desired by application.
+	 */
+#if defined(CONFIG_NRF700X_RAW_DATA_RX) || defined(CONFIG_NRF700X_PROMISC_DATA_RX)
+	vif_ctx->packet_filter = 1;
+#endif
+
 	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
 			      vif_ctx->mac_addr,
 			      vif_info->mac_addr,


### PR DESCRIPTION
When sniffer packet length is attempted to be set by the application, it is possible that the filter setting from the upper layer might come in as zero. In such a scenario, set the previously configured filter setting to the lower layer.

Additional fix for SHEL-2790