### PR TITLE
nrf_modem: add an explicit default for which binary is linked

### DIFF
--- a/nrf_modem/Kconfig
+++ b/nrf_modem/Kconfig
@@ -12,8 +12,9 @@ config NRF_MODEM
 	select REQUIRES_FULL_LIBC
 
 choice NRF_MODEM_BUILD_STRATEGY
-	depends on NRF_MODEM
 	prompt "Build strategy"
+	depends on NRF_MODEM
+	default NRF_MODEM_LINK_BINARY_CELLULAR
 
 config NRF_MODEM_LINK_BINARY_CELLULAR
 	bool "Link cellular binary"
@@ -23,8 +24,8 @@ config NRF_MODEM_LINK_BINARY_DECT_PHY
 endchoice
 
 config NRF_MODEM_LOG
-	depends on NRF_MODEM_LINK_BINARY_CELLULAR || NRF_MODEM_LINK_BINARY_DECT_PHY
 	bool "Link binary with logs"
+	depends on NRF_MODEM_LINK_BINARY_CELLULAR || NRF_MODEM_LINK_BINARY_DECT_PHY
 	help
 	  Links the application with the library version capable of emitting logs.
 	  This increases the final size of the application.


### PR DESCRIPTION
Add an explicit default, to ease integration with a private repository.