### PR TITLE
kconfig: don't 'select' ZCBOR

### DIFF
--- a/nrf_rpc/Kconfig
+++ b/nrf_rpc/Kconfig
@@ -14,8 +14,8 @@ if NRF_RPC
 config NRF_RPC_CBOR
 	bool "Add CBOR layer"
 	default y
-	select ZCBOR
-	select ZCBOR_STOP_ON_ERROR
+	depends on ZCBOR
+	depends on ZCBOR_STOP_ON_ERROR
 	help
 	  Adds API that helps use of CBOR library for data serialization.
 


### PR DESCRIPTION
When an option depends on another option being set, its definition should use 'depends on' - not 'select'.

Using 'select' introduces a two way dependency which makes it impossible to express proper kconfig dependencies in some cases.

See 'select pitfalls' chapter in zephyr documentation for details.

Ref: NCSDK-27818