### PR TITLE
nrf_wifi: Remove dependency on OSAL layer handle

### DIFF
--- a/nrf_wifi/bus_if/bal/inc/bal_api.h
+++ b/nrf_wifi/bus_if/bal/inc/bal_api.h
@@ -30,8 +30,7 @@
  *
  * @return Pointer to instance of BAL layer context.
  */
-struct nrf_wifi_bal_priv *nrf_wifi_bal_init(struct nrf_wifi_osal_priv *opriv,
-					    struct nrf_wifi_bal_cfg_params *cfg_params,
+struct nrf_wifi_bal_priv *nrf_wifi_bal_init(struct nrf_wifi_bal_cfg_params *cfg_params,
 					    enum nrf_wifi_status (*intr_callbk_fn)(void *hal_ctx));
 
 

--- a/nrf_wifi/bus_if/bal/inc/bal_ops.h
+++ b/nrf_wifi/bus_if/bal/inc/bal_ops.h
@@ -22,14 +22,12 @@ struct nrf_wifi_bal_ops {
 	/**
 	 * @brief Initialize the bus.
 	 *
-	 * @param opriv Pointer to the OS-specific private data.
 	 * @param cfg_params Pointer to the configuration parameters.
 	 * @param intr_callbk_fn Pointer to the interrupt callback function.
 	 * @return Pointer to the initialized instance of the bus.
 	 */
-	void * (*init)(struct nrf_wifi_osal_priv *opriv,
-			   void *cfg_params,
-			   enum nrf_wifi_status (*intr_callbk_fn)(void *hal_ctx));
+	void * (*init)(void *cfg_params,
+		       enum nrf_wifi_status (*intr_callbk_fn)(void *hal_ctx));
 
 	/**
 	 * @brief Deinitialize the bus.

--- a/nrf_wifi/bus_if/bal/inc/bal_structs.h
+++ b/nrf_wifi/bus_if/bal/inc/bal_structs.h
@@ -29,8 +29,6 @@ struct nrf_wifi_bal_cfg_params {
  * @brief Structure holding context information for the BAL.
  */
 struct nrf_wifi_bal_priv {
-	/** Pointer to the OSAL context. */
-	struct nrf_wifi_osal_priv *opriv;
 	/** Pointer to a specific bus context. */
 	void *bus_priv;
 	/** Pointer to bus operations provided by a specific bus implementation. */

--- a/nrf_wifi/bus_if/bal/src/bal.c
+++ b/nrf_wifi/bus_if/bal/src/bal.c
@@ -38,8 +38,7 @@ static void nrf_wifi_rpu_bal_sleep_chk(struct nrf_wifi_bal_dev_ctx *bal_ctx,
 			     (1 << RPU_REG_BIT_READY_STATE));
 
 	if ((sleep_reg_val & rpu_ps_state_mask) != rpu_ps_state_mask) {
-		nrf_wifi_osal_log_err(bal_ctx->bpriv->opriv,
-				      "%s:RPU is being accessed when it is not ready !!! (Reg val = 0x%X)",
+		nrf_wifi_osal_log_err("%s:RPU accessed when it is not ready !!! (Reg val = 0x%X)",
 				      __func__,
 				      sleep_reg_val);
 	}
@@ -54,12 +53,10 @@ struct nrf_wifi_bal_dev_ctx *nrf_wifi_bal_dev_add(struct nrf_wifi_bal_priv *bpri
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_bal_dev_ctx *bal_dev_ctx = NULL;
 
-	bal_dev_ctx = nrf_wifi_osal_mem_zalloc(bpriv->opriv,
-					       sizeof(*bal_dev_ctx));
+	bal_dev_ctx = nrf_wifi_osal_mem_zalloc(sizeof(*bal_dev_ctx));
 
 	if (!bal_dev_ctx) {
-		nrf_wifi_osal_log_err(bpriv->opriv,
-				      "%s: Unable to allocate bal_dev_ctx", __func__);
+		nrf_wifi_osal_log_err("%s: Unable to allocate bal_dev_ctx", __func__);
 		goto out;
 	}
 
@@ -70,8 +67,7 @@ struct nrf_wifi_bal_dev_ctx *nrf_wifi_bal_dev_add(struct nrf_wifi_bal_priv *bpri
 						       bal_dev_ctx);
 
 	if (!bal_dev_ctx->bus_dev_ctx) {
-		nrf_wifi_osal_log_err(bpriv->opriv,
-				      "%s: Bus dev_add failed", __func__);
+		nrf_wifi_osal_log_err("%s: Bus dev_add failed", __func__);
 		goto out;
 	}
 
@@ -79,8 +75,7 @@ struct nrf_wifi_bal_dev_ctx *nrf_wifi_bal_dev_add(struct nrf_wifi_bal_priv *bpri
 out:
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
 		if (bal_dev_ctx) {
-			nrf_wifi_osal_mem_free(bpriv->opriv,
-					       bal_dev_ctx);
+			nrf_wifi_osal_mem_free(bal_dev_ctx);
 			bal_dev_ctx = NULL;
 		}
 	}
@@ -93,8 +88,7 @@ void nrf_wifi_bal_dev_rem(struct nrf_wifi_bal_dev_ctx *bal_dev_ctx)
 {
 	bal_dev_ctx->bpriv->ops->dev_rem(bal_dev_ctx->bus_dev_ctx);
 
-	nrf_wifi_osal_mem_free(bal_dev_ctx->bpriv->opriv,
-			       bal_dev_ctx);
+	nrf_wifi_osal_mem_free(bal_dev_ctx);
 }
 
 
@@ -109,8 +103,7 @@ enum nrf_wifi_status nrf_wifi_bal_dev_init(struct nrf_wifi_bal_dev_ctx *bal_dev_
 	status = bal_dev_ctx->bpriv->ops->dev_init(bal_dev_ctx->bus_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(bal_dev_ctx->bpriv->opriv,
-				      "%s: dev_init failed", __func__);
+		nrf_wifi_osal_log_err("%s: dev_init failed", __func__);
 		goto out;
 	}
 out:
@@ -138,36 +131,28 @@ static enum nrf_wifi_status nrf_wifi_bal_isr(void *ctx)
 
 
 struct nrf_wifi_bal_priv *
-nrf_wifi_bal_init(struct nrf_wifi_osal_priv *opriv,
-		  struct nrf_wifi_bal_cfg_params *cfg_params,
+nrf_wifi_bal_init(struct nrf_wifi_bal_cfg_params *cfg_params,
 		  enum nrf_wifi_status (*intr_callbk_fn)(void *hal_dev_ctx))
 {
 	struct nrf_wifi_bal_priv *bpriv = NULL;
 
-	bpriv = nrf_wifi_osal_mem_zalloc(opriv,
-					 sizeof(*bpriv));
+	bpriv = nrf_wifi_osal_mem_zalloc(sizeof(*bpriv));
 
 	if (!bpriv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate memory for bpriv", __func__);
+		nrf_wifi_osal_log_err("%s: Unable to allocate memory for bpriv", __func__);
 		goto out;
 	}
-
-	bpriv->opriv = opriv;
 
 	bpriv->intr_callbk_fn = intr_callbk_fn;
 
 	bpriv->ops = get_bus_ops();
 
-	bpriv->bus_priv = bpriv->ops->init(opriv,
-					   cfg_params,
+	bpriv->bus_priv = bpriv->ops->init(cfg_params,
 					   &nrf_wifi_bal_isr);
 
 	if (!bpriv->bus_priv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Failed", __func__);
-		nrf_wifi_osal_mem_free(opriv,
-				       bpriv);
+		nrf_wifi_osal_log_err("%s: Failed", __func__);
+		nrf_wifi_osal_mem_free(bpriv);
 		bpriv = NULL;
 	}
 
@@ -180,8 +165,7 @@ void nrf_wifi_bal_deinit(struct nrf_wifi_bal_priv *bpriv)
 {
 	bpriv->ops->deinit(bpriv->bus_priv);
 
-	nrf_wifi_osal_mem_free(bpriv->opriv,
-			       bpriv);
+	nrf_wifi_osal_mem_free(bpriv);
 }
 
 

--- a/nrf_wifi/bus_if/bus/qspi/inc/qspi.h
+++ b/nrf_wifi/bus_if/bus/qspi/inc/qspi.h
@@ -17,8 +17,6 @@
  * @brief Structure to hold context information for the QSPI bus.
  */
 struct nrf_wifi_bus_qspi_priv {
-	/** Pointer to the OSAL context. */
-	struct nrf_wifi_osal_priv *opriv;
 	/** Pointer to the QSPI bus-specific context. */
 	void *os_qspi_priv;
 

--- a/nrf_wifi/bus_if/bus/qspi/src/qspi.c
+++ b/nrf_wifi/bus_if/bus/qspi/src/qspi.c
@@ -38,36 +38,30 @@ static void *nrf_wifi_bus_qspi_dev_add(void *bus_priv,
 
 	qspi_priv = bus_priv;
 
-	qspi_dev_ctx = nrf_wifi_osal_mem_zalloc(qspi_priv->opriv,
-						sizeof(*qspi_dev_ctx));
+	qspi_dev_ctx = nrf_wifi_osal_mem_zalloc(sizeof(*qspi_dev_ctx));
 
 	if (!qspi_dev_ctx) {
-		nrf_wifi_osal_log_err(qspi_priv->opriv,
-				      "%s: Unable to allocate qspi_dev_ctx", __func__);
+		nrf_wifi_osal_log_err("%s: Unable to allocate qspi_dev_ctx", __func__);
 		goto out;
 	}
 
 	qspi_dev_ctx->qspi_priv = qspi_priv;
 	qspi_dev_ctx->bal_dev_ctx = bal_dev_ctx;
 
-	qspi_dev_ctx->os_qspi_dev_ctx = nrf_wifi_osal_bus_qspi_dev_add(qspi_priv->opriv,
-								       qspi_priv->os_qspi_priv,
+	qspi_dev_ctx->os_qspi_dev_ctx = nrf_wifi_osal_bus_qspi_dev_add(qspi_priv->os_qspi_priv,
 								       qspi_dev_ctx);
 
 	if (!qspi_dev_ctx->os_qspi_dev_ctx) {
-		nrf_wifi_osal_log_err(qspi_priv->opriv,
-				      "%s: nrf_wifi_osal_bus_qspi_dev_add failed", __func__);
+		nrf_wifi_osal_log_err("%s: nrf_wifi_osal_bus_qspi_dev_add failed", __func__);
 
-		nrf_wifi_osal_mem_free(qspi_priv->opriv,
-				       qspi_dev_ctx);
+		nrf_wifi_osal_mem_free(qspi_dev_ctx);
 
 		qspi_dev_ctx = NULL;
 
 		goto out;
 	}
 
-	nrf_wifi_osal_bus_qspi_dev_host_map_get(qspi_priv->opriv,
-						qspi_dev_ctx->os_qspi_dev_ctx,
+	nrf_wifi_osal_bus_qspi_dev_host_map_get(qspi_dev_ctx->os_qspi_dev_ctx,
 						&host_map);
 
 	qspi_dev_ctx->host_addr_base = host_map.addr;
@@ -86,11 +80,9 @@ static void nrf_wifi_bus_qspi_dev_rem(void *bus_dev_ctx)
 
 	qspi_dev_ctx = bus_dev_ctx;
 
-	nrf_wifi_osal_bus_qspi_dev_rem(qspi_dev_ctx->qspi_priv->opriv,
-					       qspi_dev_ctx->os_qspi_dev_ctx);
+	nrf_wifi_osal_bus_qspi_dev_rem(qspi_dev_ctx->os_qspi_dev_ctx);
 
-	nrf_wifi_osal_mem_free(qspi_dev_ctx->qspi_priv->opriv,
-			       qspi_dev_ctx);
+	nrf_wifi_osal_mem_free(qspi_dev_ctx);
 }
 
 
@@ -102,29 +94,24 @@ static enum nrf_wifi_status nrf_wifi_bus_qspi_dev_init(void *bus_dev_ctx)
 	qspi_dev_ctx = bus_dev_ctx;
 
 
-	status = nrf_wifi_osal_bus_qspi_dev_intr_reg(qspi_dev_ctx->qspi_priv->opriv,
-						     qspi_dev_ctx->os_qspi_dev_ctx,
+	status = nrf_wifi_osal_bus_qspi_dev_intr_reg(qspi_dev_ctx->os_qspi_dev_ctx,
 						     qspi_dev_ctx,
 						     &nrf_wifi_bus_qspi_irq_handler);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(qspi_dev_ctx->qspi_priv->opriv,
-				      "%s: Unable to register interrupt to the OS",
+		nrf_wifi_osal_log_err("%s: Unable to register interrupt to the OS",
 				      __func__);
 		qspi_dev_ctx = NULL;
 
 		goto out;
 	}
 
-	status = nrf_wifi_osal_bus_qspi_dev_init(qspi_dev_ctx->qspi_priv->opriv,
-						 qspi_dev_ctx->os_qspi_dev_ctx);
+	status = nrf_wifi_osal_bus_qspi_dev_init(qspi_dev_ctx->os_qspi_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(qspi_dev_ctx->qspi_priv->opriv,
-				      "%s: nrf_wifi_osal_qspi_dev_init failed", __func__);
+		nrf_wifi_osal_log_err("%s: nrf_wifi_osal_qspi_dev_init failed", __func__);
 
-		nrf_wifi_osal_bus_qspi_dev_intr_unreg(qspi_dev_ctx->qspi_priv->opriv,
-						      qspi_dev_ctx->os_qspi_dev_ctx);
+		nrf_wifi_osal_bus_qspi_dev_intr_unreg(qspi_dev_ctx->os_qspi_dev_ctx);
 		goto out;
 	}
 out:
@@ -138,48 +125,38 @@ static void nrf_wifi_bus_qspi_dev_deinit(void *bus_dev_ctx)
 
 	qspi_dev_ctx = bus_dev_ctx;
 
-	nrf_wifi_osal_bus_qspi_dev_intr_unreg(qspi_dev_ctx->qspi_priv->opriv,
-					      qspi_dev_ctx->os_qspi_dev_ctx);
+	nrf_wifi_osal_bus_qspi_dev_intr_unreg(qspi_dev_ctx->os_qspi_dev_ctx);
 
-	nrf_wifi_osal_bus_qspi_dev_deinit(qspi_dev_ctx->qspi_priv->opriv,
-					  qspi_dev_ctx->os_qspi_dev_ctx);
+	nrf_wifi_osal_bus_qspi_dev_deinit(qspi_dev_ctx->os_qspi_dev_ctx);
 }
 
 
-static void *nrf_wifi_bus_qspi_init(struct nrf_wifi_osal_priv *opriv,
-				    void *params,
+static void *nrf_wifi_bus_qspi_init(void *params,
 				    enum nrf_wifi_status (*intr_callbk_fn)(void *bal_dev_ctx))
 {
 	struct nrf_wifi_bus_qspi_priv *qspi_priv = NULL;
 
-	qspi_priv = nrf_wifi_osal_mem_zalloc(opriv,
-					     sizeof(*qspi_priv));
+	qspi_priv = nrf_wifi_osal_mem_zalloc(sizeof(*qspi_priv));
 
 	if (!qspi_priv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate memory for qspi_priv",
+		nrf_wifi_osal_log_err("%s: Unable to allocate memory for qspi_priv",
 				      __func__);
 		goto out;
 	}
 
-	qspi_priv->opriv = opriv;
-
-	nrf_wifi_osal_mem_cpy(opriv,
-			      &qspi_priv->cfg_params,
+	nrf_wifi_osal_mem_cpy(&qspi_priv->cfg_params,
 			      params,
 			      sizeof(qspi_priv->cfg_params));
 
 	qspi_priv->intr_callbk_fn = intr_callbk_fn;
 
-	qspi_priv->os_qspi_priv = nrf_wifi_osal_bus_qspi_init(opriv);
+	qspi_priv->os_qspi_priv = nrf_wifi_osal_bus_qspi_init();
 
 	if (!qspi_priv->os_qspi_priv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to register QSPI driver",
+		nrf_wifi_osal_log_err("%s: Unable to register QSPI driver",
 				      __func__);
 
-		nrf_wifi_osal_mem_free(opriv,
-				       qspi_priv);
+		nrf_wifi_osal_mem_free(qspi_priv);
 
 		qspi_priv = NULL;
 
@@ -196,11 +173,9 @@ static void nrf_wifi_bus_qspi_deinit(void *bus_priv)
 
 	qspi_priv = bus_priv;
 
-	nrf_wifi_osal_bus_qspi_deinit(qspi_priv->opriv,
-				      qspi_priv->os_qspi_priv);
+	nrf_wifi_osal_bus_qspi_deinit(qspi_priv->os_qspi_priv);
 
-	nrf_wifi_osal_mem_free(qspi_priv->opriv,
-			       qspi_priv);
+	nrf_wifi_osal_mem_free(qspi_priv);
 }
 
 
@@ -212,8 +187,7 @@ static unsigned int nrf_wifi_bus_qspi_read_word(void *dev_ctx,
 
 	qspi_dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)dev_ctx;
 
-	val = nrf_wifi_osal_qspi_read_reg32(qspi_dev_ctx->qspi_priv->opriv,
-					    qspi_dev_ctx->os_qspi_dev_ctx,
+	val = nrf_wifi_osal_qspi_read_reg32(qspi_dev_ctx->os_qspi_dev_ctx,
 					    qspi_dev_ctx->host_addr_base + addr_offset);
 
 	return val;
@@ -228,8 +202,7 @@ static void nrf_wifi_bus_qspi_write_word(void *dev_ctx,
 
 	qspi_dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)dev_ctx;
 
-	nrf_wifi_osal_qspi_write_reg32(qspi_dev_ctx->qspi_priv->opriv,
-				       qspi_dev_ctx->os_qspi_dev_ctx,
+	nrf_wifi_osal_qspi_write_reg32(qspi_dev_ctx->os_qspi_dev_ctx,
 				       qspi_dev_ctx->host_addr_base + addr_offset,
 				       val);
 }
@@ -244,8 +217,7 @@ static void nrf_wifi_bus_qspi_read_block(void *dev_ctx,
 
 	qspi_dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)dev_ctx;
 
-	nrf_wifi_osal_qspi_cpy_from(qspi_dev_ctx->qspi_priv->opriv,
-				    qspi_dev_ctx->os_qspi_dev_ctx,
+	nrf_wifi_osal_qspi_cpy_from(qspi_dev_ctx->os_qspi_dev_ctx,
 				    dest_addr,
 				    qspi_dev_ctx->host_addr_base + src_addr_offset,
 				    len);
@@ -261,8 +233,7 @@ static void nrf_wifi_bus_qspi_write_block(void *dev_ctx,
 
 	qspi_dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)dev_ctx;
 
-	nrf_wifi_osal_qspi_cpy_to(qspi_dev_ctx->qspi_priv->opriv,
-				  qspi_dev_ctx->os_qspi_dev_ctx,
+	nrf_wifi_osal_qspi_cpy_to(qspi_dev_ctx->os_qspi_dev_ctx,
 				  qspi_dev_ctx->host_addr_base + dest_addr_offset,
 				  src_addr,
 				  len);
@@ -308,8 +279,7 @@ static void nrf_wifi_bus_qspi_ps_sleep(void *dev_ctx)
 
 	qspi_dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)dev_ctx;
 
-	nrf_wifi_osal_bus_qspi_ps_sleep(qspi_dev_ctx->qspi_priv->opriv,
-					qspi_dev_ctx->os_qspi_dev_ctx);
+	nrf_wifi_osal_bus_qspi_ps_sleep(qspi_dev_ctx->os_qspi_dev_ctx);
 }
 
 
@@ -319,8 +289,7 @@ static void nrf_wifi_bus_qspi_ps_wake(void *dev_ctx)
 
 	qspi_dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)dev_ctx;
 
-	nrf_wifi_osal_bus_qspi_ps_wake(qspi_dev_ctx->qspi_priv->opriv,
-				       qspi_dev_ctx->os_qspi_dev_ctx);
+	nrf_wifi_osal_bus_qspi_ps_wake(qspi_dev_ctx->os_qspi_dev_ctx);
 }
 
 
@@ -330,8 +299,7 @@ static int nrf_wifi_bus_qspi_ps_status(void *dev_ctx)
 
 	qspi_dev_ctx = (struct nrf_wifi_bus_qspi_dev_ctx *)dev_ctx;
 
-	return nrf_wifi_osal_bus_qspi_ps_status(qspi_dev_ctx->qspi_priv->opriv,
-						qspi_dev_ctx->os_qspi_dev_ctx);
+	return nrf_wifi_osal_bus_qspi_ps_status(qspi_dev_ctx->os_qspi_dev_ctx);
 }
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 

--- a/nrf_wifi/bus_if/bus/spi/inc/spi.h
+++ b/nrf_wifi/bus_if/bus/spi/inc/spi.h
@@ -21,8 +21,6 @@
  * @brief Structure to hold context information for the Linux SPI bus.
  */
 struct nrf_wifi_bus_spi_priv {
-	/** Pointer to the OSAL context. */
-	struct nrf_wifi_osal_priv *opriv;
 	/** Pointer to the OS-specific SPI context. */
 	void *os_spi_priv;
 

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_api_common.h
@@ -293,7 +293,6 @@ enum nrf_wifi_status nrf_wifi_fmac_get_power_save_info(void *fmac_dev_ctx,
 
 /**
  * @brief Initialize RF parameters.
- * @param opriv Pointer to the OSAL context.
  * @param prf Pointer to the RF parameter structure.
  * @param package_info Package information, QFN, CSP etc.
  * @param str String of RF params
@@ -302,8 +301,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_power_save_info(void *fmac_dev_ctx,
  * with the XO, power ceiling info, voltage and temperature based
  * backoffs etc.
  */
-int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
-				struct nrf_wifi_phy_rf_params *prf,
+int nrf_wifi_phy_rf_params_init(struct nrf_wifi_phy_rf_params *prf,
 				unsigned int package_info,
 				unsigned char *str);
 

--- a/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fmac_structs_common.h
@@ -133,8 +133,6 @@ struct nrf_wifi_fmac_reg_info {
  *
  */
 struct nrf_wifi_fmac_priv {
-	/** Handle to the OS abstraction layer. */
-	struct nrf_wifi_osal_priv *opriv;
 	/** Handle to the HAL layer. */
 	struct nrf_wifi_hal_priv *hpriv;
 	/** Data pointer to mode specific parameters */

--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -20,12 +20,10 @@ struct host_rpu_msg *umac_cmd_alloc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 {
 	struct host_rpu_msg *umac_cmd = NULL;
 
-	umac_cmd = nrf_wifi_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
-					    sizeof(*umac_cmd) + len);
+	umac_cmd = nrf_wifi_osal_mem_zalloc(sizeof(*umac_cmd) + len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to allocate UMAC cmd",
+		nrf_wifi_osal_log_err("%s: Failed to allocate UMAC cmd",
 				      __func__);
 		goto out;
 	}
@@ -49,8 +47,7 @@ enum nrf_wifi_status umac_cmd_cfg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		struct nrf_wifi_umac_hdr *umac_hdr = NULL;
 
 		umac_hdr = (struct nrf_wifi_umac_hdr *)params;
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC buff config not yet done(%d)",
+		nrf_wifi_osal_log_err("%s: UMAC buff config not yet done(%d)",
 				      __func__,
 				      umac_hdr->cmd_evnt);
 		goto out;
@@ -61,14 +58,12 @@ enum nrf_wifi_status umac_cmd_cfg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      umac_cmd->msg,
+	nrf_wifi_osal_mem_cpy(umac_cmd->msg,
 			      params,
 			      len);
 
@@ -76,8 +71,7 @@ enum nrf_wifi_status umac_cmd_cfg(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 					    umac_cmd,
 					    (sizeof(*umac_cmd) + len));
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Command %d sent to RPU",
+	nrf_wifi_osal_log_dbg("%s: Command %d sent to RPU",
 			      __func__,
 			      ((struct nrf_wifi_umac_hdr *)params)->cmd_evnt);
 
@@ -116,8 +110,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -131,8 +124,7 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	umac_cmd_data->sys_params.rf_params_valid = rf_params_valid;
 
 	if (rf_params_valid) {
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      umac_cmd_data->sys_params.rf_params,
+		nrf_wifi_osal_mem_cpy(umac_cmd_data->sys_params.rf_params,
 				      rf_params,
 				      NRF_WIFI_RF_PARAMS_SIZE);
 	}
@@ -151,17 +143,15 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 #endif /* CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD */
 	umac_cmd_data->discon_timeout = CONFIG_NRF_WIFI_AP_DEAD_DETECT_TIMEOUT;
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv, "RPU LPM type: %s",
+	nrf_wifi_osal_log_dbg("RPU LPM type: %s",
 		umac_cmd_data->sys_params.sleep_enable == 2 ? "HW" :
 		umac_cmd_data->sys_params.sleep_enable == 1 ? "SW" : "DISABLED");
 #ifndef CONFIG_NRF700X_RADIO_TEST
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      umac_cmd_data->rx_buf_pools,
+	nrf_wifi_osal_mem_cpy(umac_cmd_data->rx_buf_pools,
 			      def_priv->rx_buf_pools,
 			      sizeof(umac_cmd_data->rx_buf_pools));
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->data_config_params,
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->data_config_params,
 			      config,
 			      sizeof(umac_cmd_data->data_config_params));
 
@@ -177,23 +167,19 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	umac_cmd_data->op_band = op_band;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->sys_params.rf_params[PCB_LOSS_BYTE_2G_OFST],
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->sys_params.rf_params[PCB_LOSS_BYTE_2G_OFST],
 			      &board_params->pcb_loss_2g,
 			      NUM_PCB_LOSS_OFFSET);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->sys_params.rf_params[ANT_GAIN_2G_OFST],
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->sys_params.rf_params[ANT_GAIN_2G_OFST],
 			      &tx_pwr_ctrl_params->ant_gain_2g,
 			      NUM_ANT_GAIN);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->sys_params.rf_params[BAND_2G_LW_ED_BKF_DSSS_OFST],
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->sys_params.rf_params[BAND_2G_LW_ED_BKF_DSSS_OFST],
 			      &tx_pwr_ctrl_params->band_edge_2g_lo_dss,
 			      NUM_EDGE_BACKOFF);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      umac_cmd_data->country_code,
+	nrf_wifi_osal_mem_cpy(umac_cmd_data->country_code,
 			      CONFIG_NRF700X_REG_DOMAIN,
 			      NRF_WIFI_COUNTRY_CODE_LEN);
 
@@ -229,8 +215,7 @@ enum nrf_wifi_status umac_cmd_deinit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 				  NRF_WIFI_HOST_RPU_MSG_TYPE_SYSTEM,
 				  len);
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -260,8 +245,7 @@ enum nrf_wifi_status umac_cmd_srcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -272,8 +256,7 @@ enum nrf_wifi_status umac_cmd_srcoex(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	umac_cmd_data->sys_head.len = len;
 	umac_cmd_data->coex_config_info.len = cmd_len;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      umac_cmd_data->coex_config_info.coex_cmd,
+	nrf_wifi_osal_mem_cpy(umac_cmd_data->coex_config_info.coex_cmd,
 			      cmd,
 			      cmd_len);
 
@@ -303,8 +286,7 @@ enum nrf_wifi_status umac_cmd_he_ltf_gi(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -315,18 +297,15 @@ enum nrf_wifi_status umac_cmd_he_ltf_gi(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 	umac_cmd_data->sys_head.len = len;
 
 	if (enabled) {
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      &umac_cmd_data->he_ltf,
+		nrf_wifi_osal_mem_cpy(&umac_cmd_data->he_ltf,
 				      &he_ltf,
 				      sizeof(he_ltf));
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      &umac_cmd_data->he_gi_type,
+		nrf_wifi_osal_mem_cpy(&umac_cmd_data->he_gi_type,
 				      &he_gi,
 				      sizeof(he_gi));
 	}
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->enable,
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->enable,
 			      &enabled,
 			      sizeof(enabled));
 
@@ -353,8 +332,7 @@ enum nrf_wifi_status umac_cmd_prog_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -364,8 +342,7 @@ enum nrf_wifi_status umac_cmd_prog_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_c
 	umac_cmd_data->sys_head.cmd_event = NRF_WIFI_CMD_RADIO_TEST_INIT;
 	umac_cmd_data->sys_head.len = len;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->conf,
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->conf,
 			      init_params,
 			      sizeof(umac_cmd_data->conf));
 
@@ -392,8 +369,7 @@ enum nrf_wifi_status umac_cmd_prog_tx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -403,8 +379,7 @@ enum nrf_wifi_status umac_cmd_prog_tx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 	umac_cmd_data->sys_head.cmd_event = NRF_WIFI_CMD_TX;
 	umac_cmd_data->sys_head.len = len;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->conf,
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->conf,
 			      params,
 			      sizeof(umac_cmd_data->conf));
 
@@ -432,8 +407,7 @@ enum nrf_wifi_status umac_cmd_prog_rx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -443,8 +417,7 @@ enum nrf_wifi_status umac_cmd_prog_rx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx
 	umac_cmd_data->sys_head.cmd_event = NRF_WIFI_CMD_RX;
 	umac_cmd_data->sys_head.len = len;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &umac_cmd_data->conf,
+	nrf_wifi_osal_mem_cpy(&umac_cmd_data->conf,
 			      rx_params,
 			      sizeof(umac_cmd_data->conf));
 
@@ -473,8 +446,7 @@ enum nrf_wifi_status umac_cmd_prog_rf_test(struct nrf_wifi_fmac_dev_ctx *fmac_de
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -484,8 +456,7 @@ enum nrf_wifi_status umac_cmd_prog_rf_test(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	umac_cmd_data->sys_head.cmd_event = NRF_WIFI_CMD_RF_TEST;
 	umac_cmd_data->sys_head.len = len;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      (void *)umac_cmd_data->rf_test_info.rfcmd,
+	nrf_wifi_osal_mem_cpy((void *)umac_cmd_data->rf_test_info.rfcmd,
 			      rf_test_params,
 			      rf_test_params_sz);
 
@@ -519,8 +490,7 @@ enum nrf_wifi_status umac_cmd_prog_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -555,8 +525,7 @@ enum nrf_wifi_status umac_cmd_prog_stats_reset(struct nrf_wifi_fmac_dev_ctx *fma
 				  NRF_WIFI_HOST_RPU_MSG_TYPE_SYSTEM,
 				  len);
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/nrf_wifi/fw_if/umac_if/src/event.c
@@ -35,16 +35,14 @@ nrf_wifi_fmac_if_carr_state_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 	def_priv = wifi_fmac_priv(fmac_dev_ctx->fpriv);
 
 	if (!fmac_dev_ctx || !umac_head) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 
 		goto out;
 	}
 
 	if (!def_priv->callbk_fns.if_carr_state_chg_callbk_fn) {
-		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No callback handler registered",
+		nrf_wifi_osal_log_dbg("%s: No callback handler registered",
 				      __func__);
 
 		status = NRF_WIFI_STATUS_SUCCESS;
@@ -54,8 +52,7 @@ nrf_wifi_fmac_if_carr_state_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 	if_idx = ((struct nrf_wifi_data_carrier_state *)umac_head)->wdev_id;
 
 	if (if_idx >= MAX_NUM_VIFS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid wdev_id recd from UMAC %d",
+		nrf_wifi_osal_log_err("%s: Invalid wdev_id recd from UMAC %d",
 				      __func__,
 				      if_idx);
 		goto out;
@@ -67,8 +64,7 @@ nrf_wifi_fmac_if_carr_state_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ct
 									     carr_state);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Interface carrier state change callback function failed for VIF idx = %d",
+		nrf_wifi_osal_log_err("%s: IF carrier state change failed for VIF idx = %d",
 				      __func__,
 				      if_idx);
 		goto out;
@@ -95,8 +91,7 @@ static void umac_event_connect(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	vif_ctx = def_dev_ctx->vif_ctx[if_index];
 	if (if_index >= MAX_NUM_VIFS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid wdev_id recd from UMAC %d",
+		nrf_wifi_osal_log_err("%s: Invalid wdev_id recd from UMAC %d",
 				      __func__,
 				      if_index);
 		return;
@@ -104,8 +99,7 @@ static void umac_event_connect(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 	if (event->umac_hdr.cmd_evnt == NRF_WIFI_UMAC_EVENT_NEW_STATION) {
 		if (vif_ctx->if_type == 2) {
-			nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-					      vif_ctx->bssid,
+			nrf_wifi_osal_mem_cpy(vif_ctx->bssid,
 					      event->mac_addr,
 					      NRF_WIFI_ETH_ADDR_LEN);
 		}
@@ -119,8 +113,7 @@ static void umac_event_connect(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 							 event->wme);
 
 			if (peer_id == -1) {
-				nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-						      "%s:Can't add new station.",
+				nrf_wifi_osal_log_err("%s:Can't add new station.",
 						      __func__);
 				return;
 			}
@@ -160,8 +153,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	unsigned int event_num = 0;
 
 	if (!fmac_dev_ctx || !event_data) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -181,8 +173,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	event_num = umac_hdr->cmd_evnt;
 
 	if (if_id >= MAX_NUM_VIFS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid wdev_id recd from UMAC %d",
+		nrf_wifi_osal_log_err("%s: Invalid wdev_id recd from UMAC %d",
 				      __func__,
 				      if_id);
 
@@ -194,8 +185,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 	callbk_fns = &def_priv->callbk_fns;
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event %d received from UMAC",
+	nrf_wifi_osal_log_dbg("%s: Event %d received from UMAC",
 			      __func__,
 			      event_num);
 
@@ -207,16 +197,14 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						      event_data,
 						      event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 #endif /* CONFIG_NRF700X_STA_MODE */
 #ifdef CONFIG_NRF700X_RADIO_TEST
 		get_reg_event = (struct nrf_wifi_reg *)event_data;
 
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      &fmac_dev_ctx->alpha2,
+		nrf_wifi_osal_mem_cpy(&fmac_dev_ctx->alpha2,
 				      &get_reg_event->nrf_wifi_alpha2,
 				      sizeof(get_reg_event->nrf_wifi_alpha2));
 		fmac_dev_ctx->alpha2_valid = true;
@@ -229,26 +217,22 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_data,
 							 event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 #endif /* CONFIG_NRF700X_STA_MODE */
 #ifdef CONFIG_NRF700X_RADIO_TEST
 		reg_change_event = (struct nrf_wifi_event_regulatory_change *)event_data;
 
-		fmac_dev_ctx->reg_change = nrf_wifi_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
-								    sizeof(*reg_change_event));
+		fmac_dev_ctx->reg_change = nrf_wifi_osal_mem_zalloc(sizeof(*reg_change_event));
 
 		if (!fmac_dev_ctx->reg_change) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to allocate memory for reg_change",
+			nrf_wifi_osal_log_err("%s: Failed to allocate memory for reg_change",
 					      __func__);
 			goto out;
 		}
 
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      fmac_dev_ctx->reg_change,
+		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->reg_change,
 				      reg_change_event,
 				      sizeof(*reg_change_event));
 		fmac_dev_ctx->reg_set_status = true;
@@ -261,8 +245,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_data,
 							 event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -272,8 +255,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_data,
 							event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -283,8 +265,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_data,
 							 event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -298,8 +279,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							    event_len,
 							    more_res);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -307,8 +287,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 		evnt_vif_state = (struct nrf_wifi_umac_event_vif_state *)event_data;
 
 		if (evnt_vif_state->status < 0) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to set interface flags: %d",
+			nrf_wifi_osal_log_err("%s: Failed to set interface flags: %d",
 					      __func__,
 						evnt_vif_state->status);
 			goto out;
@@ -322,8 +301,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_data,
 							event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -337,8 +315,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						       event_len,
 						       more_res);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -348,8 +325,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_data,
 							event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -359,8 +335,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_data,
 							 event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -370,8 +345,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_data,
 						     event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -381,8 +355,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						       event_data,
 						       event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -392,8 +365,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						      event_data,
 						      event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -403,8 +375,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_data,
 							 event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -414,8 +385,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						       event_data,
 						       event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -425,8 +395,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_data,
 						     event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -436,8 +405,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_data,
 						     event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -447,8 +415,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_data,
 							 event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -458,8 +425,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_data,
 							event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -470,8 +436,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 								  event_data,
 								  event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -481,8 +446,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						     event_data,
 						     event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -492,8 +456,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							event_data,
 							event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -503,8 +466,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							   event_data,
 							   event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -514,8 +476,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						    event_data,
 						    event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -524,8 +485,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 		struct nrf_wifi_umac_event_cmd_status *cmd_status =
 			(struct nrf_wifi_umac_event_cmd_status *)event_data;
 #endif
-		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Command %d -> status %d",
+		nrf_wifi_osal_log_dbg("%s: Command %d -> status %d",
 				      __func__,
 				      cmd_status->cmd_id,
 				      cmd_status->cmd_status);
@@ -541,8 +501,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						      event_data,
 						      event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -560,8 +519,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 						  event_data,
 						  event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -571,8 +529,7 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							 event_data,
 							 event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
@@ -583,23 +540,20 @@ static enum nrf_wifi_status umac_event_ctrl_process(struct nrf_wifi_fmac_dev_ctx
 							    event_data,
 							    event_len);
 		else
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No callback registered for event %d",
+			nrf_wifi_osal_log_err("%s: No callback registered for event %d",
 					      __func__,
 					      umac_hdr->cmd_evnt);
 		break;
 #endif /* CONFIG_NRF700X_STA_MODE */
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 	default:
-		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No callback registered for event %d",
+		nrf_wifi_osal_log_dbg("%s: No callback registered for event %d",
 				      __func__,
 				      umac_hdr->cmd_evnt);
 		break;
 	}
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event %d processed",
+	nrf_wifi_osal_log_dbg("%s: Event %d processed",
 			      __func__,
 			      event_num);
 
@@ -623,16 +577,14 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	}
 
 	if (!umac_head) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
 
 	event = ((struct nrf_wifi_umac_head *)umac_head)->cmd;
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event %d received from UMAC",
+	nrf_wifi_osal_log_dbg("%s: Event %d received from UMAC",
 			      __func__,
 			      event);
 
@@ -640,32 +592,25 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	case NRF_WIFI_CMD_RX_BUFF:
 #ifdef CONFIG_NRF700X_RX_DONE_WQ_ENABLED
 		struct nrf_wifi_rx_buff *config = nrf_wifi_osal_mem_zalloc(
-			fmac_dev_ctx->fpriv->opriv,
 			sizeof(struct nrf_wifi_rx_buff));
 		if (!config) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to allocate memory (RX)",
+			nrf_wifi_osal_log_err("%s: Failed to allocate memory (RX)",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			break;
 		}
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-					config,
-					umac_head,
-					sizeof(struct nrf_wifi_rx_buff));
-		status = nrf_wifi_utils_q_enqueue(fmac_dev_ctx->fpriv->opriv,
-					 def_dev_ctx->rx_config.rx_tasklet_event_q,
-					 config);
+		nrf_wifi_osal_mem_cpy(config,
+				      umac_head,
+				      sizeof(struct nrf_wifi_rx_buff));
+		status = nrf_wifi_utils_q_enqueue(def_dev_ctx->rx_config.rx_tasklet_event_q,
+						  config);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to enqueue RX buffer",
+			nrf_wifi_osal_log_err("%s: Failed to enqueue RX buffer",
 					      __func__);
-			nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-					       config);
+			nrf_wifi_osal_mem_free(config);
 			break;
 		}
-		nrf_wifi_osal_tasklet_schedule(fmac_dev_ctx->fpriv->opriv,
-					       def_dev_ctx->rx_tasklet);
+		nrf_wifi_osal_tasklet_schedule(def_dev_ctx->rx_tasklet);
 #else
 		status = nrf_wifi_fmac_rx_event_process(fmac_dev_ctx,
 							umac_head);
@@ -675,32 +620,25 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	case NRF_WIFI_CMD_TX_BUFF_DONE:
 #ifdef CONFIG_NRF700X_TX_DONE_WQ_ENABLED
 		struct nrf_wifi_tx_buff_done *config = nrf_wifi_osal_mem_zalloc(
-					fmac_dev_ctx->fpriv->opriv,
 					sizeof(struct nrf_wifi_tx_buff_done));
 		if (!config) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to allocate memory (TX)",
+			nrf_wifi_osal_log_err("%s: Failed to allocate memory (TX)",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			break;
 		}
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-					config,
-					umac_head,
-					sizeof(struct nrf_wifi_tx_buff_done));
-		status = nrf_wifi_utils_q_enqueue(fmac_dev_ctx->fpriv->opriv,
-			def_dev_ctx->tx_config.tx_done_tasklet_event_q,
-			config);
+		nrf_wifi_osal_mem_cpy(config,
+				      umac_head,
+				      sizeof(struct nrf_wifi_tx_buff_done));
+		status = nrf_wifi_utils_q_enqueue(def_dev_ctx->tx_config.tx_done_tasklet_event_q,
+						  config);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Failed to enqueue TX buffer",
+			nrf_wifi_osal_log_err("%s: Failed to enqueue TX buffer",
 					      __func__);
-			nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-					       config);
+			nrf_wifi_osal_mem_free(config);
 			break;
 		}
-		nrf_wifi_osal_tasklet_schedule(fmac_dev_ctx->fpriv->opriv,
-				def_dev_ctx->tx_done_tasklet);
+		nrf_wifi_osal_tasklet_schedule(def_dev_ctx->tx_done_tasklet);
 #else
 		status = nrf_wifi_fmac_tx_done_event_process(fmac_dev_ctx,
 								umac_head);
@@ -733,8 +671,7 @@ nrf_wifi_fmac_data_event_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 out:
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed for event = %d",
+		nrf_wifi_osal_log_err("%s: Failed for event = %d",
 				      __func__,
 				      event);
 	}
@@ -763,8 +700,7 @@ nrf_wifi_fmac_data_events_process(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 							  umac_head);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: umac_process_data_event failed",
+			nrf_wifi_osal_log_err("%s: umac_process_data_event failed",
 					      __func__);
 			goto out;
 		}
@@ -790,8 +726,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	if (!event) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -799,8 +734,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 	rf_test_event = ((struct nrf_wifi_event_rftest *)event);
 
 	if (rf_test_event->rf_test_info.rfevent[0] != def_dev_ctx->rf_test_type) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid event type (%d) recd for RF test type (%d)",
+		nrf_wifi_osal_log_err("%s: Invalid event type (%d) recd for RF test type (%d)",
 				      __func__,
 				      rf_test_event->rf_test_info.rfevent[0],
 				      def_dev_ctx->rf_test_type);
@@ -822,45 +756,40 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 		break;
 
 	case NRF_WIFI_RF_TEST_GET_TEMPERATURE:
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv, &rf_test_get_temperature,
-			(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
-			sizeof(rf_test_get_temperature));
+		nrf_wifi_osal_mem_cpy(&rf_test_get_temperature,
+				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
+				sizeof(rf_test_get_temperature));
 
 		if (rf_test_get_temperature.readTemperatureStatus) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Temperature reading failed");
+			nrf_wifi_osal_log_err("Temperature reading failed");
 		} else {
-			nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-			"The temperature is = %d degree celsius",
-			rf_test_get_temperature.temperature);
+			nrf_wifi_osal_log_info("The temperature is = %d degree celsius",
+					       rf_test_get_temperature.temperature);
 		}
 		break;
 	case NRF_WIFI_RF_TEST_EVENT_RF_RSSI:
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv, &rf_get_rf_rssi,
-			(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
-			sizeof(rf_get_rf_rssi));
+		nrf_wifi_osal_mem_cpy(&rf_get_rf_rssi,
+				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
+				sizeof(rf_get_rf_rssi));
 
-		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-		"RF RSSI value is = %d",
-		rf_get_rf_rssi.agc_status_val);
+		nrf_wifi_osal_log_info("RF RSSI value is = %d",
+				       rf_get_rf_rssi.agc_status_val);
 		break;
 	case NRF_WIFI_RF_TEST_EVENT_XO_CALIB:
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv, &xo_calib_params,
-			(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
-			sizeof(xo_calib_params));
+		nrf_wifi_osal_mem_cpy(&xo_calib_params,
+				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
+				sizeof(xo_calib_params));
 
-		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-		"XO value configured is = %d",
-		xo_calib_params.xo_val);
+		nrf_wifi_osal_log_info("XO value configured is = %d",
+				       xo_calib_params.xo_val);
 		break;
 	case NRF_WIFI_RF_TEST_XO_TUNE:
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv, &rf_get_xo_value_params,
-			(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
-			sizeof(rf_get_xo_value_params));
+		nrf_wifi_osal_mem_cpy(&rf_get_xo_value_params,
+				(const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
+				sizeof(rf_get_xo_value_params));
 
-		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-		"Best XO value is = %d",
-		rf_get_xo_value_params.xo_value);
+		nrf_wifi_osal_log_info("Best XO value is = %d",
+				       rf_get_xo_value_params.xo_value);
 		break;
 	default:
 		break;
@@ -884,23 +813,20 @@ static enum nrf_wifi_status umac_event_stats_process(struct nrf_wifi_fmac_dev_ct
 	struct nrf_wifi_umac_event_stats *stats = NULL;
 
 	if (!event) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
 
 	if (!fmac_dev_ctx->stats_req) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Stats recd when req was not sent!",
+		nrf_wifi_osal_log_err("%s: Stats recd when req was not sent!",
 				      __func__);
 		goto out;
 	}
 
 	stats = ((struct nrf_wifi_umac_event_stats *)event);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      fmac_dev_ctx->fw_stats,
+	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fw_stats,
 			      &stats->fw,
 			      sizeof(*fmac_dev_ctx->fw_stats));
 
@@ -998,8 +924,7 @@ nrf_wifi_fmac_if_mode_set_event_proc(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		}
 #endif
 	} else {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Set mode failed!",
+		nrf_wifi_osal_log_err("%s: Set mode failed!",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 	}
@@ -1093,8 +1018,7 @@ static enum nrf_wifi_status umac_process_sys_events(struct nrf_wifi_fmac_dev_ctx
 		break;
 #endif /* CONFIG_NRF700X_RAW_DATA_RX || CONFIG_NRF700X_PROMISC_DATA_RX */
 	default:
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unknown event recd: %d",
+		nrf_wifi_osal_log_err("%s: Unknown event recd: %d",
 				      __func__,
 				      ((struct nrf_wifi_sys_head *)sys_head)->cmd_event);
 		break;
@@ -1121,8 +1045,7 @@ enum nrf_wifi_status nrf_wifi_fmac_event_callback(void *mac_dev_ctx,
 	umac_msg_len = rpu_msg->hdr.len;
 	umac_msg_type = umac_hdr->cmd_evnt;
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Event type %d recd",
+	nrf_wifi_osal_log_dbg("%s: Event type %d recd",
 			      __func__,
 			      rpu_msg->type);
 
@@ -1139,8 +1062,7 @@ enum nrf_wifi_status nrf_wifi_fmac_event_callback(void *mac_dev_ctx,
 						 rpu_msg->hdr.len);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: umac_event_ctrl_process failed",
+			nrf_wifi_osal_log_err("%s: umac_event_ctrl_process failed",
 					      __func__);
 			goto out;
 		}

--- a/nrf_wifi/fw_if/umac_if/src/fmac_ap.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_ap.c
@@ -28,8 +28,7 @@ enum nrf_wifi_status sap_client_ps_get_frames(struct nrf_wifi_fmac_dev_ctx *fmac
 	struct nrf_wifi_fmac_priv_def *def_priv = NULL;
 
 	if (!fmac_dev_ctx || !config) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid params",
+		nrf_wifi_osal_log_err("%s: Invalid params",
 				      __func__);
 		goto out;
 	}
@@ -37,19 +36,16 @@ enum nrf_wifi_status sap_client_ps_get_frames(struct nrf_wifi_fmac_dev_ctx *fmac
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 	def_priv = wifi_fmac_priv(fmac_dev_ctx->fpriv);
 
-	nrf_wifi_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
-				    def_dev_ctx->tx_config.tx_lock);
+	nrf_wifi_osal_spinlock_take(def_dev_ctx->tx_config.tx_lock);
 
 	id = nrf_wifi_fmac_peer_get_id(fmac_dev_ctx, config->mac_addr);
 
 	if (id == -1) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid Peer_ID, Mac Addr =%pM",
+		nrf_wifi_osal_log_err("%s: Invalid Peer_ID, Mac Addr =%pM",
 				      __func__,
 				      config->mac_addr);
 
-		nrf_wifi_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
-					   def_dev_ctx->tx_config.tx_lock);
+		nrf_wifi_osal_spinlock_rel(def_dev_ctx->tx_config.tx_lock);
 		goto out;
 	}
 
@@ -60,8 +56,7 @@ enum nrf_wifi_status sap_client_ps_get_frames(struct nrf_wifi_fmac_dev_ctx *fmac
 	wakeup_client_q = def_dev_ctx->tx_config.wakeup_client_q;
 
 	if (wakeup_client_q) {
-		nrf_wifi_utils_q_enqueue(fmac_dev_ctx->fpriv->opriv,
-					 wakeup_client_q,
+		nrf_wifi_utils_q_enqueue(wakeup_client_q,
 					 peer);
 	}
 
@@ -73,8 +68,7 @@ enum nrf_wifi_status sap_client_ps_get_frames(struct nrf_wifi_fmac_dev_ctx *fmac
 		}
 	}
 
-	nrf_wifi_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
-				   def_dev_ctx->tx_config.tx_lock);
+	nrf_wifi_osal_spinlock_rel(def_dev_ctx->tx_config.tx_lock);
 
 	status = NRF_WIFI_STATUS_SUCCESS;
 out:
@@ -95,8 +89,7 @@ enum nrf_wifi_status sap_client_update_pmmode(struct nrf_wifi_fmac_dev_ctx *fmac
 	struct nrf_wifi_fmac_priv_def *def_priv = NULL;
 
 	if (!fmac_dev_ctx || !config) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid params",
+		nrf_wifi_osal_log_err("%s: Invalid params",
 				      __func__);
 		goto out;
 	}
@@ -104,20 +97,17 @@ enum nrf_wifi_status sap_client_update_pmmode(struct nrf_wifi_fmac_dev_ctx *fmac
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 	def_priv = wifi_fmac_priv(fmac_dev_ctx->fpriv);
 
-	nrf_wifi_osal_spinlock_take(fmac_dev_ctx->fpriv->opriv,
-				    def_dev_ctx->tx_config.tx_lock);
+	nrf_wifi_osal_spinlock_take(def_dev_ctx->tx_config.tx_lock);
 
 	id = nrf_wifi_fmac_peer_get_id(fmac_dev_ctx,
 				       config->mac_addr);
 
 	if (id == -1) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid Peer_ID, Mac address = %pM",
+		nrf_wifi_osal_log_err("%s: Invalid Peer_ID, Mac address = %pM",
 				      __func__,
 				      config->mac_addr);
 
-		nrf_wifi_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
-					   def_dev_ctx->tx_config.tx_lock);
+		nrf_wifi_osal_spinlock_rel(def_dev_ctx->tx_config.tx_lock);
 
 		goto out;
 	}
@@ -130,8 +120,7 @@ enum nrf_wifi_status sap_client_update_pmmode(struct nrf_wifi_fmac_dev_ctx *fmac
 		wakeup_client_q = def_dev_ctx->tx_config.wakeup_client_q;
 
 		if (wakeup_client_q) {
-			nrf_wifi_utils_q_enqueue(fmac_dev_ctx->fpriv->opriv,
-						 wakeup_client_q,
+			nrf_wifi_utils_q_enqueue(wakeup_client_q,
 						 peer);
 		}
 
@@ -144,8 +133,7 @@ enum nrf_wifi_status sap_client_update_pmmode(struct nrf_wifi_fmac_dev_ctx *fmac
 		}
 	}
 
-	nrf_wifi_osal_spinlock_rel(fmac_dev_ctx->fpriv->opriv,
-				   def_dev_ctx->tx_config.tx_lock);
+	nrf_wifi_osal_spinlock_rel(def_dev_ctx->tx_config.tx_lock);
 
 	status = NRF_WIFI_STATUS_SUCCESS;
 

--- a/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_api_common.c
@@ -45,32 +45,28 @@ static int nrf_wifi_patch_version_compat(struct nrf_wifi_fmac_dev_ctx *fmac_dev_
 	patch = (version >> 0) & 0xff;
 
 	if (family != RPU_FAMILY) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Incompatible RPU version: %d, expected: %d",
-			family, RPU_FAMILY);
+		nrf_wifi_osal_log_err("Incompatible RPU version: %d, expected: %d",
+				      family, RPU_FAMILY);
 		return -1;
 	}
 
 	if (major != RPU_MAJOR_VERSION) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Incompatible RPU major version: %d, expected: %d",
-			major, RPU_MAJOR_VERSION);
+		nrf_wifi_osal_log_err("Incompatible RPU major version: %d, expected: %d",
+				      major, RPU_MAJOR_VERSION);
 		return -1;
 	}
 
 	/* TODO: Allow minor version to be different */
 	if (minor != RPU_MINOR_VERSION) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Incompatible RPU minor version: %d, expected: %d",
-			minor, RPU_MINOR_VERSION);
+		nrf_wifi_osal_log_err("Incompatible RPU minor version: %d, expected: %d",
+				      minor, RPU_MINOR_VERSION);
 		return -1;
 	}
 
 	/* TODO: Allow patch version to be different */
 	if (patch != RPU_PATCH_VERSION) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Incompatible RPU patch version: %d, expected: %d",
-			patch, RPU_PATCH_VERSION);
+		nrf_wifi_osal_log_err("Incompatible RPU patch version: %d, expected: %d",
+				      patch, RPU_PATCH_VERSION);
 		return -1;
 	}
 
@@ -82,32 +78,27 @@ static int nrf_wifi_patch_feature_flags_compat(struct nrf_wifi_fmac_dev_ctx *fma
 {
 #ifdef CONFIG_NRF700X_RADIO_TEST
 	if (!(feature_flags & NRF70_FEAT_RADIO_TEST)) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Radio test feature flag not set");
+		nrf_wifi_osal_log_err("Radio test feature flag not set");
 		return -1;
 	}
 #elif defined(CONFIG_NRF700X_SCAN_ONLY)
 	if (!(feature_flags & NRF70_FEAT_SCAN_ONLY)) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Scan only feature flag not set");
+		nrf_wifi_osal_log_err("Scan only feature flag not set");
 		return -1;
 	}
 #elif defined(CONFIG_NRF700X_SYSTEM_MODE)
 	if (!(feature_flags & NRF70_FEAT_SYSTEM_MODE)) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"System mode feature flag not set");
+		nrf_wifi_osal_log_err("System mode feature flag not set");
 		return -1;
 	}
 #elif defined(CONFIG_NRF700X_SYSTEM_WITH_RAW_MODES)
 	if (!(feature_flags & NRF70_FEAT_SYSTEM_WITH_RAW_MODES)) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"System with raw modes feature flag not set");
+		nrf_wifi_osal_log_err("System with raw modes feature flag not set");
 		return -1;
 	}
 #else
-	nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-		"Invalid feature flags: 0x%x or build configuration",
-		feature_flags);
+	nrf_wifi_osal_log_err("Invalid feature flags: 0x%x or build configuration",
+			      feature_flags);
 #endif
 
 	return 0;
@@ -117,38 +108,30 @@ enum nrf_wifi_status nrf_wifi_validate_fw_header(struct nrf_wifi_fmac_dev_ctx *f
 						 struct nrf70_fw_image_info *info)
 {
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-		"Signature: 0x%x", info->signature);
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-		"num_images: %d", info->num_images);
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-		"version: 0x%x", info->version);
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-		"feature_flags: %d", info->feature_flags);
+	nrf_wifi_osal_log_dbg("Signature: 0x%x", info->signature);
+	nrf_wifi_osal_log_dbg("num_images: %d", info->num_images);
+	nrf_wifi_osal_log_dbg("version: 0x%x", info->version);
+	nrf_wifi_osal_log_dbg("feature_flags: %d", info->feature_flags);
 
 	if (info->signature != NRF_WIFI_PATCH_SIGNATURE) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Invalid patch signature: 0x%x, expected: 0x%x",
-			info->signature, NRF_WIFI_PATCH_SIGNATURE);
+		nrf_wifi_osal_log_err("Invalid patch signature: 0x%x, expected: 0x%x",
+				      info->signature, NRF_WIFI_PATCH_SIGNATURE);
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
 	if (info->num_images != NRF_WIFI_PATCH_NUM_IMAGES) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Invalid number of images, expected %d, got %d",
-			NRF_WIFI_PATCH_NUM_IMAGES, info->num_images);
+		nrf_wifi_osal_log_err("Invalid number of images, expected %d, got %d",
+				      NRF_WIFI_PATCH_NUM_IMAGES, info->num_images);
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
 	if (nrf_wifi_patch_version_compat(fmac_dev_ctx, info->version) != 0) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Incompatible patch");
+		nrf_wifi_osal_log_err("Incompatible patch");
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
 	if (nrf_wifi_patch_feature_flags_compat(fmac_dev_ctx, info->feature_flags) != 0) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Incompatible feature flags");
+		nrf_wifi_osal_log_err("Incompatible feature flags");
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
@@ -165,46 +148,39 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_parse(struct nrf_wifi_fmac_dev_ctx *fmac_d
 	unsigned int image_id;
 
 	if (!fw_data || !fw_size || !fw_info) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Invalid parameters");
+		nrf_wifi_osal_log_err("Invalid parameters");
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
 	if (fw_size < sizeof(struct nrf70_fw_image_info)) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Invalid fw_size: %d, minimum size: %d",
+		nrf_wifi_osal_log_err("Invalid fw_size: %d, minimum size: %d",
 			fw_size, sizeof(struct nrf70_fw_image_info));
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
 
 	if (nrf_wifi_validate_fw_header(fmac_dev_ctx, info) != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			"Invalid fw header");
+		nrf_wifi_osal_log_err("Invalid fw header");
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
 	offset = sizeof(struct nrf70_fw_image_info);
 
-	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv, "====");
+	nrf_wifi_osal_log_dbg("====");
 	for (image_id = 0; image_id < info->num_images; image_id++) {
 		struct nrf70_fw_image *image =
 			(struct nrf70_fw_image *)((char *)fw_data + offset);
 		const void *data = (char *)fw_data + offset + sizeof(struct nrf70_fw_image);
 
 		if (offset + sizeof(struct nrf70_fw_image) + image->len > fw_size) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				"Invalid fw_size: %d for image[%d] len: %d",
-				fw_size, image_id, image->len);
+			nrf_wifi_osal_log_err("Invalid fw_size: %d for image[%d] len: %d",
+					      fw_size, image_id, image->len);
 			return NRF_WIFI_STATUS_FAIL;
 		}
 
-		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			"image[%d] type: %d", image_id, image->type);
-		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			"image[%d] len: %d", image_id, image->len);
-		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-			"====");
+		nrf_wifi_osal_log_dbg("image[%d] type: %d", image_id, image->type);
+		nrf_wifi_osal_log_dbg("image[%d] len: %d", image_id, image->len);
+		nrf_wifi_osal_log_dbg("====");
 
 		switch (image_id) {
 		case NRF70_IMAGE_LMAC_PRI:
@@ -224,8 +200,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_parse(struct nrf_wifi_fmac_dev_ctx *fmac_d
 			fw_info->umac_patch_sec.size = image->len;
 			break;
 		default:
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				"Invalid image id: %d", image_id);
+			nrf_wifi_osal_log_err("Invalid image id: %d", image_id);
 			break;
 		}
 
@@ -245,8 +220,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_reset(struct nrf_wifi_fmac_dev_ctx *fmac_d
 						 wifi_proc[i].type);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: %s processor reset failed\n",
+			nrf_wifi_osal_log_err("%s: %s processor reset failed\n",
 					      __func__, wifi_proc[i].name);
 			return NRF_WIFI_STATUS_FAIL;
 		}
@@ -266,8 +240,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_boot(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						    wifi_proc[i].is_patch_present);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: %s processor ROM boot failed\n",
+			nrf_wifi_osal_log_err("%s: %s processor ROM boot failed\n",
 					      __func__, wifi_proc[i].name);
 			return NRF_WIFI_STATUS_FAIL;
 		}
@@ -276,8 +249,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_boot(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						  wifi_proc[i].type);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: %s processor ROM boot check failed\n",
+			nrf_wifi_osal_log_err("%s: %s processor ROM boot check failed\n",
 					      __func__, wifi_proc[i].name);
 			return NRF_WIFI_STATUS_FAIL;
 		}
@@ -305,8 +277,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	status = nrf_wifi_fmac_fw_reset(fmac_dev_ctx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: FW reset failed\n",
+		nrf_wifi_osal_log_err("%s: FW reset failed\n",
 				      __func__);
 		goto out;
 	}
@@ -322,13 +293,11 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						    fmac_fw->umac_patch_sec.size);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC patch load failed\n",
+			nrf_wifi_osal_log_err("%s: UMAC patch load failed\n",
 					      __func__);
 			goto out;
 		} else {
-			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: UMAC patches loaded\n",
+			nrf_wifi_osal_log_dbg("%s: UMAC patches loaded\n",
 					      __func__);
 		}
 	} else {
@@ -346,13 +315,11 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 						    fmac_fw->lmac_patch_sec.size);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC patch load failed\n",
+			nrf_wifi_osal_log_err("%s: LMAC patch load failed\n",
 					      __func__);
 			goto out;
 		} else {
-			nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-					      "%s: LMAC patches loaded\n",
+			nrf_wifi_osal_log_dbg("%s: LMAC patches loaded\n",
 					      __func__);
 		}
 	} else {
@@ -361,8 +328,7 @@ enum nrf_wifi_status nrf_wifi_fmac_fw_load(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	status = nrf_wifi_fmac_fw_boot(fmac_dev_ctx);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: FW boot failed\n",
+		nrf_wifi_osal_log_err("%s: FW boot failed\n",
 				      __func__);
 		goto out;
 	}
@@ -391,12 +357,10 @@ struct nrf_wifi_fmac_dev_ctx *nrf_wifi_fmac_dev_add(struct nrf_wifi_fmac_priv *f
 		return NULL;
 	}
 
-	fmac_dev_ctx = nrf_wifi_osal_mem_zalloc(fpriv->opriv,
-						sizeof(*fmac_dev_ctx) + sizeof(*fmac_dev_priv));
+	fmac_dev_ctx = nrf_wifi_osal_mem_zalloc(sizeof(*fmac_dev_ctx) + sizeof(*fmac_dev_priv));
 
 	if (!fmac_dev_ctx) {
-		nrf_wifi_osal_log_err(fpriv->opriv,
-				      "%s: Unable to allocate fmac_dev_ctx",
+		nrf_wifi_osal_log_err("%s: Unable to allocate fmac_dev_ctx",
 				      __func__);
 		goto out;
 	}
@@ -408,12 +372,10 @@ struct nrf_wifi_fmac_dev_ctx *nrf_wifi_fmac_dev_add(struct nrf_wifi_fmac_priv *f
 							 fmac_dev_ctx);
 
 	if (!fmac_dev_ctx->hal_dev_ctx) {
-		nrf_wifi_osal_log_err(fpriv->opriv,
-				      "%s: nrf_wifi_hal_dev_add failed",
+		nrf_wifi_osal_log_err("%s: nrf_wifi_hal_dev_add failed",
 				      __func__);
 
-		nrf_wifi_osal_mem_free(fpriv->opriv,
-				       fmac_dev_ctx);
+		nrf_wifi_osal_mem_free(fmac_dev_ctx);
 		fmac_dev_ctx = NULL;
 		goto out;
 	}
@@ -449,8 +411,7 @@ enum nrf_wifi_status nrf_wifi_fmac_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 	    (stats_type == RPU_STATS_TYPE_LMAC) ||
 	    (stats_type == RPU_STATS_TYPE_PHY)) {
 		if (fmac_dev_ctx->stats_req == true) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Stats request already pending",
+			nrf_wifi_osal_log_err("%s: Stats request already pending",
 					      __func__);
 			goto out;
 		}
@@ -469,15 +430,13 @@ enum nrf_wifi_status nrf_wifi_fmac_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 		}
 
 		do {
-			nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-					       1);
+			nrf_wifi_osal_sleep_ms(1);
 			count++;
 		} while ((fmac_dev_ctx->stats_req == true) &&
 			 (count < NRF_WIFI_FMAC_STATS_RECV_TIMEOUT));
 
 		if (count == NRF_WIFI_FMAC_STATS_RECV_TIMEOUT) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Timed out",
+			nrf_wifi_osal_log_err("%s: Timed out",
 					      __func__);
 			goto out;
 		}
@@ -488,8 +447,7 @@ enum nrf_wifi_status nrf_wifi_fmac_stats_get(struct nrf_wifi_fmac_dev_ctx *fmac_
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 	if ((stats_type == RPU_STATS_TYPE_ALL) ||
 	    (stats_type == RPU_STATS_TYPE_HOST)) {
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      &stats->host,
+		nrf_wifi_osal_mem_cpy(&stats->host,
 				      &def_dev_ctx->host_stats,
 				      sizeof(def_dev_ctx->host_stats));
 	}
@@ -511,8 +469,7 @@ enum nrf_wifi_status nrf_wifi_fmac_ver_get(struct nrf_wifi_fmac_dev_ctx *fmac_de
 				  sizeof(*fw_ver));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to read UMAC ver",
+		nrf_wifi_osal_log_err("%s: Unable to read UMAC ver",
 				      __func__);
 		goto out;
 	}
@@ -554,14 +511,12 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 	unsigned int otp_mac_addr_flag_mask = 0;
 
 	if (!fmac_dev_ctx || !mac_addr || (vif_idx >= MAX_NUM_VIFS)) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &otp_info,
+	nrf_wifi_osal_mem_set(&otp_info,
 			      0xFF,
 			      sizeof(otp_info));
 
@@ -570,8 +525,7 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 					   &otp_info.flags);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU OTP information failed",
+		nrf_wifi_osal_log_err("%s: Fetching of RPU OTP information failed",
 				      __func__);
 		goto out;
 	}
@@ -588,20 +542,16 @@ enum nrf_wifi_status nrf_wifi_fmac_otp_mac_addr_get(struct nrf_wifi_fmac_dev_ctx
 	/* Check if a valid MAC address has been programmed in the OTP */
 
 	if (otp_info.flags & otp_mac_addr_flag_mask) {
-		nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-				       "%s: MAC addr not programmed in OTP",
+		nrf_wifi_osal_log_info("%s: MAC addr not programmed in OTP",
 				       __func__);
 
 	} else {
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      mac_addr,
+		nrf_wifi_osal_mem_cpy(mac_addr,
 				      otp_mac_addr,
 				      NRF_WIFI_ETH_ADDR_LEN);
 
-		if (!nrf_wifi_utils_is_mac_addr_valid(fmac_dev_ctx->fpriv->opriv,
-						      (const char *)mac_addr)) {
-			nrf_wifi_osal_log_info(fmac_dev_ctx->fpriv->opriv,
-					       "%s:  Invalid OTP MAC addr: %02X%02X%02X%02X%02X%02X",
+		if (!nrf_wifi_utils_is_mac_addr_valid((const char *)mac_addr)) {
+			nrf_wifi_osal_log_info("%s:  Invalid OTP MA: %02X%02X%02X%02X%02X%02X",
 					       __func__,
 					       (*(mac_addr + 0)),
 					       (*(mac_addr + 1)),
@@ -632,16 +582,14 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 	unsigned char backoff_5g_lowband = 0, backoff_5g_midband = 0, backoff_5g_highband = 0;
 
 	if (!fmac_dev_ctx || !phy_rf_params) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
 
 	tx_pwr_ceil_params = fmac_dev_ctx->tx_pwr_ceil_params;
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &otp_info,
+	nrf_wifi_osal_mem_set(&otp_info,
 			      0xFF,
 			      sizeof(otp_info));
 
@@ -650,8 +598,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 					   &otp_info.flags);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU OTP information failed",
+		nrf_wifi_osal_log_err("%s: Fetching of RPU OTP information failed",
 				      __func__);
 		goto out;
 	}
@@ -659,8 +606,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 	status = nrf_wifi_hal_otp_ft_prog_ver_get(fmac_dev_ctx->hal_dev_ctx,
 						  &ft_prog_ver);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of FT program version failed",
+		nrf_wifi_osal_log_err("%s: Fetching of FT program version failed",
 				      __func__);
 		goto out;
 	}
@@ -668,27 +614,23 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_params_get(
 	status = nrf_wifi_hal_otp_pack_info_get(fmac_dev_ctx->hal_dev_ctx,
 						&package_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of Package info failed",
+		nrf_wifi_osal_log_err("%s: Fetching of Package info failed",
 				      __func__);
 		goto out;
 	}
 
-	ret = nrf_wifi_phy_rf_params_init(fmac_dev_ctx->fpriv->opriv,
-				    	  phy_rf_params,
+	ret = nrf_wifi_phy_rf_params_init(phy_rf_params,
 				    	  package_info,
 				    	  NRF_WIFI_DEF_RF_PARAMS);
 
 	if (ret == -1) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Initialization of RF params with default values failed",
+		nrf_wifi_osal_log_err("%s: Initialization of RF params with default values failed",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
 	}
 	if (!(otp_info.flags & (~CALIB_XO_FLAG_MASK))) {
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      &phy_rf_params->xo_offset.xo_freq_offset,
+		nrf_wifi_osal_mem_cpy(&phy_rf_params->xo_offset.xo_freq_offset,
 				      (char *)otp_info.info.calib + OTP_OFF_CALIB_XO,
 				      OTP_SZ_CALIB_XO);
 
@@ -764,8 +706,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	struct nrf_wifi_event_regulatory_change *reg_change = NULL;
 
 	if (!fmac_dev_ctx || !reg_info) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -773,31 +714,26 @@ enum nrf_wifi_status nrf_wifi_fmac_set_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	/* No change event from UMAC for same regd */
 	status = nrf_wifi_fmac_get_reg(fmac_dev_ctx, &cur_reg_info);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to get current regulatory information",
+		nrf_wifi_osal_log_err("%s: Failed to get current regulatory information",
 				      __func__);
 		goto out;
 	}
 
-	if (nrf_wifi_osal_mem_cmp(fmac_dev_ctx->fpriv->opriv,
-				  cur_reg_info.alpha2,
+	if (nrf_wifi_osal_mem_cmp(cur_reg_info.alpha2,
 				  reg_info->alpha2,
 				  NRF_WIFI_COUNTRY_CODE_LEN) == 0) {
-		nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
-				       "%s: Regulatory domain already set to %c%c",
-				       __func__,
-				       reg_info->alpha2[0],
-				       reg_info->alpha2[1]);
+		nrf_wifi_osal_log_dbg("%s: Regulatory domain already set to %c%c",
+				      __func__,
+				      reg_info->alpha2[0],
+				      reg_info->alpha2[1]);
 		status = NRF_WIFI_STATUS_SUCCESS;
 		goto out;
 	}
 
-	set_reg_cmd = nrf_wifi_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
-					       sizeof(*set_reg_cmd));
+	set_reg_cmd = nrf_wifi_osal_mem_zalloc(sizeof(*set_reg_cmd));
 
 	if (!set_reg_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory",
+		nrf_wifi_osal_log_err("%s: Unable to allocate memory",
 				      __func__);
 		goto out;
 	}
@@ -805,8 +741,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	set_reg_cmd->umac_hdr.cmd_evnt = NRF_WIFI_UMAC_CMD_REQ_SET_REG;
 	set_reg_cmd->umac_hdr.ids.valid_fields = 0;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      set_reg_cmd->nrf_wifi_alpha2,
+	nrf_wifi_osal_mem_cpy(set_reg_cmd->nrf_wifi_alpha2,
 			      reg_info->alpha2,
 			      NRF_WIFI_COUNTRY_CODE_LEN);
 
@@ -828,21 +763,18 @@ enum nrf_wifi_status nrf_wifi_fmac_set_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 			      set_reg_cmd,
 			      sizeof(*set_reg_cmd));
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to set regulatory information",
+		nrf_wifi_osal_log_err("%s: Failed to set regulatory information",
 				      __func__);
 		goto out;
 	}
 
 	fmac_dev_ctx->reg_set_status = false;
 	while (!fmac_dev_ctx->reg_set_status && count++ <= max_count) {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 	}
 
 	if (!fmac_dev_ctx->reg_set_status) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to set regulatory information",
+		nrf_wifi_osal_log_err("%s: Failed to set regulatory information",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -851,50 +783,45 @@ enum nrf_wifi_status nrf_wifi_fmac_set_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	reg_change = fmac_dev_ctx->reg_change;
 
 	if (reg_change->intr != exp_initiator) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Regulatory domain change not initiated by user: exp: %d, got: %d",
+		nrf_wifi_osal_log_err("%s: Non-user initiated reg domain change: exp: %d, got: %d",
 				      __func__,
-					  exp_initiator,
-					  reg_change->intr);
+				      exp_initiator,
+				      reg_change->intr);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
 	}
 
 	if (reg_change->regulatory_type != exp_reg_type) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Regulatory domain change not to expected type: exp: %d, got: %d",
+		nrf_wifi_osal_log_err("%s: Unexpected reg domain change: exp: %d, got: %d",
 				      __func__,
-					  exp_reg_type,
-					  reg_change->regulatory_type);
+				      exp_reg_type,
+				      reg_change->regulatory_type);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
 	}
 
 	if ((reg_change->regulatory_type == NRF_WIFI_REGDOM_TYPE_COUNTRY) &&
-		 nrf_wifi_osal_mem_cmp(fmac_dev_ctx->fpriv->opriv,
-				  reg_change->nrf_wifi_alpha2,
-				  exp_alpha2,
-				  NRF_WIFI_COUNTRY_CODE_LEN) != 0) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Regulatory domain change not to expected alpha2: exp: %c%c, got: %c%c",
+		 nrf_wifi_osal_mem_cmp(reg_change->nrf_wifi_alpha2,
+				       exp_alpha2,
+				       NRF_WIFI_COUNTRY_CODE_LEN) != 0) {
+		nrf_wifi_osal_log_err("%s: Unexpected alpha2 reg domain change: "
+				      "exp: %c%c, got: %c%c",
 				      __func__,
-					  exp_alpha2[0],
-					  exp_alpha2[1],
-					  reg_change->nrf_wifi_alpha2[0],
-					  reg_change->nrf_wifi_alpha2[1]);
+				      exp_alpha2[0],
+				      exp_alpha2[1],
+				      reg_change->nrf_wifi_alpha2[0],
+				      reg_change->nrf_wifi_alpha2[1]);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
 	}
 
 out:
 	if (set_reg_cmd) {
-		nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-				       set_reg_cmd);
+		nrf_wifi_osal_mem_free(set_reg_cmd);
 	}
 
 	if (reg_change) {
-		nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-				       reg_change);
+		nrf_wifi_osal_mem_free(reg_change);
 		fmac_dev_ctx->reg_change = NULL;
 	}
 
@@ -909,18 +836,15 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 	unsigned int count = 0;
 
 	if (!fmac_dev_ctx || !reg_info) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto err;
 	}
 
-	get_reg_cmd = nrf_wifi_osal_mem_zalloc(fmac_dev_ctx->fpriv->opriv,
-					       sizeof(*get_reg_cmd));
+	get_reg_cmd = nrf_wifi_osal_mem_zalloc(sizeof(*get_reg_cmd));
 
 	if (!get_reg_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to allocate memory",
+		nrf_wifi_osal_log_err("%s: Unable to allocate memory",
 				      __func__);
 		goto err;
 	}
@@ -936,27 +860,23 @@ enum nrf_wifi_status nrf_wifi_fmac_get_reg(struct nrf_wifi_fmac_dev_ctx *fmac_de
 			      sizeof(*get_reg_cmd));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to get regulatory information",	__func__);
+		nrf_wifi_osal_log_err("%s: Failed to get regulatory information",	__func__);
 		goto err;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 	} while (count++ < 100 && !fmac_dev_ctx->alpha2_valid);
 
 	if (!fmac_dev_ctx->alpha2_valid) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Failed to get regulatory information",
+		nrf_wifi_osal_log_err("%s: Failed to get regulatory information",
 				      __func__);
 		goto err;
 	}
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-		   reg_info->alpha2,
-	       fmac_dev_ctx->alpha2,
-	       sizeof(reg_info->alpha2));
+	nrf_wifi_osal_mem_cpy(reg_info->alpha2,
+			      fmac_dev_ctx->alpha2,
+			      sizeof(reg_info->alpha2));
 
 	reg_info->reg_chan_count = fmac_dev_ctx->reg_chan_count;
 
@@ -965,16 +885,14 @@ err:
 	return NRF_WIFI_STATUS_FAIL;
 }
 
-int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
-				struct nrf_wifi_phy_rf_params *prf,
+int nrf_wifi_phy_rf_params_init(struct nrf_wifi_phy_rf_params *prf,
 				unsigned int package_info,
 				unsigned char *str)
 {
 	int ret = -1;
 	unsigned int rf_param_offset = BAND_2G_LW_ED_BKF_DSSS_OFST - NRF_WIFI_RF_PARAMS_CONF_SIZE;
 	/* Initilaize reserved bytes */
-	nrf_wifi_osal_mem_set(opriv,
-			      prf,
+	nrf_wifi_osal_mem_set(prf,
 			      0x0,
 			      sizeof(prf));
 	/* Initialize PD adjust values for MCS7. Currently these 4 bytes are not being used */
@@ -1057,10 +975,9 @@ int nrf_wifi_phy_rf_params_init(struct nrf_wifi_osal_priv *opriv,
 #endif /* CONFIG_NRF700X_RADIO_TEST */
 	}
 
-	ret = nrf_wifi_utils_hex_str_to_val(opriv,
-					(unsigned char *)&prf->phy_params,
-					sizeof(prf->phy_params),
-					str);
+	ret = nrf_wifi_utils_hex_str_to_val((unsigned char *)&prf->phy_params,
+					    sizeof(prf->phy_params),
+					    str);
 
 	prf->phy_params[rf_param_offset]  = CONFIG_NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_DSSS;
 	prf->phy_params[rf_param_offset + 1]  = CONFIG_NRF700X_BAND_2G_LOWER_EDGE_BACKOFF_HT;
@@ -1117,8 +1034,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_tx_rate(struct nrf_wifi_fmac_dev_ctx *fma
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -1148,8 +1064,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_host_rpu_ps_ctrl_state(void *dev_ctx,
 	fmac_dev_ctx = dev_ctx;
 
 	if (!fmac_dev_ctx || !rpu_ps_ctrl_state) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1159,8 +1074,7 @@ enum nrf_wifi_status nrf_wifi_fmac_get_host_rpu_ps_ctrl_state(void *dev_ctx,
 					       rpu_ps_ctrl_state);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU PS state failed",
+		nrf_wifi_osal_log_err("%s: Fetching of RPU PS state failed",
 				      __func__);
 		goto out;
 	}
@@ -1182,8 +1096,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_mode(void *dev_ctx,
 	int len = 0;
 
 	if (!fmac_dev_ctx) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1194,8 +1107,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_mode(void *dev_ctx,
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -1226,8 +1138,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_channel(void *dev_ctx,
 	int len = 0;
 
 	if (!fmac_dev_ctx) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1238,8 +1149,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_channel(void *dev_ctx,
 				  len);
 
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed",
 				      __func__);
 		goto out;
 	}
@@ -1270,8 +1180,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_packet_filter(void *dev_ctx, unsigned cha
 	int len = 0;
 
 	if (!fmac_dev_ctx) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid parameters\n",
+		nrf_wifi_osal_log_err("%s: Invalid parameters\n",
 				      __func__);
 		goto out;
 	}
@@ -1281,8 +1190,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_packet_filter(void *dev_ctx, unsigned cha
 				  NRF_WIFI_HOST_RPU_MSG_TYPE_SYSTEM,
 				  len);
 	if (!umac_cmd) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_alloc failed\n",
+		nrf_wifi_osal_log_err("%s: umac_cmd_alloc failed\n",
 				      __func__);
 		goto out;
 	}
@@ -1313,14 +1221,12 @@ enum nrf_wifi_status nrf_wifi_fmac_stats_reset(struct nrf_wifi_fmac_dev_ctx *fma
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       1);
+		nrf_wifi_osal_sleep_ms(1);
 	} while ((fmac_dev_ctx->stats_req == true) &&
 		 (count++ < NRF_WIFI_FMAC_STATS_RECV_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_STATS_RECV_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/fw_if/umac_if/src/fmac_peer.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_peer.c
@@ -71,8 +71,7 @@ int nrf_wifi_fmac_peer_add(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		peer = &def_dev_ctx->tx_config.peers[i];
 
 		if (peer->peer_id == -1) {
-			nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-					      peer->ra_addr,
+			nrf_wifi_osal_mem_cpy(peer->ra_addr,
 					      mac_addr,
 					      NRF_WIFI_ETH_ADDR_LEN);
 			peer->if_idx = if_idx;
@@ -90,8 +89,7 @@ int nrf_wifi_fmac_peer_add(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		}
 	}
 
-	nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-			      "%s: Failed !! No Space Available",
+	nrf_wifi_osal_log_err("%s: Failed !! No Space Available",
 			      __func__);
 
 	return -1;
@@ -128,8 +126,7 @@ void nrf_wifi_fmac_peer_remove(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				  NRF_WIFI_FMAC_ETH_ADDR_LEN);
 	}
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      peer,
+	nrf_wifi_osal_mem_set(peer,
 			      0x0,
 			      sizeof(struct peers_info));
 	peer->peer_id = -1;
@@ -157,8 +154,7 @@ void nrf_wifi_fmac_peers_flush(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 
 		if (peer->if_idx == if_idx) {
 
-			nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-					      peer,
+			nrf_wifi_osal_mem_set(peer,
 					      0x0,
 					      sizeof(struct peers_info));
 			peer->peer_id = -1;

--- a/nrf_wifi/fw_if/umac_if/src/fmac_util.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_util.c
@@ -89,54 +89,44 @@ void nrf_wifi_util_convert_to_eth(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	struct nrf_wifi_fmac_eth_hdr *ehdr = NULL;
 	unsigned int len = 0;
 
-	len = nrf_wifi_osal_nbuf_data_size(fmac_dev_ctx->fpriv->opriv,
-					   nwb);
+	len = nrf_wifi_osal_nbuf_data_size(nwb);
 
 	ehdr = (struct nrf_wifi_fmac_eth_hdr *)
-		nrf_wifi_osal_nbuf_data_push(fmac_dev_ctx->fpriv->opriv,
-					     nwb,
+		nrf_wifi_osal_nbuf_data_push(nwb,
 					     sizeof(struct nrf_wifi_fmac_eth_hdr));
 
 	switch (hdr->fc & (NRF_WIFI_FCTL_TODS | NRF_WIFI_FCTL_FROMDS)) {
 	case (NRF_WIFI_FCTL_TODS | NRF_WIFI_FCTL_FROMDS):
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->src,
+		nrf_wifi_osal_mem_cpy(ehdr->src,
 				      hdr->addr_4,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
 
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->dst,
+		nrf_wifi_osal_mem_cpy(ehdr->dst,
 				      hdr->addr_1,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
 		break;
 	case (NRF_WIFI_FCTL_FROMDS):
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->src,
+		nrf_wifi_osal_mem_cpy(ehdr->src,
 				      hdr->addr_3,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->dst,
+		nrf_wifi_osal_mem_cpy(ehdr->dst,
 				      hdr->addr_1,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
 		break;
 	case (NRF_WIFI_FCTL_TODS):
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->src,
+		nrf_wifi_osal_mem_cpy(ehdr->src,
 				      hdr->addr_2,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->dst,
+		nrf_wifi_osal_mem_cpy(ehdr->dst,
 				      hdr->addr_3,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
 		break;
 	default:
 		/* Both FROM and TO DS bit is zero*/
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->src,
+		nrf_wifi_osal_mem_cpy(ehdr->src,
 				      hdr->addr_2,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
-		nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-				      ehdr->dst,
+		nrf_wifi_osal_mem_cpy(ehdr->dst,
 				      hdr->addr_1,
 				      NRF_WIFI_FMAC_ETH_ADDR_LEN);
 
@@ -162,38 +152,30 @@ void nrf_wifi_util_rx_convert_amsdu_to_eth(struct nrf_wifi_fmac_dev_ctx *fmac_de
 
 	amsdu_hdr_len = sizeof(struct nrf_wifi_fmac_amsdu_hdr);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &amsdu_hdr,
-			      nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-							  nwb),
+	nrf_wifi_osal_mem_cpy(&amsdu_hdr,
+			      nrf_wifi_osal_nbuf_data_get(nwb),
 			      amsdu_hdr_len);
 
-	nwb_data = (unsigned char *)nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-								nwb) + amsdu_hdr_len;
+	nwb_data = (unsigned char *)nrf_wifi_osal_nbuf_data_get(nwb) + amsdu_hdr_len;
 
 	eth_type = nrf_wifi_util_rx_get_eth_type(fmac_dev_ctx,
 						 nwb_data);
 
-	nrf_wifi_osal_nbuf_data_pull(fmac_dev_ctx->fpriv->opriv,
-				     nwb,
+	nrf_wifi_osal_nbuf_data_pull(nwb,
 				     (amsdu_hdr_len +
 				      nrf_wifi_util_get_skip_header_bytes(eth_type)));
 
-	len = nrf_wifi_osal_nbuf_data_size(fmac_dev_ctx->fpriv->opriv,
-					   nwb);
+	len = nrf_wifi_osal_nbuf_data_size(nwb);
 
 	ehdr = (struct nrf_wifi_fmac_eth_hdr *)
-		nrf_wifi_osal_nbuf_data_push(fmac_dev_ctx->fpriv->opriv,
-					     nwb,
+		nrf_wifi_osal_nbuf_data_push(nwb,
 					     sizeof(struct nrf_wifi_fmac_eth_hdr));
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      ehdr->src,
+	nrf_wifi_osal_mem_cpy(ehdr->src,
 			      amsdu_hdr.src,
 			      NRF_WIFI_FMAC_ETH_ADDR_LEN);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      ehdr->dst,
+	nrf_wifi_osal_mem_cpy(ehdr->dst,
 			      amsdu_hdr.dst,
 			      NRF_WIFI_FMAC_ETH_ADDR_LEN);
 
@@ -219,14 +201,12 @@ int nrf_wifi_util_get_tid(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	unsigned short ipv6_hdr = 0;
 	void *nwb_data = NULL;
 
-	nwb_data = nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-					       nwb);
+	nwb_data = nrf_wifi_osal_nbuf_data_get(nwb);
 
 	ether_type = nrf_wifi_util_tx_get_eth_type(fmac_dev_ctx,
 						   nwb_data);
 
-	nwb_data = (unsigned char *)nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-								nwb) + NRF_WIFI_FMAC_ETH_HDR_LEN;
+	nwb_data = (unsigned char *)nrf_wifi_osal_nbuf_data_get(nwb) + NRF_WIFI_FMAC_ETH_HDR_LEN;
 
 	switch (ether_type & NRF_WIFI_FMAC_ETH_TYPE_MASK) {
 	/* If VLAN 802.1Q (0x8100) ||
@@ -302,8 +282,7 @@ int nrf_wifi_util_get_vif_indx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	}
 
 	if (vif_index == -1) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid vif_index = %d",
+		nrf_wifi_osal_log_err("%s: Invalid vif_index = %d",
 				      __func__,
 				      vif_index);
 	}
@@ -315,8 +294,7 @@ int nrf_wifi_util_get_vif_indx(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 unsigned char *nrf_wifi_util_get_dest(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				      void *nwb)
 {
-	return nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-					   nwb);
+	return nrf_wifi_osal_nbuf_data_get(nwb);
 }
 
 
@@ -335,16 +313,14 @@ unsigned char *nrf_wifi_util_get_ra(struct nrf_wifi_fmac_vif_ctx *vif,
 		return vif->bssid;
 	}
 
-	return nrf_wifi_osal_nbuf_data_get(vif->fmac_dev_ctx->fpriv->opriv,
-					   nwb);
+	return nrf_wifi_osal_nbuf_data_get(nwb);
 }
 
 
 unsigned char *nrf_wifi_util_get_src(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 				     void *nwb)
 {
-	return (unsigned char *)nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-							    nwb) + NRF_WIFI_FMAC_ETH_ADDR_LEN;
+	return (unsigned char *)nrf_wifi_osal_nbuf_data_get(nwb) + NRF_WIFI_FMAC_ETH_ADDR_LEN;
 }
 
 #endif /* CONFIG_NRF700X_STA_MODE */

--- a/nrf_wifi/fw_if/umac_if/src/fmac_vif.c
+++ b/nrf_wifi/fw_if/umac_if/src/fmac_vif.c
@@ -25,8 +25,7 @@ int nrf_wifi_fmac_vif_check_if_limit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	case NRF_WIFI_IFTYPE_STATION:
 	case NRF_WIFI_IFTYPE_P2P_CLIENT:
 		if (def_dev_ctx->num_sta >= MAX_NUM_STAS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Maximum STA Interface type exceeded",
+			nrf_wifi_osal_log_err("%s: Maximum STA Interface type exceeded",
 					      __func__);
 			return -1;
 		}
@@ -34,15 +33,13 @@ int nrf_wifi_fmac_vif_check_if_limit(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	case NRF_WIFI_IFTYPE_AP:
 	case NRF_WIFI_IFTYPE_P2P_GO:
 		if (def_dev_ctx->num_ap >= MAX_NUM_APS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Maximum AP Interface type exceeded",
+			nrf_wifi_osal_log_err("%s: Maximum AP Interface type exceeded",
 					      __func__);
 			return -1;
 		}
 		break;
 	default:
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Interface type not supported",
+		nrf_wifi_osal_log_err("%s: Interface type not supported",
 				      __func__);
 		return -1;
 	}
@@ -68,8 +65,7 @@ void nrf_wifi_fmac_vif_incr_if_type(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		def_dev_ctx->num_ap++;
 		break;
 	default:
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s:Unsupported VIF type",
+		nrf_wifi_osal_log_err("%s:Unsupported VIF type",
 				      __func__);
 	}
 }
@@ -92,8 +88,7 @@ void nrf_wifi_fmac_vif_decr_if_type(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		def_dev_ctx->num_ap--;
 		break;
 	default:
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s:Unsupported VIF type",
+		nrf_wifi_osal_log_err("%s:Unsupported VIF type",
 				      __func__);
 	}
 }
@@ -111,8 +106,7 @@ void nrf_wifi_fmac_vif_clear_ctx(void *dev_ctx,
 
 	vif_ctx = def_dev_ctx->vif_ctx[if_idx];
 
-	nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-			       vif_ctx);
+	nrf_wifi_osal_mem_free(vif_ctx);
 	def_dev_ctx->vif_ctx[if_idx] = NULL;
 }
 

--- a/nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c
@@ -44,8 +44,7 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init_rt(struct nrf_wifi_fmac_dev_ct
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
 	if (!fmac_dev_ctx) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid device context",
+		nrf_wifi_osal_log_err("%s: Invalid device context",
 				      __func__);
 		goto out;
 	}
@@ -63,24 +62,21 @@ static enum nrf_wifi_status nrf_wifi_fmac_fw_init_rt(struct nrf_wifi_fmac_dev_ct
 			       board_params);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC init failed",
+		nrf_wifi_osal_log_err("%s: UMAC init failed",
 				      __func__);
 		goto out;
 	}
-	start_time_us = nrf_wifi_osal_time_get_curr_us(fmac_dev_ctx->fpriv->opriv);
+	start_time_us = nrf_wifi_osal_time_get_curr_us();
 	while (!fmac_dev_ctx->fw_init_done) {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv, 1);
+		nrf_wifi_osal_sleep_ms(1);
 #define MAX_INIT_WAIT (5 * 1000 * 1000)
-		if (nrf_wifi_osal_time_elapsed_us(fmac_dev_ctx->fpriv->opriv,
-						  start_time_us) >= MAX_INIT_WAIT) {
+		if (nrf_wifi_osal_time_elapsed_us(start_time_us) >= MAX_INIT_WAIT) {
 			break;
 		}
 	}
 
 	if (!fmac_dev_ctx->fw_init_done) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: UMAC init timed out",
+		nrf_wifi_osal_log_err("%s: UMAC init timed out",
 				      __func__);
 		status = NRF_WIFI_STATUS_FAIL;
 		goto out;
@@ -100,8 +96,7 @@ void nrf_wifi_fmac_dev_rem_rt(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 {
 	nrf_wifi_hal_dev_rem(fmac_dev_ctx->hal_dev_ctx);
 
-	nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-			       fmac_dev_ctx);
+	nrf_wifi_osal_mem_free(fmac_dev_ctx);
 }
 
 
@@ -121,8 +116,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 	struct nrf_wifi_phy_rf_params phy_rf_params;
 
 	if (!fmac_dev_ctx) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Invalid device context",
+		nrf_wifi_osal_log_err("%s: Invalid device context",
 				      __func__);
 		goto out;
 	}
@@ -130,21 +124,17 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 	status = nrf_wifi_hal_dev_init(fmac_dev_ctx->hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_hal_dev_init failed",
+		nrf_wifi_osal_log_err("%s: nrf_wifi_hal_dev_init failed",
 				      __func__);
 		goto out;
 	}
 
-	fmac_dev_ctx->tx_pwr_ceil_params = nrf_wifi_osal_mem_alloc(fmac_dev_ctx->fpriv->opriv,
-								   sizeof(*tx_pwr_ceil_params));
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      fmac_dev_ctx->tx_pwr_ceil_params,
+	fmac_dev_ctx->tx_pwr_ceil_params = nrf_wifi_osal_mem_alloc(sizeof(*tx_pwr_ceil_params));
+	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->tx_pwr_ceil_params,
 			      tx_pwr_ceil_params,
 			      sizeof(*tx_pwr_ceil_params));
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &otp_info,
+	nrf_wifi_osal_mem_set(&otp_info,
 			      0xFF,
 			      sizeof(otp_info));
 
@@ -153,8 +143,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 					   &otp_info.flags);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Fetching of RPU OTP information failed",
+		nrf_wifi_osal_log_err("%s: Fetching of RPU OTP information failed",
 				      __func__);
 		goto out;
 	}
@@ -163,8 +152,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 		                             &phy_rf_params);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: RF parameters get failed",
+		nrf_wifi_osal_log_err("%s: RF parameters get failed",
 				     __func__);
 		goto out;
 	}
@@ -182,8 +170,7 @@ enum nrf_wifi_status nrf_wifi_fmac_dev_init_rt(struct nrf_wifi_fmac_dev_ctx *fma
 					  board_params);
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_fw_init failed",
+		nrf_wifi_osal_log_err("%s: nrf_wifi_fmac_fw_init failed",
 				      __func__);
 		goto out;
 	}
@@ -193,37 +180,25 @@ out:
 
 void nrf_wifi_fmac_dev_deinit_rt(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx)
 {
-	nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-			       fmac_dev_ctx->tx_pwr_ceil_params);
+	nrf_wifi_osal_mem_free(fmac_dev_ctx->tx_pwr_ceil_params);
 	nrf_wifi_fmac_fw_deinit_rt(fmac_dev_ctx);
 }
 
 struct nrf_wifi_fmac_priv *nrf_wifi_fmac_init_rt(void)
 {
-	struct nrf_wifi_osal_priv *opriv = NULL;
 	struct nrf_wifi_fmac_priv *fpriv = NULL;
 	struct nrf_wifi_hal_cfg_params hal_cfg_params;
 
-	opriv = nrf_wifi_osal_init();
-
-	if (!opriv) {
-		goto out;
-	}
-
-	fpriv = nrf_wifi_osal_mem_zalloc(opriv,
-					 sizeof(*fpriv));
+	fpriv = nrf_wifi_osal_mem_zalloc(sizeof(*fpriv));
 
 	if (!fpriv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate fpriv",
+		nrf_wifi_osal_log_err("%s: Unable to allocate fpriv",
 				      __func__);
 		goto out;
 	}
 
-	fpriv->opriv = opriv;
 
-	nrf_wifi_osal_mem_set(opriv,
-			      &hal_cfg_params,
+	nrf_wifi_osal_mem_set(&hal_cfg_params,
 			      0,
 			      sizeof(hal_cfg_params));
 
@@ -231,20 +206,15 @@ struct nrf_wifi_fmac_priv *nrf_wifi_fmac_init_rt(void)
 	hal_cfg_params.max_cmd_size = MAX_NRF_WIFI_UMAC_CMD_SIZE;
 	hal_cfg_params.max_event_size = MAX_EVENT_POOL_LEN;
 
-	fpriv->hpriv = nrf_wifi_hal_init(opriv,
-					 &hal_cfg_params,
+	fpriv->hpriv = nrf_wifi_hal_init(&hal_cfg_params,
 					 &nrf_wifi_fmac_event_callback,
 					 NULL);
 
 	if (!fpriv->hpriv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to do HAL init",
+		nrf_wifi_osal_log_err("%s: Unable to do HAL init",
 				      __func__);
-		nrf_wifi_osal_mem_free(opriv,
-				       fpriv);
+		nrf_wifi_osal_mem_free(fpriv);
 		fpriv = NULL;
-		nrf_wifi_osal_deinit(opriv);
-		opriv = NULL;
 		goto out;
 	}
 out:
@@ -254,16 +224,9 @@ out:
 
 void nrf_wifi_fmac_deinit_rt(struct nrf_wifi_fmac_priv *fpriv)
 {
-	struct nrf_wifi_osal_priv *opriv = NULL;
-
-	opriv = fpriv->opriv;
-
 	nrf_wifi_hal_deinit(fpriv->hpriv);
 
-	nrf_wifi_osal_mem_free(opriv,
-			       fpriv);
-
-	nrf_wifi_osal_deinit(opriv);
+	nrf_wifi_osal_mem_free(fpriv);
 }
 
 enum nrf_wifi_status wait_for_radio_cmd_status(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
@@ -275,15 +238,13 @@ enum nrf_wifi_status wait_for_radio_cmd_status(struct nrf_wifi_fmac_dev_ctx *fma
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       1);
+		nrf_wifi_osal_sleep_ms(1);
 		count++;
 	} while ((!rt_dev_ctx->radio_cmd_done) &&
 		 (count < timeout));
 
 	if (count == timeout) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out (%d secs)",
+		nrf_wifi_osal_log_err("%s: Timed out (%d secs)",
 				      __func__,
 					 timeout / 1000);
 		goto out;
@@ -292,8 +253,7 @@ enum nrf_wifi_status wait_for_radio_cmd_status(struct nrf_wifi_fmac_dev_ctx *fma
 	radio_cmd_status = rt_dev_ctx->radio_cmd_status;
 
 	if (radio_cmd_status != NRF_WIFI_UMAC_CMD_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Radio test command failed with status %d",
+		nrf_wifi_osal_log_err("%s: Radio test command failed with status %d",
 				      __func__,
 				      radio_cmd_status);
 		goto out;
@@ -313,18 +273,15 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_init(struct nrf_wifi_fmac_dev_ctx 
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &init_params,
+	nrf_wifi_osal_mem_set(&init_params,
 			      0,
 			      sizeof(init_params));
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      init_params.rf_params,
+	nrf_wifi_osal_mem_cpy(init_params.rf_params,
 			      params->rf_params,
 			      NRF_WIFI_RF_PARAMS_SIZE);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &init_params.chan,
+	nrf_wifi_osal_mem_cpy(&init_params.chan,
 			      &params->chan,
 			      sizeof(init_params.chan));
 
@@ -336,8 +293,7 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_init(struct nrf_wifi_fmac_dev_ctx 
 				    &init_params);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to init radio test",
+		nrf_wifi_osal_log_err("%s: Unable to init radio test",
 				      __func__);
 		goto out;
 	}
@@ -366,8 +322,7 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_prog_tx(struct nrf_wifi_fmac_dev_c
 				  params);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to program radio test TX",
+		nrf_wifi_osal_log_err("%s: Unable to program radio test TX",
 				      __func__);
 		goto out;
 	}
@@ -391,20 +346,17 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_prog_rx(struct nrf_wifi_fmac_dev_c
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &rx_params,
+	nrf_wifi_osal_mem_set(&rx_params,
 			      0,
 			      sizeof(rx_params));
 
 	rx_params.nss = params->nss;
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      rx_params.rf_params,
+	nrf_wifi_osal_mem_cpy(rx_params.rf_params,
 			      params->rf_params,
 			      NRF_WIFI_RF_PARAMS_SIZE);
 
-	nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-			      &rx_params.chan,
+	nrf_wifi_osal_mem_cpy(&rx_params.chan,
 			      &params->chan,
 			      sizeof(rx_params.chan));
 
@@ -417,8 +369,7 @@ enum nrf_wifi_status nrf_wifi_fmac_radio_test_prog_rx(struct nrf_wifi_fmac_dev_c
 				  &rx_params);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unable to program radio test RX",
+		nrf_wifi_osal_log_err("%s: Unable to program radio test RX",
 				      __func__);
 		goto out;
 	}
@@ -447,8 +398,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ctx *
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &rf_test_cap_params,
+	nrf_wifi_osal_mem_set(&rf_test_cap_params,
 			      0,
 			      sizeof(rf_test_cap_params));
 
@@ -466,23 +416,20 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ctx *
 				       sizeof(rf_test_cap_params));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_test_cap failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_prog_rf_test_cap failed",
 				      __func__);
 
 		goto out;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 		count++;
 	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -507,8 +454,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_ctx 
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &rf_test_tx_params,
+	nrf_wifi_osal_mem_set(&rf_test_tx_params,
 			      0,
 			      sizeof(rf_test_tx_params));
 
@@ -526,23 +472,20 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_tx_tone(struct nrf_wifi_fmac_dev_ctx 
 				       sizeof(rf_test_tx_params));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_test_tx_tone failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_prog_rf_test_tx_tone failed",
 				      __func__);
 
 		goto out;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 		count++;
 	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -565,8 +508,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_dpd(struct nrf_wifi_fmac_dev_ctx *fma
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &rf_test_dpd_params,
+	nrf_wifi_osal_mem_set(&rf_test_dpd_params,
 			      0,
 			      sizeof(rf_test_dpd_params));
 
@@ -582,23 +524,20 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_dpd(struct nrf_wifi_fmac_dev_ctx *fma
 					   sizeof(rf_test_dpd_params));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_test_dpd failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_prog_rf_test_dpd failed",
 				      __func__);
 
 		goto out;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 		count++;
 	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -620,8 +559,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_temp(struct nrf_wifi_fmac_dev_ctx *fma
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &rf_test_get_temperature,
+	nrf_wifi_osal_mem_set(&rf_test_get_temperature,
 			      0,
 			      sizeof(rf_test_get_temperature));
 
@@ -636,23 +574,20 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_temp(struct nrf_wifi_fmac_dev_ctx *fma
 					   sizeof(rf_test_get_temperature));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_get_temperature failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_prog_rf_get_temperature failed",
 				      __func__);
 
 		goto out;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 		count++;
 	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -673,8 +608,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_rf_rssi(struct nrf_wifi_fmac_dev_ctx *
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &rf_get_rf_rssi_params,
+	nrf_wifi_osal_mem_set(&rf_get_rf_rssi_params,
 			      0,
 			      sizeof(rf_get_rf_rssi_params));
 
@@ -691,23 +625,20 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_get_rf_rssi(struct nrf_wifi_fmac_dev_ctx *
 					   sizeof(rf_get_rf_rssi_params));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_get_rf_rssi failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_prog_rf_get_rf_rssi failed",
 				      __func__);
 
 		goto out;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 		count++;
 	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -730,8 +661,7 @@ enum nrf_wifi_status nrf_wifi_fmac_set_xo_val(struct nrf_wifi_fmac_dev_ctx *fmac
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &nrf_wifi_rf_test_xo_calib_params,
+	nrf_wifi_osal_mem_set(&nrf_wifi_rf_test_xo_calib_params,
 			      0,
 			      sizeof(nrf_wifi_rf_test_xo_calib_params));
 
@@ -748,23 +678,20 @@ enum nrf_wifi_status nrf_wifi_fmac_set_xo_val(struct nrf_wifi_fmac_dev_ctx *fmac
 					   sizeof(nrf_wifi_rf_test_xo_calib_params));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_set_xo_val failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_prog_set_xo_val failed",
 				      __func__);
 
 		goto out;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 		count++;
 	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;
@@ -786,8 +713,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_compute_xo(struct nrf_wifi_fmac_dev_c
 
 	rt_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
-	nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-			      &rf_get_xo_value_params,
+	nrf_wifi_osal_mem_set(&rf_get_xo_value_params,
 			      0,
 			      sizeof(rf_get_xo_value_params));
 
@@ -802,23 +728,20 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_compute_xo(struct nrf_wifi_fmac_dev_c
 					   sizeof(rf_get_xo_value_params));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: umac_cmd_prog_rf_get_xo_value failed",
+		nrf_wifi_osal_log_err("%s: umac_cmd_prog_rf_get_xo_value failed",
 				      __func__);
 
 		goto out;
 	}
 
 	do {
-		nrf_wifi_osal_sleep_ms(fmac_dev_ctx->fpriv->opriv,
-				       100);
+		nrf_wifi_osal_sleep_ms(100);
 		count++;
 	} while ((rt_dev_ctx->rf_test_type != NRF_WIFI_RF_TEST_MAX) &&
 		 (count < NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT));
 
 	if (count == NRF_WIFI_FMAC_RF_TEST_EVNT_TIMEOUT) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Timed out",
+		nrf_wifi_osal_log_err("%s: Timed out",
 				      __func__);
 		rt_dev_ctx->rf_test_type = NRF_WIFI_RF_TEST_MAX;
 		rt_dev_ctx->rf_test_cap_data = NULL;

--- a/nrf_wifi/fw_if/umac_if/src/rx.c
+++ b/nrf_wifi/fw_if/umac_if/src/rx.c
@@ -65,8 +65,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 						&pool_info);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_map_desc_to_pool failed",
+		nrf_wifi_osal_log_err("%s: nrf_wifi_fmac_map_desc_to_pool failed",
 				      __func__);
 		goto out;
 	}
@@ -77,27 +76,23 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 
 	if (cmd_type == NRF_WIFI_FMAC_RX_CMD_TYPE_INIT) {
 		if (rx_buf_info->mapped) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Init RX command called for already mapped RX buffer(%d)",
+			nrf_wifi_osal_log_err("%s: RX init called for mapped RX buffer(%d)",
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
 		}
 
-		nwb = (unsigned long)nrf_wifi_osal_nbuf_alloc(fmac_dev_ctx->fpriv->opriv,
-							      buf_len);
+		nwb = (unsigned long)nrf_wifi_osal_nbuf_alloc(buf_len);
 
 		if (!nwb) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: No space for allocating RX buffer",
+			nrf_wifi_osal_log_err("%s: No space for allocating RX buffer",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
 		}
 
-		nwb_data = (unsigned long)nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-								      (void *)nwb);
+		nwb_data = (unsigned long)nrf_wifi_osal_nbuf_data_get((void *)nwb);
 
 		*(unsigned int *)(nwb_data) = desc_id;
 
@@ -108,8 +103,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 						   pool_info.buf_id);
 
 		if (!phy_addr) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_hal_buf_map_rx failed",
+			nrf_wifi_osal_log_err("%s: nrf_wifi_hal_buf_map_rx failed",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
@@ -118,8 +112,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 		rx_buf_info->nwb = nwb;
 		rx_buf_info->mapped = true;
 
-		nrf_wifi_osal_mem_set(fmac_dev_ctx->fpriv->opriv,
-				      &rx_cmd,
+		nrf_wifi_osal_mem_set(&rx_cmd,
 				      0x0,
 				      sizeof(rx_cmd));
 
@@ -136,8 +129,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 		 * when LMAC is capable of handling deinit command
 		 */
 		if (!rx_buf_info->mapped) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Deinit RX command called for unmapped RX buffer(%d)",
+			nrf_wifi_osal_log_err("%s: RX deinit called for unmapped RX buffer(%d)",
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -150,20 +142,17 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_cmd_send(struct nrf_wifi_fmac_dev_ctx *fma
 						     pool_info.buf_id);
 
 		if (!nwb_data) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_hal_buf_unmap_rx failed",
+			nrf_wifi_osal_log_err("%s: nrf_wifi_hal_buf_unmap_rx failed",
 					      __func__);
 			goto out;
 		}
 
-		nrf_wifi_osal_nbuf_free(fmac_dev_ctx->fpriv->opriv,
-					(void *)rx_buf_info->nwb);
+		nrf_wifi_osal_nbuf_free((void *)rx_buf_info->nwb);
 		rx_buf_info->nwb = 0;
 		rx_buf_info->mapped = false;
 		status = NRF_WIFI_STATUS_SUCCESS;
 	} else {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: Unknown cmd_type (%d)",
+		nrf_wifi_osal_log_err("%s: Unknown cmd_type (%d)",
 				      __func__,
 				      cmd_type);
 		goto out;
@@ -191,12 +180,10 @@ void nrf_wifi_fmac_rx_tasklet(void *data)
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
 	config = (struct nrf_wifi_rx_buff *)nrf_wifi_utils_q_dequeue(
-		fmac_dev_ctx->fpriv->opriv,
 		def_dev_ctx->rx_tasklet_event_q);
 
 	if (!config) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: No RX config available",
+		nrf_wifi_osal_log_err("%s: No RX config available",
 				      __func__);
 		goto out;
 	}
@@ -205,14 +192,12 @@ void nrf_wifi_fmac_rx_tasklet(void *data)
 						config);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-				      "%s: nrf_wifi_fmac_rx_event_process failed",
+		nrf_wifi_osal_log_err("%s: nrf_wifi_fmac_rx_event_process failed",
 				      __func__);
 		goto out;
 	}
 out:
-	nrf_wifi_osal_mem_free(fmac_dev_ctx->fpriv->opriv,
-			       config);
+	nrf_wifi_osal_mem_free(config);
 	nrf_wifi_hal_unlock_rx(fmac_dev_ctx->hal_dev_ctx);
 }
 #endif /* CONFIG_NRF700X_RX_WQ_ENABLED */
@@ -257,8 +242,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 		pkt_len = config->rx_buff_info[i].rx_pkt_len;
 
 		if (desc_id >= def_priv->num_rx_bufs) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Invalid desc_id %d",
+			nrf_wifi_osal_log_err("%s: Invalid desc_id %d",
 					      __func__,
 					      desc_id);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -270,8 +254,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 							&pool_info);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_fmac_map_desc_to_pool failed",
+			nrf_wifi_osal_log_err("%s: nrf_wifi_fmac_map_desc_to_pool failed",
 					      __func__);
 			goto out;
 		}
@@ -282,8 +265,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 							     pool_info.buf_id);
 
 		if (!nwb_data) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_hal_buf_unmap_rx failed",
+			nrf_wifi_osal_log_err("%s: nrf_wifi_hal_buf_unmap_rx failed",
 					      __func__);
 			goto out;
 		}
@@ -291,14 +273,11 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 		rx_buf_info = &def_dev_ctx->rx_buf_info[desc_id];
 		nwb = (void *)rx_buf_info->nwb;
 
-		nrf_wifi_osal_nbuf_data_put(fmac_dev_ctx->fpriv->opriv,
-					    nwb,
+		nrf_wifi_osal_nbuf_data_put(nwb,
 					    pkt_len + RX_BUF_HEADROOM);
-		nrf_wifi_osal_nbuf_data_pull(fmac_dev_ctx->fpriv->opriv,
-					     nwb,
+		nrf_wifi_osal_nbuf_data_pull(nwb,
 					     RX_BUF_HEADROOM);
-		nwb_data = nrf_wifi_osal_nbuf_data_get(fmac_dev_ctx->fpriv->opriv,
-						       nwb);
+		nwb_data = nrf_wifi_osal_nbuf_data_get(nwb);
 
 		rx_buf_info->nwb = 0;
 		rx_buf_info->mapped = false;
@@ -320,8 +299,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 #ifdef CONFIG_NRF700X_STA_MODE
 			switch (config->rx_buff_info[i].pkt_type) {
 			case PKT_TYPE_MPDU:
-				nrf_wifi_osal_mem_cpy(fmac_dev_ctx->fpriv->opriv,
-						      &hdr,
+				nrf_wifi_osal_mem_cpy(&hdr,
 						      nwb_data,
 						      sizeof(struct nrf_wifi_fmac_ieee80211_hdr));
 
@@ -333,8 +311,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 					nrf_wifi_util_get_skip_header_bytes(eth_type);
 
 				/* Remove hdr len and llc header/length */
-				nrf_wifi_osal_nbuf_data_pull(fmac_dev_ctx->fpriv->opriv,
-							     nwb,
+				nrf_wifi_osal_nbuf_data_pull(nwb,
 							     size);
 
 				nrf_wifi_util_convert_to_eth(fmac_dev_ctx,
@@ -343,8 +320,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 							     eth_type);
 				break;
 			case PKT_TYPE_MSDU_WITH_MAC:
-				nrf_wifi_osal_nbuf_data_pull(fmac_dev_ctx->fpriv->opriv,
-							     nwb,
+				nrf_wifi_osal_nbuf_data_pull(nwb,
 							     config->mac_header_len);
 
 				nrf_wifi_util_rx_convert_amsdu_to_eth(fmac_dev_ctx,
@@ -355,8 +331,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 								      nwb);
 				break;
 			default:
-				nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-						      "%s: Invalid pkt_type=%d",
+				nrf_wifi_osal_log_err("%s: Invalid pkt_type=%d",
 						      __func__,
 						      (config->rx_buff_info[i].pkt_type));
 				status = NRF_WIFI_STATUS_FAIL;
@@ -373,8 +348,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 							config->frequency,
 							config->signal);
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
-			nrf_wifi_osal_nbuf_free(fmac_dev_ctx->fpriv->opriv,
-						nwb);
+			nrf_wifi_osal_nbuf_free(nwb);
 		}
 #if defined(CONFIG_NRF700X_RAW_DATA_RX) || defined(CONFIG_NRF700X_PROMISC_DATA_RX)
 		else if (config->rx_pkt_type == NRF_WIFI_RAW_RX_PKT) {
@@ -390,8 +364,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 		}
 #endif /* CONFIG_NRF700X_RAW_DATA_RX || CONFIG_NRF700X_PROMISC_DATA_RX */
 		else {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: Invalid frame type received %d",
+			nrf_wifi_osal_log_err("%s: Invalid frame type received %d",
 					      __func__,
 					      config->rx_pkt_type);
 			status = NRF_WIFI_STATUS_FAIL;
@@ -403,8 +376,7 @@ enum nrf_wifi_status nrf_wifi_fmac_rx_event_process(struct nrf_wifi_fmac_dev_ctx
 						   desc_id);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(fmac_dev_ctx->fpriv->opriv,
-					      "%s: nrf_wifi_fmac_rx_cmd_send failed",
+			nrf_wifi_osal_log_err("%s: nrf_wifi_fmac_rx_cmd_send failed",
 					      __func__);
 			goto out;
 		}

--- a/nrf_wifi/hw_if/hal/inc/hal_api.h
+++ b/nrf_wifi/hw_if/hal/inc/hal_api.h
@@ -34,7 +34,6 @@ extern const struct nrf70_fw_addr_info nrf70_fw_addr_info[];
 /**
  * @brief Initialize the HAL layer.
  *
- * @param opriv Pointer to the OSAL layer.
  * @param cfg_params Parameters needed to configure the HAL for WLAN operation.
  * @param intr_callbk_fn Pointer to the callback function which the user of this
  *                       layer needs to implement to handle events from the RPU.
@@ -47,15 +46,14 @@ extern const struct nrf70_fw_addr_info nrf70_fw_addr_info[];
  *
  * @return Pointer to instance of HAL layer context.
  */
-struct nrf_wifi_hal_priv *nrf_wifi_hal_init(struct nrf_wifi_osal_priv *opriv,
-		struct nrf_wifi_hal_cfg_params *cfg_params,
-		enum nrf_wifi_status (*intr_callbk_fn)(void *mac_ctx,
-			void *event_data,
-			unsigned int len),
-		enum nrf_wifi_status (*rpu_recovery_callbk_fn)(void *mac_ctx,
-			void *event_data,
-			unsigned int len)
-);
+struct nrf_wifi_hal_priv *
+nrf_wifi_hal_init(struct nrf_wifi_hal_cfg_params *cfg_params,
+		  enum nrf_wifi_status (*intr_callbk_fn)(void *mac_ctx,
+							 void *event_data,
+							 unsigned int len),
+		  enum nrf_wifi_status (*rpu_recovery_callbk_fn)(void *mac_ctx,
+							     void *event_data,
+							     unsigned int len));
 
 /**
  * @brief Deinitialize the HAL layer.

--- a/nrf_wifi/hw_if/hal/inc/hal_structs.h
+++ b/nrf_wifi/hw_if/hal/inc/hal_structs.h
@@ -142,8 +142,6 @@ struct nrf_wifi_hal_cfg_params {
  * @brief Structure to hold context information for the HAL layer.
  */
 struct nrf_wifi_hal_priv {
-	/** Pointer to OS abstraction layer private data */
-	struct nrf_wifi_osal_priv *opriv;
 	/** Pointer to BAL private data */
 	struct nrf_wifi_bal_priv *bpriv;
 	/** Number of devices */

--- a/nrf_wifi/hw_if/hal/inc/pal.h
+++ b/nrf_wifi/hw_if/hal/inc/pal.h
@@ -82,18 +82,16 @@ static inline enum RPU_MCU_ADDR_REGIONS pal_mem_type_to_region(enum HAL_RPU_MEM_
 	}
 }
 
-enum nrf_wifi_status pal_rpu_addr_offset_get(struct nrf_wifi_osal_priv *opriv,
-					     unsigned int rpu_addr,
+enum nrf_wifi_status pal_rpu_addr_offset_get(unsigned int rpu_addr,
 					     unsigned long *addr_offset,
-						 enum RPU_PROC_TYPE proc);
+					     enum RPU_PROC_TYPE proc);
 
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 unsigned long pal_rpu_ps_ctrl_reg_addr_get(void);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
-char *pal_ops_get_fw_loc(struct nrf_wifi_osal_priv *opriv,
-			 enum nrf_wifi_fw_type fw_type,
+char *pal_ops_get_fw_loc(enum nrf_wifi_fw_type fw_type,
 			 enum nrf_wifi_fw_subtype fw_subtype);
 
 #endif /* __PAL_H__ */

--- a/nrf_wifi/hw_if/hal/src/hal_api.c
+++ b/nrf_wifi/hw_if/hal/src/hal_api.c
@@ -24,14 +24,12 @@ nrf_wifi_hal_rpu_pktram_buf_map_init(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	unsigned int pool_idx = 0;
 
-	status = pal_rpu_addr_offset_get(hal_dev_ctx->hpriv->opriv,
-					 RPU_MEM_PKT_BASE,
+	status = pal_rpu_addr_offset_get(RPU_MEM_PKT_BASE,
 					 &hal_dev_ctx->addr_rpu_pktram_base,
 					 hal_dev_ctx->curr_proc);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed",
+		nrf_wifi_osal_log_err("%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		goto out;
 	}
@@ -69,8 +67,7 @@ unsigned long nrf_wifi_hal_buf_map_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	rx_buf_info = &hal_dev_ctx->rx_buf_info[pool_id][buf_id];
 
 	if (rx_buf_info->mapped) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for already mapped RX buffer",
+		nrf_wifi_osal_log_err("%s: Called for already mapped RX buffer",
 				      __func__);
 		goto out;
 	}
@@ -79,8 +76,7 @@ unsigned long nrf_wifi_hal_buf_map_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	rx_buf_info->buf_len = buf_len;
 
 	if (buf_len != hal_dev_ctx->hpriv->cfg_params.rx_buf_pool[pool_id].buf_sz) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid buf_len (%d) for pool_id (%d)",
+		nrf_wifi_osal_log_err("%s: Invalid buf_len (%d) for pool_id (%d)",
 				      __func__,
 				      buf_len,
 				      pool_id);
@@ -105,8 +101,7 @@ unsigned long nrf_wifi_hal_buf_map_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 						     NRF_WIFI_OSAL_DMA_DIR_FROM_DEV);
 
 	if (!rx_buf_info->phy_addr) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: DMA map failed",
+		nrf_wifi_osal_log_err("%s: DMA map failed",
 				      __func__);
 		goto out;
 	}
@@ -133,8 +128,7 @@ unsigned long nrf_wifi_hal_buf_unmap_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 	rx_buf_info = &hal_dev_ctx->rx_buf_info[pool_id][buf_id];
 
 	if (!rx_buf_info->mapped) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for unmapped RX buffer",
+		nrf_wifi_osal_log_err("%s: Called for unmapped RX buffer",
 				      __func__);
 		goto out;
 	}
@@ -148,8 +142,7 @@ unsigned long nrf_wifi_hal_buf_unmap_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	if (data_len) {
 		if (!unmapped_addr) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: DMA unmap failed",
+			nrf_wifi_osal_log_err("%s: DMA unmap failed",
 					      __func__);
 			goto out;
 		}
@@ -163,8 +156,7 @@ unsigned long nrf_wifi_hal_buf_unmap_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 
 	virt_addr = rx_buf_info->virt_addr;
 
-	nrf_wifi_osal_mem_set(hal_dev_ctx->hpriv->opriv,
-			      rx_buf_info,
+	nrf_wifi_osal_mem_set(rx_buf_info,
 			      0,
 			      sizeof(*rx_buf_info));
 out:
@@ -189,8 +181,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	tx_buf_info = &hal_dev_ctx->tx_buf_info[desc_id];
 
 	if (tx_buf_info->mapped) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for already mapped TX buffer",
+		nrf_wifi_osal_log_err("%s: Called for already mapped TX buffer",
 				      __func__);
 		goto out;
 	}
@@ -199,8 +190,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if (buf_len > (hal_dev_ctx->hpriv->cfg_params.max_tx_frm_sz -
 		       hal_dev_ctx->hpriv->cfg_params.tx_buf_headroom_sz)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid TX buf_len (%d) for (%d)",
+		nrf_wifi_osal_log_err("%s: Invalid TX buf_len (%d) for (%d)",
 				      __func__,
 				      buf_len,
 				      desc_id);
@@ -222,8 +212,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	rpu_addr = RPU_MEM_PKT_BASE + (bounce_buf_addr - hal_dev_ctx->addr_rpu_pktram_base);
 
-	nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-	       "%s: bounce_buf_addr: 0x%lx, rpu_addr: 0x%lx, buf_len: %d off:%d",
+	nrf_wifi_osal_log_dbg("%s: bounce_buf_addr: 0x%lx, rpu_addr: 0x%lx, buf_len: %d off:%d",
 	       __func__,
 	       bounce_buf_addr,
 	       rpu_addr,
@@ -243,8 +232,7 @@ unsigned long nrf_wifi_hal_buf_map_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 						     NRF_WIFI_OSAL_DMA_DIR_TO_DEV);
 
 	if (!tx_buf_info->phy_addr) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: DMA map failed",
+		nrf_wifi_osal_log_err("%s: DMA map failed",
 				      __func__);
 		goto out;
 	}
@@ -269,8 +257,7 @@ unsigned long nrf_wifi_hal_buf_unmap_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 	tx_buf_info = &hal_dev_ctx->tx_buf_info[desc_id];
 
 	if (!tx_buf_info->mapped) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Called for unmapped TX buffer",
+		nrf_wifi_osal_log_err("%s: Called for unmapped TX buffer",
 				      __func__);
 		goto out;
 	}
@@ -281,16 +268,14 @@ unsigned long nrf_wifi_hal_buf_unmap_tx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 					       NRF_WIFI_OSAL_DMA_DIR_TO_DEV);
 
 	if (!unmapped_addr) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: DMA unmap failed",
+		nrf_wifi_osal_log_err("%s: DMA unmap failed",
 				      __func__);
 		goto out;
 	}
 
 	virt_addr = tx_buf_info->virt_addr;
 
-	nrf_wifi_osal_mem_set(hal_dev_ctx->hpriv->opriv,
-			      tx_buf_info,
+	nrf_wifi_osal_mem_set(tx_buf_info,
 			      0,
 			      sizeof(*tx_buf_info));
 out:
@@ -312,8 +297,7 @@ enum nrf_wifi_status hal_rpu_ps_wake(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
 	if (!hal_dev_ctx) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		return status;
 	}
@@ -333,15 +317,14 @@ enum nrf_wifi_status hal_rpu_ps_wake(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 
 	nrf_wifi_bal_rpu_ps_wake(hal_dev_ctx->bal_dev_ctx);
 
-	start_time_us = nrf_wifi_osal_time_get_curr_us(hal_dev_ctx->hpriv->opriv);
+	start_time_us = nrf_wifi_osal_time_get_curr_us();
 
 	rpu_ps_state_mask = ((1 << RPU_REG_BIT_PS_STATE) |
 			     (1 << RPU_REG_BIT_READY_STATE));
 
 	/* Add a delay to avoid a race condition in the RPU */
 	/* TODO: Reduce to 200 us after sleep has been stabilized */
-	nrf_wifi_osal_delay_us(hal_dev_ctx->hpriv->opriv,
-			       1000);
+	nrf_wifi_osal_delay_us(1000);
 
 	do {
 		/* Poll the RPU PS state */
@@ -352,36 +335,31 @@ enum nrf_wifi_status hal_rpu_ps_wake(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 			break;
 		}
 
-		idle_time_start_us = nrf_wifi_osal_time_get_curr_us(hal_dev_ctx->hpriv->opriv);
+		idle_time_start_us = nrf_wifi_osal_time_get_curr_us();
 
 		do {
-			idle_time_us = nrf_wifi_osal_time_elapsed_us(hal_dev_ctx->hpriv->opriv,
-								     idle_time_start_us);
+			idle_time_us = nrf_wifi_osal_time_elapsed_us(idle_time_start_us);
 		} while ((idle_time_us / 1000) < RPU_PS_WAKE_INTERVAL_MS);
 
-		elapsed_time_usec = nrf_wifi_osal_time_elapsed_us(hal_dev_ctx->hpriv->opriv,
-								  start_time_us);
+		elapsed_time_usec = nrf_wifi_osal_time_elapsed_us(start_time_us);
 		elapsed_time_sec = (elapsed_time_usec / 1000000);
 	} while (elapsed_time_sec < RPU_PS_WAKE_TIMEOUT_S);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU is not ready for more than %d sec,"
+		nrf_wifi_osal_log_err("%s: RPU is not ready for more than %d sec,"
 				      "reg_val = 0x%X rpu_ps_state_mask = 0x%X",
 				      __func__,
 				      RPU_PS_WAKE_TIMEOUT_S,
 				      reg_val,
 				      rpu_ps_state_mask);
-		nrf_wifi_osal_tasklet_schedule(hal_dev_ctx->hpriv->opriv,
-					       hal_dev_ctx->recovery_tasklet);
+		nrf_wifi_osal_tasklet_schedule(hal_dev_ctx->recovery_tasklet);
 		goto out;
 	}
 	hal_dev_ctx->rpu_ps_state = RPU_PS_STATE_AWAKE;
 
 out:
 	if (!hal_dev_ctx->irq_ctx) {
-		nrf_wifi_osal_timer_schedule(hal_dev_ctx->hpriv->opriv,
-					     hal_dev_ctx->rpu_ps_timer,
+		nrf_wifi_osal_timer_schedule(hal_dev_ctx->rpu_ps_timer,
 					     CONFIG_NRF700X_RPU_PS_IDLE_TIMEOUT_MS);
 	}
 	return status;
@@ -395,16 +373,14 @@ static void hal_rpu_ps_sleep(unsigned long data)
 
 	hal_dev_ctx = (struct nrf_wifi_hal_dev_ctx *)data;
 
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->rpu_ps_lock,
 					&flags);
 
 	nrf_wifi_bal_rpu_ps_sleep(hal_dev_ctx->bal_dev_ctx);
 
 	hal_dev_ctx->rpu_ps_state = RPU_PS_STATE_ASLEEP;
 
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
 				       &flags);
 }
 
@@ -413,31 +389,26 @@ static enum nrf_wifi_status hal_rpu_ps_init(struct nrf_wifi_hal_dev_ctx *hal_dev
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
-	hal_dev_ctx->rpu_ps_lock = nrf_wifi_osal_spinlock_alloc(hal_dev_ctx->hpriv->opriv);
+	hal_dev_ctx->rpu_ps_lock = nrf_wifi_osal_spinlock_alloc();
 
 	if (!hal_dev_ctx->rpu_ps_lock) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Unable to allocate lock",
+		nrf_wifi_osal_log_err("%s: Unable to allocate lock",
 				      __func__);
 		goto out;
 	}
 
-	nrf_wifi_osal_spinlock_init(hal_dev_ctx->hpriv->opriv,
-				    hal_dev_ctx->rpu_ps_lock);
+	nrf_wifi_osal_spinlock_init(hal_dev_ctx->rpu_ps_lock);
 
-	hal_dev_ctx->rpu_ps_timer = nrf_wifi_osal_timer_alloc(hal_dev_ctx->hpriv->opriv);
+	hal_dev_ctx->rpu_ps_timer = nrf_wifi_osal_timer_alloc();
 
 	if (!hal_dev_ctx->rpu_ps_timer) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Unable to allocate timer",
+		nrf_wifi_osal_log_err("%s: Unable to allocate timer",
 				      __func__);
-		nrf_wifi_osal_spinlock_free(hal_dev_ctx->hpriv->opriv,
-					    hal_dev_ctx->rpu_ps_lock);
+		nrf_wifi_osal_spinlock_free(hal_dev_ctx->rpu_ps_lock);
 		goto out;
 	}
 
-	nrf_wifi_osal_timer_init(hal_dev_ctx->hpriv->opriv,
-				 hal_dev_ctx->rpu_ps_timer,
+	nrf_wifi_osal_timer_init(hal_dev_ctx->rpu_ps_timer,
 				 hal_rpu_ps_sleep,
 				 (unsigned long)hal_dev_ctx);
 
@@ -452,14 +423,11 @@ out:
 
 static void hal_rpu_ps_deinit(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
-	nrf_wifi_osal_timer_kill(hal_dev_ctx->hpriv->opriv,
-				 hal_dev_ctx->rpu_ps_timer);
+	nrf_wifi_osal_timer_kill(hal_dev_ctx->rpu_ps_timer);
 
-	nrf_wifi_osal_timer_free(hal_dev_ctx->hpriv->opriv,
-				 hal_dev_ctx->rpu_ps_timer);
+	nrf_wifi_osal_timer_free(hal_dev_ctx->rpu_ps_timer);
 
-	nrf_wifi_osal_spinlock_free(hal_dev_ctx->hpriv->opriv,
-				    hal_dev_ctx->rpu_ps_lock);
+	nrf_wifi_osal_spinlock_free(hal_dev_ctx->rpu_ps_lock);
 }
 
 
@@ -476,8 +444,7 @@ enum nrf_wifi_status nrf_wifi_hal_get_rpu_ps_state(
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
 	if (!hal_dev_ctx) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -502,8 +469,7 @@ static bool hal_rpu_hpq_is_empty(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 				  hpq->dequeue_addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Read from dequeue address failed, val (0x%X)",
+		nrf_wifi_osal_log_err("%s: Read from dequeue address failed, val (0x%X)",
 				      __func__,
 				      val);
 		return true;
@@ -526,8 +492,7 @@ static enum nrf_wifi_status hal_rpu_ready(struct nrf_wifi_hal_dev_ctx *hal_dev_c
 	if (msg_type == NRF_WIFI_HAL_MSG_TYPE_CMD_CTRL) {
 		avl_buf_q = &hal_dev_ctx->rpu_info.hpqm_info.cmd_avl_queue;
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid msg type %d",
+		nrf_wifi_osal_log_err("%s: Invalid msg type %d",
 				      __func__,
 				      msg_type);
 
@@ -552,13 +517,11 @@ static enum nrf_wifi_status hal_rpu_ready_wait(struct nrf_wifi_hal_dev_ctx *hal_
 	unsigned long start_time_us = 0;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
-	start_time_us = nrf_wifi_osal_time_get_curr_us(hal_dev_ctx->hpriv->opriv);
+	start_time_us = nrf_wifi_osal_time_get_curr_us();
 
 	while (hal_rpu_ready(hal_dev_ctx, msg_type) != NRF_WIFI_STATUS_SUCCESS) {
-		if (nrf_wifi_osal_time_elapsed_us(hal_dev_ctx->hpriv->opriv,
-						  start_time_us) >= MAX_HAL_RPU_READY_WAIT) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Timed out waiting (msg_type = %d)",
+		if (nrf_wifi_osal_time_elapsed_us(start_time_us) >= MAX_HAL_RPU_READY_WAIT) {
+			nrf_wifi_osal_log_err("%s: Timed out waiting (msg_type = %d)",
 					      __func__,
 					      msg_type);
 			goto out;
@@ -580,8 +543,7 @@ static enum nrf_wifi_status hal_rpu_msg_trigger(struct nrf_wifi_hal_dev_ctx *hal
 				   (hal_dev_ctx->num_cmds | 0x7fff0000));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to MCU cmd register failed",
+		nrf_wifi_osal_log_err("%s: Writing to MCU cmd register failed",
 				      __func__);
 		goto out;
 	}
@@ -601,8 +563,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 	struct host_rpu_hpq *busy_queue = NULL;
 
 	if (queue_id >= MAX_NUM_OF_RX_QUEUES) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid queue_id (%d)",
+		nrf_wifi_osal_log_err("%s: Invalid queue_id (%d)",
 				      __func__,
 				      queue_id);
 		goto out;
@@ -614,8 +575,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 	} else if (msg_type == NRF_WIFI_HAL_MSG_TYPE_CMD_DATA_RX) {
 		busy_queue = &hal_dev_ctx->rpu_info.hpqm_info.rx_buf_busy_queue[queue_id];
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid msg_type (%d)",
+		nrf_wifi_osal_log_err("%s: Invalid msg_type (%d)",
 				      __func__,
 				      msg_type);
 		goto out;
@@ -629,8 +589,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 				     msg_addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Queueing of message to RPU failed",
+		nrf_wifi_osal_log_err("%s: Queueing of message to RPU failed",
 				      __func__);
 		goto out;
 	}
@@ -640,8 +599,7 @@ static enum nrf_wifi_status hal_rpu_msg_post(struct nrf_wifi_hal_dev_ctx *hal_de
 		status = hal_rpu_msg_trigger(hal_dev_ctx);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Posting command to RPU failed",
+			nrf_wifi_osal_log_err("%s: Posting command to RPU failed",
 					      __func__);
 			goto out;
 		}
@@ -661,8 +619,7 @@ static enum nrf_wifi_status hal_rpu_msg_get_addr(struct nrf_wifi_hal_dev_ctx *ha
 	if (msg_type == NRF_WIFI_HAL_MSG_TYPE_CMD_CTRL) {
 		avl_queue = &hal_dev_ctx->rpu_info.hpqm_info.cmd_avl_queue;
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid msg_type (%d)",
+		nrf_wifi_osal_log_err("%s: Invalid msg_type (%d)",
 				      __func__,
 				      msg_type);
 		goto out;
@@ -673,8 +630,7 @@ static enum nrf_wifi_status hal_rpu_msg_get_addr(struct nrf_wifi_hal_dev_ctx *ha
 				     msg_addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Dequeue of address failed msg_addr 0x%X",
+		nrf_wifi_osal_log_err("%s: Dequeue of address failed msg_addr 0x%X",
 				      __func__,
 				      *msg_addr);
 		*msg_addr = 0;
@@ -701,8 +657,7 @@ static enum nrf_wifi_status hal_rpu_msg_write(struct nrf_wifi_hal_dev_ctx *hal_d
 				      &msg_addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Getting address (0x%X) to post message failed",
+		nrf_wifi_osal_log_err("%s: Getting address (0x%X) to post message failed",
 				      __func__,
 				      msg_addr);
 		goto out;
@@ -715,8 +670,7 @@ static enum nrf_wifi_status hal_rpu_msg_write(struct nrf_wifi_hal_dev_ctx *hal_d
 				   len);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Copying information to RPU failed",
+		nrf_wifi_osal_log_err("%s: Copying information to RPU failed",
 				      __func__);
 		goto out;
 	}
@@ -728,8 +682,7 @@ static enum nrf_wifi_status hal_rpu_msg_write(struct nrf_wifi_hal_dev_ctx *hal_d
 				  msg_addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Posting command to RPU failed",
+		nrf_wifi_osal_log_err("%s: Posting command to RPU failed",
 				      __func__);
 		goto out;
 	}
@@ -744,17 +697,14 @@ static enum nrf_wifi_status hal_rpu_cmd_process_queue(struct nrf_wifi_hal_dev_ct
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	struct nrf_wifi_hal_msg *cmd = NULL;
 
-	while ((cmd = nrf_wifi_utils_q_dequeue(hal_dev_ctx->hpriv->opriv,
-					       hal_dev_ctx->cmd_q))) {
+	while ((cmd = nrf_wifi_utils_q_dequeue(hal_dev_ctx->cmd_q))) {
 		status = hal_rpu_ready_wait(hal_dev_ctx,
 					    NRF_WIFI_HAL_MSG_TYPE_CMD_CTRL);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Timeout waiting to get free cmd buff from RPU",
+			nrf_wifi_osal_log_err("%s: Timeout waiting to get free cmd buff from RPU",
 					      __func__);
-			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-					       cmd);
+			nrf_wifi_osal_mem_free(cmd);
 			cmd = NULL;
 			continue;
 		}
@@ -765,18 +715,15 @@ static enum nrf_wifi_status hal_rpu_cmd_process_queue(struct nrf_wifi_hal_dev_ct
 					   cmd->len);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing command to RPU failed",
+			nrf_wifi_osal_log_err("%s: Writing command to RPU failed",
 					      __func__);
-			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-					       cmd);
+			nrf_wifi_osal_mem_free(cmd);
 			cmd = NULL;
 			continue;
 		}
 
 		/* Free the command data and command */
-		nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-				       cmd);
+		nrf_wifi_osal_mem_free(cmd);
 		cmd = NULL;
 	}
 
@@ -805,31 +752,26 @@ static enum nrf_wifi_status hal_rpu_cmd_queue(struct nrf_wifi_hal_dev_ctx *hal_d
 				size = len;
 			}
 
-			hal_msg = nrf_wifi_osal_mem_zalloc(hal_dev_ctx->hpriv->opriv,
-							   sizeof(*hal_msg) + size);
+			hal_msg = nrf_wifi_osal_mem_zalloc(sizeof(*hal_msg) + size);
 
 			if (!hal_msg) {
-				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Unable to alloc buff for frag HAL cmd",
+				nrf_wifi_osal_log_err("%s: Unable to alloc buff for frag HAL cmd",
 						      __func__);
 				status = NRF_WIFI_STATUS_FAIL;
 				goto out;
 			}
 
-			nrf_wifi_osal_mem_cpy(hal_dev_ctx->hpriv->opriv,
-					      hal_msg->data,
+			nrf_wifi_osal_mem_cpy(hal_msg->data,
 					      data,
 					      size);
 
 			hal_msg->len = size;
 
-			status = nrf_wifi_utils_q_enqueue(hal_dev_ctx->hpriv->opriv,
-							  hal_dev_ctx->cmd_q,
+			status = nrf_wifi_utils_q_enqueue(hal_dev_ctx->cmd_q,
 							  hal_msg);
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
-				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Unable to queue frag HAL cmd",
+				nrf_wifi_osal_log_err("%s: Unable to queue frag HAL cmd",
 						      __func__);
 				goto out;
 			}
@@ -838,39 +780,33 @@ static enum nrf_wifi_status hal_rpu_cmd_queue(struct nrf_wifi_hal_dev_ctx *hal_d
 			data += size;
 		}
 	} else {
-		hal_msg = nrf_wifi_osal_mem_zalloc(hal_dev_ctx->hpriv->opriv,
-						   sizeof(*hal_msg) + len);
+		hal_msg = nrf_wifi_osal_mem_zalloc(sizeof(*hal_msg) + len);
 
 		if (!hal_msg) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to allocate buffer for HAL command",
+			nrf_wifi_osal_log_err("%s: Unable to allocate buffer for HAL command",
 					      __func__);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
 		}
 
-		nrf_wifi_osal_mem_cpy(hal_dev_ctx->hpriv->opriv,
-				      hal_msg->data,
+		nrf_wifi_osal_mem_cpy(hal_msg->data,
 				      cmd,
 				      len);
 
 		hal_msg->len = len;
 
-		status = nrf_wifi_utils_q_enqueue(hal_dev_ctx->hpriv->opriv,
-						  hal_dev_ctx->cmd_q,
+		status = nrf_wifi_utils_q_enqueue(hal_dev_ctx->cmd_q,
 						  hal_msg);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to queue fragmented command",
+			nrf_wifi_osal_log_err("%s: Unable to queue fragmented command",
 					      __func__);
 			goto out;
 		}
 	}
 
 	/* Free the original command data */
-	nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-			       cmd);
+	nrf_wifi_osal_mem_free(cmd);
 
 out:
 	return status;
@@ -883,16 +819,14 @@ enum nrf_wifi_status nrf_wifi_hal_ctrl_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
-	nrf_wifi_osal_spinlock_take(hal_dev_ctx->hpriv->opriv,
-				    hal_dev_ctx->lock_hal);
+	nrf_wifi_osal_spinlock_take(hal_dev_ctx->lock_hal);
 
 	status = hal_rpu_cmd_queue(hal_dev_ctx,
 				   cmd,
 				   cmd_size);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Queueing of command failed",
+		nrf_wifi_osal_log_err("%s: Queueing of command failed",
 				      __func__);
 		goto out;
 	}
@@ -900,8 +834,7 @@ enum nrf_wifi_status nrf_wifi_hal_ctrl_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 	status = hal_rpu_cmd_process_queue(hal_dev_ctx);
 
 out:
-	nrf_wifi_osal_spinlock_rel(hal_dev_ctx->hpriv->opriv,
-				   hal_dev_ctx->lock_hal);
+	nrf_wifi_osal_spinlock_rel(hal_dev_ctx->lock_hal);
 
 	return status;
 }
@@ -921,8 +854,7 @@ enum nrf_wifi_status nrf_wifi_hal_data_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 	unsigned int host_addr = 0;
 
 
-	nrf_wifi_osal_spinlock_take(hal_dev_ctx->hpriv->opriv,
-				    hal_dev_ctx->lock_hal);
+	nrf_wifi_osal_spinlock_take(hal_dev_ctx->lock_hal);
 
 	if (cmd_type == NRF_WIFI_HAL_MSG_TYPE_CMD_DATA_RX) {
 		addr_base = hal_dev_ctx->rpu_info.rx_cmd_base;
@@ -931,8 +863,7 @@ enum nrf_wifi_status nrf_wifi_hal_data_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 		addr_base = hal_dev_ctx->rpu_info.tx_cmd_base;
 		max_cmd_size = RPU_DATA_CMD_SIZE_MAX_TX;
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid data command type %d",
+		nrf_wifi_osal_log_err("%s: Invalid data command type %d",
 				      __func__,
 				      cmd_type);
 	}
@@ -953,8 +884,7 @@ enum nrf_wifi_status nrf_wifi_hal_data_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 				   cmd_size);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Copying data cmd(%d) to RPU failed",
+		nrf_wifi_osal_log_err("%s: Copying data cmd(%d) to RPU failed",
 				      __func__,
 				      cmd_type);
 		goto out;
@@ -967,14 +897,12 @@ enum nrf_wifi_status nrf_wifi_hal_data_cmd_send(struct nrf_wifi_hal_dev_ctx *hal
 				  addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Posting RX buf info to RPU failed",
+		nrf_wifi_osal_log_err("%s: Posting RX buf info to RPU failed",
 				      __func__);
 		goto out;
 	}
 out:
-	nrf_wifi_osal_spinlock_rel(hal_dev_ctx->hpriv->opriv,
-				   hal_dev_ctx->lock_hal);
+	nrf_wifi_osal_spinlock_rel(hal_dev_ctx->lock_hal);
 
 
 	return status;
@@ -989,8 +917,7 @@ static void event_tasklet_fn(unsigned long data)
 
 	hal_dev_ctx = (struct nrf_wifi_hal_dev_ctx *)data;
 
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->lock_rx,
 					&flags);
 
 	if (hal_dev_ctx->hal_status != NRF_WIFI_HAL_STATUS_ENABLED) {
@@ -1002,14 +929,12 @@ static void event_tasklet_fn(unsigned long data)
 	status = hal_rpu_eventq_process(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Event queue processing failed",
+		nrf_wifi_osal_log_err("%s: Event queue processing failed",
 				      __func__);
 	}
 
 out:
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->lock_rx,
 				       &flags);
 }
 
@@ -1022,8 +947,7 @@ enum nrf_wifi_status hal_rpu_eventq_process(struct nrf_wifi_hal_dev_ctx *hal_dev
 	unsigned int event_len = 0;
 
 	while (1) {
-		event = nrf_wifi_utils_q_dequeue(hal_dev_ctx->hpriv->opriv,
-						 hal_dev_ctx->event_q);
+		event = nrf_wifi_utils_q_dequeue(hal_dev_ctx->event_q);
 		if (!event) {
 			goto out;
 		}
@@ -1037,14 +961,12 @@ enum nrf_wifi_status hal_rpu_eventq_process(struct nrf_wifi_hal_dev_ctx *hal_dev
 							    event_len);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Interrupt callback failed",
+			nrf_wifi_osal_log_err("%s: Interrupt callback failed",
 					      __func__);
 		}
 
 		/* Free up the local buffer */
-		nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-				       event);
+		nrf_wifi_osal_mem_free(event);
 		event = NULL;
 	}
 
@@ -1058,15 +980,12 @@ void hal_rpu_eventq_drain(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 	unsigned long flags = 0;
 
 	while (1) {
-		nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-						hal_dev_ctx->lock_rx,
+		nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->lock_rx,
 						&flags);
 
-		event = nrf_wifi_utils_q_dequeue(hal_dev_ctx->hpriv->opriv,
-						 hal_dev_ctx->event_q);
+		event = nrf_wifi_utils_q_dequeue(hal_dev_ctx->event_q);
 
-		nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-					       hal_dev_ctx->lock_rx,
+		nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->lock_rx,
 					       &flags);
 
 		if (!event) {
@@ -1074,8 +993,7 @@ void hal_rpu_eventq_drain(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 		}
 
 		/* Free up the local buffer */
-		nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-				       event);
+		nrf_wifi_osal_mem_free(event);
 		event = NULL;
 	}
 
@@ -1097,16 +1015,14 @@ static enum nrf_wifi_status hal_rpu_recovery(struct nrf_wifi_hal_dev_ctx *hal_de
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
 	if (!hal_dev_ctx->hpriv->rpu_recovery_callbk_fn) {
-		nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU recovery callback not registered",
+		nrf_wifi_osal_log_dbg("%s: RPU recovery callback not registered",
 				      __func__);
 		goto out;
 	}
 
 	status = hal_dev_ctx->hpriv->rpu_recovery_callbk_fn(hal_dev_ctx->mac_dev_ctx, NULL, 0);
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU recovery failed",
+		nrf_wifi_osal_log_err("%s: RPU recovery failed",
 				      __func__);
 		goto out;
 	}
@@ -1122,18 +1038,15 @@ static void recovery_tasklet_fn(unsigned long data)
 
 	hal_dev_ctx = (struct nrf_wifi_hal_dev_ctx *)data;
 	if (!hal_dev_ctx) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid hal_dev_ctx",
+		nrf_wifi_osal_log_err("%s: Invalid hal_dev_ctx",
 				      __func__);
 		return;
 	}
 
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->lock_recovery,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->lock_recovery,
 					&flags);
 	hal_rpu_recovery(hal_dev_ctx);
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->lock_recovery,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->lock_recovery,
 				       &flags);
 }
 
@@ -1148,12 +1061,10 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 	unsigned int size = 0;
 #endif /* !CONFIG_NRF700X_RADIO_TEST */
 
-	hal_dev_ctx = nrf_wifi_osal_mem_zalloc(hpriv->opriv,
-					       sizeof(*hal_dev_ctx));
+	hal_dev_ctx = nrf_wifi_osal_mem_zalloc(sizeof(*hal_dev_ctx));
 
 	if (!hal_dev_ctx) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate hal_dev_ctx",
+		nrf_wifi_osal_log_err("%s: Unable to allocate hal_dev_ctx",
 				      __func__);
 		goto err;
 	}
@@ -1164,92 +1075,77 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 	hal_dev_ctx->num_cmds = RPU_CMD_START_MAGIC;
 
-	hal_dev_ctx->cmd_q = nrf_wifi_utils_q_alloc(hpriv->opriv);
+	hal_dev_ctx->cmd_q = nrf_wifi_utils_q_alloc();
 
 	if (!hal_dev_ctx->cmd_q) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate command queue",
+		nrf_wifi_osal_log_err("%s: Unable to allocate command queue",
 				      __func__);
 		goto hal_dev_free;
 	}
 
-	hal_dev_ctx->event_q = nrf_wifi_utils_q_alloc(hpriv->opriv);
+	hal_dev_ctx->event_q = nrf_wifi_utils_q_alloc();
 
 	if (!hal_dev_ctx->event_q) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate event queue",
+		nrf_wifi_osal_log_err("%s: Unable to allocate event queue",
 				      __func__);
 		goto cmd_q_free;
 	}
 
-	hal_dev_ctx->lock_hal = nrf_wifi_osal_spinlock_alloc(hpriv->opriv);
+	hal_dev_ctx->lock_hal = nrf_wifi_osal_spinlock_alloc();
 
 	if (!hal_dev_ctx->lock_hal) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate HAL lock", __func__);
+		nrf_wifi_osal_log_err("%s: Unable to allocate HAL lock", __func__);
 		hal_dev_ctx = NULL;
 		goto event_q_free;
 	}
 
-	nrf_wifi_osal_spinlock_init(hpriv->opriv,
-				    hal_dev_ctx->lock_hal);
+	nrf_wifi_osal_spinlock_init(hal_dev_ctx->lock_hal);
 
-	hal_dev_ctx->lock_rx = nrf_wifi_osal_spinlock_alloc(hpriv->opriv);
+	hal_dev_ctx->lock_rx = nrf_wifi_osal_spinlock_alloc();
 
 	if (!hal_dev_ctx->lock_rx) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate HAL lock",
+		nrf_wifi_osal_log_err("%s: Unable to allocate HAL lock",
 				      __func__);
 		goto lock_hal_free;
 	}
 
-	nrf_wifi_osal_spinlock_init(hpriv->opriv,
-				    hal_dev_ctx->lock_rx);
+	nrf_wifi_osal_spinlock_init(hal_dev_ctx->lock_rx);
 
-	hal_dev_ctx->event_tasklet = nrf_wifi_osal_tasklet_alloc(hpriv->opriv,
-		NRF_WIFI_TASKLET_TYPE_BH);
+	hal_dev_ctx->event_tasklet = nrf_wifi_osal_tasklet_alloc(NRF_WIFI_TASKLET_TYPE_BH);
 
 	if (!hal_dev_ctx->event_tasklet) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate event_tasklet",
+		nrf_wifi_osal_log_err("%s: Unable to allocate event_tasklet",
 				      __func__);
 		goto lock_rx_free;
 	}
 
-	nrf_wifi_osal_tasklet_init(hpriv->opriv,
-				   hal_dev_ctx->event_tasklet,
+	nrf_wifi_osal_tasklet_init(hal_dev_ctx->event_tasklet,
 				   event_tasklet_fn,
 				   (unsigned long)hal_dev_ctx);
 
-	hal_dev_ctx->recovery_tasklet = nrf_wifi_osal_tasklet_alloc(hpriv->opriv,
-		NRF_WIFI_TASKLET_TYPE_BH);
+	hal_dev_ctx->recovery_tasklet = nrf_wifi_osal_tasklet_alloc(NRF_WIFI_TASKLET_TYPE_BH);
 	if (!hal_dev_ctx->recovery_tasklet) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate recovery_tasklet",
+		nrf_wifi_osal_log_err("%s: Unable to allocate recovery_tasklet",
 				      __func__);
 		goto event_tasklet_free;
 	}
-	nrf_wifi_osal_tasklet_init(hpriv->opriv,
-				   hal_dev_ctx->recovery_tasklet,
+	nrf_wifi_osal_tasklet_init(hal_dev_ctx->recovery_tasklet,
 				   recovery_tasklet_fn,
 				   (unsigned long)hal_dev_ctx);
 
-	hal_dev_ctx->lock_recovery = nrf_wifi_osal_spinlock_alloc(hpriv->opriv);
+	hal_dev_ctx->lock_recovery = nrf_wifi_osal_spinlock_alloc();
 	if (!hal_dev_ctx->lock_recovery) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Unable to allocate recovery lock",
+		nrf_wifi_osal_log_err("%s: Unable to allocate recovery lock",
 				      __func__);
 		goto recovery_tasklet_free;
 	}
 
-	nrf_wifi_osal_spinlock_init(hpriv->opriv,
-				    hal_dev_ctx->lock_recovery);
+	nrf_wifi_osal_spinlock_init(hal_dev_ctx->lock_recovery);
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 	status = hal_rpu_ps_init(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: hal_rpu_ps_init failed",
+		nrf_wifi_osal_log_err("%s: hal_rpu_ps_init failed",
 				      __func__);
 		goto lock_recovery_free;
 	}
@@ -1259,8 +1155,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 							hal_dev_ctx);
 
 	if (!hal_dev_ctx->bal_dev_ctx) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: nrf_wifi_bal_dev_add failed",
+		nrf_wifi_osal_log_err("%s: nrf_wifi_bal_dev_add failed",
 				      __func__);
 		goto lock_recovery_free;
 	}
@@ -1268,8 +1163,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 	status = hal_rpu_irq_enable(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: hal_rpu_irq_enable failed",
+		nrf_wifi_osal_log_err("%s: hal_rpu_irq_enable failed",
 				      __func__);
 		goto bal_dev_free;
 	}
@@ -1280,12 +1174,10 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 
 		size = (num_rx_bufs * sizeof(struct nrf_wifi_hal_buf_map_info));
 
-		hal_dev_ctx->rx_buf_info[i] = nrf_wifi_osal_mem_zalloc(hpriv->opriv,
-								       size);
+		hal_dev_ctx->rx_buf_info[i] = nrf_wifi_osal_mem_zalloc(size);
 
 		if (!hal_dev_ctx->rx_buf_info[i]) {
-			nrf_wifi_osal_log_err(hpriv->opriv,
-					      "%s: No space for RX buf info[%d]",
+			nrf_wifi_osal_log_err("%s: No space for RX buf info[%d]",
 					      __func__,
 					      i);
 			goto bal_dev_free;
@@ -1295,12 +1187,10 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 	size = (hal_dev_ctx->hpriv->cfg_params.max_tx_frms *
 		sizeof(struct nrf_wifi_hal_buf_map_info));
 
-	hal_dev_ctx->tx_buf_info = nrf_wifi_osal_mem_zalloc(hpriv->opriv,
-							    size);
+	hal_dev_ctx->tx_buf_info = nrf_wifi_osal_mem_zalloc(size);
 
 	if (!hal_dev_ctx->tx_buf_info) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: No space for TX buf info",
+		nrf_wifi_osal_log_err("%s: No space for TX buf info",
 				      __func__);
 		goto rx_buf_free;
 	}
@@ -1309,8 +1199,7 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 	status = nrf_wifi_hal_rpu_pktram_buf_map_init(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hpriv->opriv,
-				      "%s: Buffer map init failed",
+		nrf_wifi_osal_log_err("%s: Buffer map init failed",
 				      __func__);
 #ifdef CONFIG_NRF700X_DATA_TX
 		goto tx_buf_free;
@@ -1322,14 +1211,12 @@ struct nrf_wifi_hal_dev_ctx *nrf_wifi_hal_dev_add(struct nrf_wifi_hal_priv *hpri
 #ifndef CONFIG_NRF700X_RADIO_TEST
 #ifdef CONFIG_NRF700X_DATA_TX
 tx_buf_free:
-	nrf_wifi_osal_mem_free(hpriv->opriv,
-			       hal_dev_ctx->tx_buf_info);
+	nrf_wifi_osal_mem_free(hal_dev_ctx->tx_buf_info);
 	hal_dev_ctx->tx_buf_info = NULL;
 rx_buf_free:
 
 	for (i = 0; i < MAX_NUM_OF_RX_QUEUES; i++) {
-		nrf_wifi_osal_mem_free(hpriv->opriv,
-						hal_dev_ctx->rx_buf_info[i]);
+		nrf_wifi_osal_mem_free(hal_dev_ctx->rx_buf_info[i]);
 		hal_dev_ctx->rx_buf_info[i] = NULL;
 	}
 #endif /* CONFIG_NRF700X_DATA_TX */
@@ -1337,29 +1224,21 @@ rx_buf_free:
 bal_dev_free:
 	nrf_wifi_bal_dev_rem(hal_dev_ctx->bal_dev_ctx);
 lock_recovery_free:
-	nrf_wifi_osal_spinlock_free(hpriv->opriv,
-					hal_dev_ctx->lock_recovery);
+	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_recovery);
 recovery_tasklet_free:
-	nrf_wifi_osal_tasklet_free(hpriv->opriv,
-					hal_dev_ctx->recovery_tasklet);
+	nrf_wifi_osal_tasklet_free(hal_dev_ctx->recovery_tasklet);
 event_tasklet_free:
-	nrf_wifi_osal_tasklet_free(hpriv->opriv,
-					hal_dev_ctx->event_tasklet);
+	nrf_wifi_osal_tasklet_free(hal_dev_ctx->event_tasklet);
 lock_rx_free:
-	nrf_wifi_osal_spinlock_free(hpriv->opriv,
-					hal_dev_ctx->lock_rx);
+	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_rx);
 lock_hal_free:
-	nrf_wifi_osal_spinlock_free(hpriv->opriv,
-					hal_dev_ctx->lock_hal);
+	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_hal);
 event_q_free:
-	nrf_wifi_utils_q_free(hpriv->opriv,
-					hal_dev_ctx->event_q);
+	nrf_wifi_utils_q_free(hal_dev_ctx->event_q);
 cmd_q_free:
-	nrf_wifi_utils_q_free(hpriv->opriv,
-					hal_dev_ctx->cmd_q);
+	nrf_wifi_utils_q_free(hal_dev_ctx->cmd_q);
 hal_dev_free:
-	nrf_wifi_osal_mem_free(hpriv->opriv,
-					hal_dev_ctx);
+	nrf_wifi_osal_mem_free(hal_dev_ctx);
 	hal_dev_ctx = NULL;
 err:
 	return NULL;
@@ -1370,37 +1249,27 @@ void nrf_wifi_hal_dev_rem(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
 	unsigned int i = 0;
 
-	nrf_wifi_osal_tasklet_kill(hal_dev_ctx->hpriv->opriv,
-				   hal_dev_ctx->recovery_tasklet);
-	nrf_wifi_osal_tasklet_free(hal_dev_ctx->hpriv->opriv,
-				   hal_dev_ctx->recovery_tasklet);
+	nrf_wifi_osal_tasklet_kill(hal_dev_ctx->recovery_tasklet);
+	nrf_wifi_osal_tasklet_free(hal_dev_ctx->recovery_tasklet);
 
-	nrf_wifi_osal_tasklet_kill(hal_dev_ctx->hpriv->opriv,
-				   hal_dev_ctx->event_tasklet);
+	nrf_wifi_osal_tasklet_kill(hal_dev_ctx->event_tasklet);
 
-	nrf_wifi_osal_tasklet_free(hal_dev_ctx->hpriv->opriv,
-				   hal_dev_ctx->event_tasklet);
+	nrf_wifi_osal_tasklet_free(hal_dev_ctx->event_tasklet);
 
-	nrf_wifi_osal_spinlock_free(hal_dev_ctx->hpriv->opriv,
-				    hal_dev_ctx->lock_hal);
-	nrf_wifi_osal_spinlock_free(hal_dev_ctx->hpriv->opriv,
-				    hal_dev_ctx->lock_rx);
+	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_hal);
+	nrf_wifi_osal_spinlock_free(hal_dev_ctx->lock_rx);
 
-	nrf_wifi_utils_q_free(hal_dev_ctx->hpriv->opriv,
-			      hal_dev_ctx->event_q);
+	nrf_wifi_utils_q_free(hal_dev_ctx->event_q);
 
-	nrf_wifi_utils_q_free(hal_dev_ctx->hpriv->opriv,
-			      hal_dev_ctx->cmd_q);
+	nrf_wifi_utils_q_free(hal_dev_ctx->cmd_q);
 
 	nrf_wifi_bal_dev_rem(hal_dev_ctx->bal_dev_ctx);
 
-	nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-			       hal_dev_ctx->tx_buf_info);
+	nrf_wifi_osal_mem_free(hal_dev_ctx->tx_buf_info);
 	hal_dev_ctx->tx_buf_info = NULL;
 
 	for (i = 0; i < MAX_NUM_OF_RX_QUEUES; i++) {
-		nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->rx_buf_info[i]);
+		nrf_wifi_osal_mem_free(hal_dev_ctx->rx_buf_info[i]);
 		hal_dev_ctx->rx_buf_info[i] = NULL;
 	}
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
@@ -1409,8 +1278,7 @@ void nrf_wifi_hal_dev_rem(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 
 	hal_dev_ctx->hpriv->num_devs--;
 
-	nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-			       hal_dev_ctx);
+	nrf_wifi_osal_mem_free(hal_dev_ctx);
 }
 
 
@@ -1425,8 +1293,7 @@ enum nrf_wifi_status nrf_wifi_hal_dev_init(struct nrf_wifi_hal_dev_ctx *hal_dev_
 	status = nrf_wifi_bal_dev_init(hal_dev_ctx->bal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: nrf_wifi_bal_dev_init failed",
+		nrf_wifi_osal_log_err("%s: nrf_wifi_bal_dev_init failed",
 				      __func__);
 		goto out;
 	}
@@ -1440,8 +1307,7 @@ enum nrf_wifi_status nrf_wifi_hal_dev_init(struct nrf_wifi_hal_dev_ctx *hal_dev_
 				  sizeof(hal_dev_ctx->rpu_info.hpqm_info));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Failed to get the HPQ info",
+		nrf_wifi_osal_log_err("%s: Failed to get the HPQ info",
 				      __func__);
 		goto out;
 	}
@@ -1452,8 +1318,7 @@ enum nrf_wifi_status nrf_wifi_hal_dev_init(struct nrf_wifi_hal_dev_ctx *hal_dev_
 				  sizeof(hal_dev_ctx->rpu_info.rx_cmd_base));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading the RX cmd base failed",
+		nrf_wifi_osal_log_err("%s: Reading the RX cmd base failed",
 				      __func__);
 		goto out;
 	}
@@ -1477,8 +1342,7 @@ void nrf_wifi_hal_lock_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
 	unsigned long flags = 0;
 
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->lock_rx,
 					&flags);
 }
 
@@ -1486,8 +1350,7 @@ void nrf_wifi_hal_unlock_rx(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
 	unsigned long flags = 0;
 
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->lock_rx,
 				       &flags);
 }
 
@@ -1503,8 +1366,7 @@ enum nrf_wifi_status nrf_wifi_hal_irq_handler(void *data)
 
 	hal_dev_ctx = (struct nrf_wifi_hal_dev_ctx *)data;
 
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->lock_rx,
 					&flags);
 
 	if (hal_dev_ctx->hal_status != NRF_WIFI_HAL_STATUS_ENABLED) {
@@ -1537,17 +1399,14 @@ enum nrf_wifi_status nrf_wifi_hal_irq_handler(void *data)
 	}
 
 	if (do_rpu_recovery) {
-		nrf_wifi_osal_tasklet_schedule(hal_dev_ctx->hpriv->opriv,
-					       hal_dev_ctx->recovery_tasklet);
+		nrf_wifi_osal_tasklet_schedule(hal_dev_ctx->recovery_tasklet);
 		goto out;
 	}
 
-	nrf_wifi_osal_tasklet_schedule(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->event_tasklet);
+	nrf_wifi_osal_tasklet_schedule(hal_dev_ctx->event_tasklet);
 
 out:
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->lock_rx,
 				       &flags);
 	return status;
 }
@@ -1569,8 +1428,7 @@ static int nrf_wifi_hal_poll_reg(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 					  reg_addr);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Read from address (0x%X) failed, val (0x%X)",
+			nrf_wifi_osal_log_err("%s: Read from address (0x%X) failed, val (0x%X)",
 					      __func__,
 					      reg_addr,
 					      val);
@@ -1581,13 +1439,11 @@ static int nrf_wifi_hal_poll_reg(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 			break;
 		}
 
-		nrf_wifi_osal_sleep_ms(hal_dev_ctx->hpriv->opriv,
-				       poll_delay);
+		nrf_wifi_osal_sleep_ms(poll_delay);
 	} while (count-- > 0);
 
 	if (count == 0) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Timed out polling on (0x%X)",
+		nrf_wifi_osal_log_err("%s: Timed out polling on (0x%X)",
 				      __func__,
 				      reg_addr);
 
@@ -1607,8 +1463,7 @@ enum nrf_wifi_status nrf_wifi_hal_proc_reset(struct nrf_wifi_hal_dev_ctx *hal_de
 
 	if ((rpu_proc != RPU_PROC_TYPE_MCU_LMAC) &&
 	    (rpu_proc != RPU_PROC_TYPE_MCU_UMAC)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Unsupported RPU processor(%d)",
+		nrf_wifi_osal_log_err("%s: Unsupported RPU processor(%d)",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -1628,8 +1483,7 @@ enum nrf_wifi_status nrf_wifi_hal_proc_reset(struct nrf_wifi_hal_dev_ctx *hal_de
 	}
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Pulsed soft reset of MCU failed for (%d) processor",
+		nrf_wifi_osal_log_err("%s: Pulsed soft reset of MCU failed for (%d) processor",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -1652,8 +1506,7 @@ enum nrf_wifi_status nrf_wifi_hal_proc_reset(struct nrf_wifi_hal_dev_ctx *hal_de
 	}
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: MCU (%d) failed to come out of reset",
+		nrf_wifi_osal_log_err("%s: MCU (%d) failed to come out of reset",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -1697,8 +1550,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_chk_boot(struct nrf_wifi_hal_dev_ctx *hal_d
 		addr = RPU_MEM_UMAC_BOOT_SIG;
 		exp_val = NRF_WIFI_UMAC_BOOT_SIG;
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid RPU processor (%d)",
+		nrf_wifi_osal_log_err("%s: Invalid RPU processor (%d)",
 				      __func__,
 				      rpu_proc);
 	}
@@ -1712,8 +1564,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_chk_boot(struct nrf_wifi_hal_dev_ctx *hal_d
 					  sizeof(val));
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Reading of boot signature failed for RPU(%d)",
+			nrf_wifi_osal_log_err("%s: Reading of boot signature failed for RPU(%d)",
 					      __func__,
 					      rpu_proc);
 		}
@@ -1723,13 +1574,11 @@ enum nrf_wifi_status nrf_wifi_hal_fw_chk_boot(struct nrf_wifi_hal_dev_ctx *hal_d
 		}
 
 		/* Sleep for 10 ms */
-		nrf_wifi_osal_sleep_ms(hal_dev_ctx->hpriv->opriv,
-				       10);
+		nrf_wifi_osal_sleep_ms(10);
 	};
 
 	if (mcu_ready_wait_count <= 0) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Boot_sig check failed for RPU(%d), "
+		nrf_wifi_osal_log_err("%s: Boot_sig check failed for RPU(%d), "
 				      "Expected: 0x%X, Actual: 0x%X",
 				      __func__,
 				      rpu_proc,
@@ -1748,8 +1597,7 @@ out:
 
 
 struct nrf_wifi_hal_priv *
-nrf_wifi_hal_init(struct nrf_wifi_osal_priv *opriv,
-		  struct nrf_wifi_hal_cfg_params *cfg_params,
+nrf_wifi_hal_init(struct nrf_wifi_hal_cfg_params *cfg_params,
 		  enum nrf_wifi_status (*intr_callbk_fn)(void *dev_ctx,
 							 void *event_data,
 							 unsigned int len),
@@ -1761,50 +1609,40 @@ nrf_wifi_hal_init(struct nrf_wifi_osal_priv *opriv,
 	struct nrf_wifi_hal_priv *hpriv = NULL;
 	struct nrf_wifi_bal_cfg_params bal_cfg_params;
 
-	hpriv = nrf_wifi_osal_mem_zalloc(opriv,
-					 sizeof(*hpriv));
+	hpriv = nrf_wifi_osal_mem_zalloc(sizeof(*hpriv));
 
 	if (!hpriv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate memory for hpriv",
+		nrf_wifi_osal_log_err("%s: Unable to allocate memory for hpriv",
 				      __func__);
 		goto out;
 	}
 
-	hpriv->opriv = opriv;
-
-	nrf_wifi_osal_mem_cpy(opriv,
-			      &hpriv->cfg_params,
+	nrf_wifi_osal_mem_cpy(&hpriv->cfg_params,
 			      cfg_params,
 			      sizeof(hpriv->cfg_params));
 
 	hpriv->intr_callbk_fn = intr_callbk_fn;
 	hpriv->rpu_recovery_callbk_fn = rpu_recovery_callbk_fn;
 
-	status = pal_rpu_addr_offset_get(opriv,
-					 RPU_ADDR_PKTRAM_START,
+	status = pal_rpu_addr_offset_get(RPU_ADDR_PKTRAM_START,
 					 &hpriv->addr_pktram_base,
 					 RPU_PROC_TYPE_MAX);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: pal_rpu_addr_offset_get failed",
+		nrf_wifi_osal_log_err("%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		goto out;
 	}
 
 	bal_cfg_params.addr_pktram_base = hpriv->addr_pktram_base;
 
-	hpriv->bpriv = nrf_wifi_bal_init(opriv,
-					 &bal_cfg_params,
+	hpriv->bpriv = nrf_wifi_bal_init(&bal_cfg_params,
 					 &nrf_wifi_hal_irq_handler);
 
 	if (!hpriv->bpriv) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Failed",
+		nrf_wifi_osal_log_err("%s: Failed",
 				      __func__);
-		nrf_wifi_osal_mem_free(opriv,
-				       hpriv);
+		nrf_wifi_osal_mem_free(hpriv);
 		hpriv = NULL;
 	}
 out:
@@ -1816,8 +1654,7 @@ void nrf_wifi_hal_deinit(struct nrf_wifi_hal_priv *hpriv)
 {
 	nrf_wifi_bal_deinit(hpriv->bpriv);
 
-	nrf_wifi_osal_mem_free(hpriv->opriv,
-			       hpriv);
+	nrf_wifi_osal_mem_free(hpriv);
 }
 
 
@@ -1828,8 +1665,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_info_get(struct nrf_wifi_hal_dev_ctx *hal_
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
 	if (!hal_dev_ctx || !otp_info) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1840,8 +1676,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_info_get(struct nrf_wifi_hal_dev_ctx *hal_
 				  sizeof(*otp_info));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: OTP info get failed",
+		nrf_wifi_osal_log_err("%s: OTP info get failed",
 				      __func__);
 		goto out;
 	}
@@ -1852,8 +1687,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_info_get(struct nrf_wifi_hal_dev_ctx *hal_
 				  sizeof(*otp_flags));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: OTP flags get failed",
+		nrf_wifi_osal_log_err("%s: OTP flags get failed",
 				      __func__);
 		goto out;
 	}
@@ -1868,8 +1702,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_ft_prog_ver_get(struct nrf_wifi_hal_dev_ct
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
 	if (!hal_dev_ctx || !ft_prog_ver) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1880,8 +1713,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_ft_prog_ver_get(struct nrf_wifi_hal_dev_ct
 				  sizeof(*ft_prog_ver));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: FT program version get failed",
+		nrf_wifi_osal_log_err("%s: FT program version get failed",
 				      __func__);
 		goto out;
 	}
@@ -1895,8 +1727,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_pack_info_get(struct nrf_wifi_hal_dev_ctx 
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
 	if (!hal_dev_ctx || !package_info) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid parameters",
+		nrf_wifi_osal_log_err("%s: Invalid parameters",
 				      __func__);
 		goto out;
 	}
@@ -1907,8 +1738,7 @@ enum nrf_wifi_status nrf_wifi_hal_otp_pack_info_get(struct nrf_wifi_hal_dev_ctx 
 				  sizeof(*package_info));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Package info get failed",
+		nrf_wifi_osal_log_err("%s: Package info get failed",
 				      __func__);
 		goto out;
 	}
@@ -1918,23 +1748,19 @@ out:
 
 void nrf_wifi_hal_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->lock_rx,
 					NULL);
 	hal_dev_ctx->hal_status = NRF_WIFI_HAL_STATUS_ENABLED;
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->lock_rx,
 				       NULL);
 }
 
 void nrf_wifi_hal_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 {
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->lock_rx,
 					NULL);
 	hal_dev_ctx->hal_status = NRF_WIFI_HAL_STATUS_DISABLED;
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->lock_rx,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->lock_rx,
 				       NULL);
 }
 

--- a/nrf_wifi/hw_if/hal/src/hal_fw_patch_loader.c
+++ b/nrf_wifi/hw_if/hal/src/hal_fw_patch_loader.c
@@ -98,35 +98,32 @@ static enum nrf_wifi_status hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal_d
 			chunk * MAX_PATCH_CHUNK_SIZE;
 		int dest_chunk_offset = dest_addr + chunk * MAX_PATCH_CHUNK_SIZE;
 
-		patch_data_ram = nrf_wifi_osal_mem_alloc(hal_dev_ctx->hpriv->opriv,
-									patch_chunk_size);
+		patch_data_ram = nrf_wifi_osal_mem_alloc(patch_chunk_size);
 		if (!patch_data_ram) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				"%s: Failed to allocate memory for patch %s-%s: chunk %d/%d, size: %d",
-				__func__,
-				rpu_proc_to_str(rpu_proc),
-				patch_id_str,
-				chunk + 1,
-				num_chunks,
-				patch_chunk_size);
+			nrf_wifi_osal_log_err("%s: Mem alloc failed for patch "
+					      "%s-%s: chunk %d/%d, size: %d",
+					      __func__,
+					      rpu_proc_to_str(rpu_proc),
+					      patch_id_str,
+					      chunk + 1,
+					      num_chunks,
+					      patch_chunk_size);
 			status = NRF_WIFI_STATUS_FAIL;
 			goto out;
 		}
 
-		nrf_wifi_osal_mem_cpy(hal_dev_ctx->hpriv->opriv,
-							patch_data_ram,
-							src_patch_offset,
-							patch_chunk_size);
+		nrf_wifi_osal_mem_cpy(patch_data_ram,
+				      src_patch_offset,
+				      patch_chunk_size);
 
 
-		nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-			"%s: Copying patch %s-%s: chunk %d/%d, size: %d",
-			__func__,
-			rpu_proc_to_str(rpu_proc),
-			patch_id_str,
-			chunk + 1,
-			num_chunks,
-			patch_chunk_size);
+		nrf_wifi_osal_log_dbg("%s: Copying patch %s-%s: chunk %d/%d, size: %d",
+				      __func__,
+				      rpu_proc_to_str(rpu_proc),
+				      patch_id_str,
+				      chunk + 1,
+				      num_chunks,
+				      patch_chunk_size);
 
 		status = hal_fw_patch_chunk_load(hal_dev_ctx,
 						rpu_proc,
@@ -134,20 +131,18 @@ static enum nrf_wifi_status hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal_d
 						patch_data_ram,
 						patch_chunk_size);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				"%s: Copying patch %s-%s: chunk %d/%d, size: %d failed",
-				__func__,
-				rpu_proc_to_str(rpu_proc),
-				patch_id_str,
-				chunk + 1,
-				num_chunks,
-				patch_chunk_size);
+			nrf_wifi_osal_log_err("%s: Patch copy %s-%s: chunk %d/%d, size: %d failed",
+					      __func__,
+					      rpu_proc_to_str(rpu_proc),
+					      patch_id_str,
+					      chunk + 1,
+					      num_chunks,
+					      patch_chunk_size);
 			goto out;
 		}
 out:
 		if (patch_data_ram)
-			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-				       patch_data_ram);
+			nrf_wifi_osal_mem_free(patch_data_ram);
 		if (status != NRF_WIFI_STATUS_SUCCESS)
 			break;
 	}
@@ -171,8 +166,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal
 	int patch = 0;
 
 	if (!fw_pri_patch_data) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Primary patch missing for RPU (%d)",
+		nrf_wifi_osal_log_err("%s: Primary patch missing for RPU (%d)",
 				      __func__,
 				      rpu_proc);
 		status = NRF_WIFI_STATUS_FAIL;
@@ -180,8 +174,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal
 	}
 
 	if (!fw_sec_patch_data) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Secondary patch missing for RPU (%d)",
+		nrf_wifi_osal_log_err("%s: Secondary patch missing for RPU (%d)",
 				      __func__,
 				      rpu_proc);
 		status = NRF_WIFI_STATUS_FAIL;
@@ -201,8 +194,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_load(struct nrf_wifi_hal_dev_ctx *hal
 		sec_dest_addr = RPU_MEM_UMAC_PATCH_BIN;
 		break;
 	default:
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid RPU processor type[%d]",
+		nrf_wifi_osal_log_err("%s: Invalid RPU processor type[%d]",
 				      __func__,
 				      rpu_proc);
 
@@ -265,8 +257,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 			sleepctrl_val = NRF_WIFI_UMAC_ROM_PATCH_OFFSET;
 		}
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid RPU processor type %d",
+		nrf_wifi_osal_log_err("%s: Invalid RPU processor type %d",
 				      __func__,
 				      rpu_proc);
 		goto out;
@@ -282,8 +273,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 				   sizeof(boot_sig_val));
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Clearing of FW pass signature failed for RPU(%d)",
+		nrf_wifi_osal_log_err("%s: Clearing of FW pass signature failed for RPU(%d)",
 				      __func__,
 				      rpu_proc);
 
@@ -296,8 +286,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 					   sleepctrl_addr,
 					   sleepctrl_val);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing to sleep control register failed for RPU(%d)\n",
+			nrf_wifi_osal_log_err("%s: Sleep control reg write failed for RPU(%d)\n",
 					      __func__,
 					      rpu_proc);
 
@@ -313,8 +302,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 					   boot_vector->addr,
 					   boot_vector->val);
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing boot vector failed for RPU(%d)\n",
+			nrf_wifi_osal_log_err("%s: Writing boot vector failed for RPU(%d)\n",
 					      __func__,
 					      rpu_proc);
 
@@ -328,8 +316,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_patch_boot(struct nrf_wifi_hal_dev_ctx *hal
 				   0x1);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU processor(%d) run failed",
+		nrf_wifi_osal_log_err("%s: RPU processor(%d) run failed",
 				      __func__,
 				      rpu_proc);
 

--- a/nrf_wifi/hw_if/hal/src/hal_interrupt.c
+++ b/nrf_wifi/hw_if/hal/src/hal_interrupt.c
@@ -29,8 +29,7 @@ enum nrf_wifi_status hal_rpu_irq_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 				  RPU_REG_INT_FROM_RPU_CTRL);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading from Root interrupt register failed",
+		nrf_wifi_osal_log_err("%s: Reading from Root interrupt register failed",
 				      __func__);
 		goto out;
 	}
@@ -42,8 +41,7 @@ enum nrf_wifi_status hal_rpu_irq_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 				   val);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Enabling Root interrupt failed",
+		nrf_wifi_osal_log_err("%s: Enabling Root interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -56,8 +54,7 @@ enum nrf_wifi_status hal_rpu_irq_enable(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx
 				   val);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s:Enabling MCU interrupt failed",
+		nrf_wifi_osal_log_err("%s:Enabling MCU interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -77,8 +74,7 @@ enum nrf_wifi_status hal_rpu_irq_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 				  RPU_REG_INT_FROM_RPU_CTRL);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading from Root interrupt register failed",
+		nrf_wifi_osal_log_err("%s: Reading from Root interrupt register failed",
 				      __func__);
 		goto out;
 	}
@@ -90,8 +86,7 @@ enum nrf_wifi_status hal_rpu_irq_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 				   val);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Disabling Root interrupt failed",
+		nrf_wifi_osal_log_err("%s: Disabling Root interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -103,8 +98,7 @@ enum nrf_wifi_status hal_rpu_irq_disable(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 				   val);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Disabling MCU interrupt failed",
+		nrf_wifi_osal_log_err("%s: Disabling MCU interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -140,8 +134,7 @@ static bool hal_rpu_irq_wdog_chk(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx)
 				  RPU_REG_MIPS_MCU_UCCP_INT_STATUS);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Reading from interrupt status register failed",
+		nrf_wifi_osal_log_err("%s: Reading from interrupt status register failed",
 				      __func__);
 		goto out;
 	}
@@ -164,8 +157,7 @@ static enum nrf_wifi_status hal_rpu_irq_wdog_ack(struct nrf_wifi_hal_dev_ctx *ha
 				   1 << RPU_REG_BIT_MIPS_WATCHDOG_INT_CLEAR);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Acknowledging watchdog interrupt failed",
+		nrf_wifi_osal_log_err("%s: Acknowledging watchdog interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -184,8 +176,7 @@ static enum nrf_wifi_status hal_rpu_irq_wdog_rearm(struct nrf_wifi_hal_dev_ctx *
 				  RPU_REG_MIPS_MCU_TIMER_RESET_VAL);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Rearming watchdog interrupt failed",
+		nrf_wifi_osal_log_err("%s: Rearming watchdog interrupt failed",
 				      __func__);
 		goto out;
 	}
@@ -204,8 +195,7 @@ static enum nrf_wifi_status hal_rpu_event_free(struct nrf_wifi_hal_dev_ctx *hal_
 				     event_addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Enqueueing of event failed",
+		nrf_wifi_osal_log_err("%s: Enqueueing of event failed",
 				      __func__);
 		goto out;
 	}
@@ -226,8 +216,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 	/* QSPI : avoid global vars as they can be unaligned */
 	unsigned char event_data_typical[RPU_EVENT_COMMON_SIZE_MAX];
 
-	nrf_wifi_osal_mem_set(hal_dev_ctx->hpriv->opriv,
-			      event_data_typical,
+	nrf_wifi_osal_mem_set(event_data_typical,
 			      0,
 			      sizeof(event_data_typical));
 
@@ -241,8 +230,7 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 					  sizeof(event_data_typical));
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Reading of the event failed",
+			nrf_wifi_osal_log_err("%s: Reading of the event failed",
 					      __func__);
 			goto out;
 		}
@@ -252,12 +240,10 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 		rpu_msg_len = rpu_msg_hdr->len;
 
 		/* Allocate space to assemble the entire event */
-		hal_dev_ctx->event_data = nrf_wifi_osal_mem_zalloc(hal_dev_ctx->hpriv->opriv,
-								   rpu_msg_len);
+		hal_dev_ctx->event_data = nrf_wifi_osal_mem_zalloc(rpu_msg_len);
 
 		if (!hal_dev_ctx->event_data) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to alloc buff for event data",
+			nrf_wifi_osal_log_err("%s: Unable to alloc buff for event data",
 					      __func__);
 			goto out;
 		} else {
@@ -277,11 +263,9 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
-				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Reading of first fragment of event failed",
+				nrf_wifi_osal_log_err("%s: Reading of first event fragment failed",
 						      __func__);
-				nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-						       hal_dev_ctx->event_data);
+				nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 				hal_dev_ctx->event_data = NULL;
 				goto out;
 			}
@@ -292,11 +276,9 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 							    event_addr);
 
 				if (status != NRF_WIFI_STATUS_SUCCESS) {
-					nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							      "%s: Freeing up of the event failed",
+					nrf_wifi_osal_log_err("%s: Freeing up of the event failed",
 							      __func__);
-					nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-							       hal_dev_ctx->event_data);
+					nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 					hal_dev_ctx->event_data = NULL;
 					goto out;
 				}
@@ -318,17 +300,14 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 							  rpu_msg_len);
 
 				if (status != NRF_WIFI_STATUS_SUCCESS) {
-					nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							      "%s: Reading of large event failed",
+					nrf_wifi_osal_log_err("%s: Reading of large event failed",
 							      __func__);
-					nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-							       hal_dev_ctx->event_data);
+					nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 					hal_dev_ctx->event_data = NULL;
 					goto out;
 				}
 			} else {
-				nrf_wifi_osal_mem_cpy(hal_dev_ctx->hpriv->opriv,
-						      hal_dev_ctx->event_data_curr,
+				nrf_wifi_osal_mem_cpy(hal_dev_ctx->event_data_curr,
 						      event_data_typical,
 						      rpu_msg_len);
 			}
@@ -339,11 +318,9 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 							    event_addr);
 
 				if (status != NRF_WIFI_STATUS_SUCCESS) {
-					nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							      "%s: Freeing up of the event failed",
+					nrf_wifi_osal_log_err("%s: Freeing up of the event failed",
 							      __func__);
-					nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-							       hal_dev_ctx->event_data);
+					nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 					hal_dev_ctx->event_data = NULL;
 					goto out;
 				}
@@ -366,11 +343,9 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 						  event_data_size);
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
-				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Reading of large event failed",
+				nrf_wifi_osal_log_err("%s: Reading of large event failed",
 						      __func__);
-				nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-						       hal_dev_ctx->event_data);
+				nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 				hal_dev_ctx->event_data = NULL;
 				goto out;
 			}
@@ -382,11 +357,9 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 						    event_addr);
 
 			if (status != NRF_WIFI_STATUS_SUCCESS) {
-				nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-						      "%s: Freeing up of the event failed",
+				nrf_wifi_osal_log_err("%s: Freeing up of the event failed",
 						      __func__);
-				nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-						       hal_dev_ctx->event_data);
+				nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 				hal_dev_ctx->event_data = NULL;
 				goto out;
 			}
@@ -400,46 +373,37 @@ static enum nrf_wifi_status hal_rpu_event_get(struct nrf_wifi_hal_dev_ctx *hal_d
 	 * fragmented event
 	 */
 	if (!hal_dev_ctx->event_data_pending) {
-		event = nrf_wifi_osal_mem_zalloc(hal_dev_ctx->hpriv->opriv,
-						 sizeof(*event) + hal_dev_ctx->event_data_len);
+		event = nrf_wifi_osal_mem_zalloc(sizeof(*event) + hal_dev_ctx->event_data_len);
 
 		if (!event) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to alloc HAL msg for event",
+			nrf_wifi_osal_log_err("%s: Unable to alloc HAL msg for event",
 					      __func__);
-			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-					       hal_dev_ctx->event_data);
+			nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 			hal_dev_ctx->event_data = NULL;
 			goto out;
 		}
 
-		nrf_wifi_osal_mem_cpy(hal_dev_ctx->hpriv->opriv,
-				      event->data,
+		nrf_wifi_osal_mem_cpy(event->data,
 				      hal_dev_ctx->event_data,
 				      hal_dev_ctx->event_data_len);
 
 		event->len = hal_dev_ctx->event_data_len;
 
-		status = nrf_wifi_utils_q_enqueue(hal_dev_ctx->hpriv->opriv,
-						  hal_dev_ctx->event_q,
+		status = nrf_wifi_utils_q_enqueue(hal_dev_ctx->event_q,
 						  event);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Unable to queue event",
+			nrf_wifi_osal_log_err("%s: Unable to queue event",
 					      __func__);
-			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-					       event);
+			nrf_wifi_osal_mem_free(event);
 			event = NULL;
-			nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-					       hal_dev_ctx->event_data);
+			nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 			hal_dev_ctx->event_data = NULL;
 			goto out;
 		}
 
 		/* Reset the state variables */
-		nrf_wifi_osal_mem_free(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->event_data);
+		nrf_wifi_osal_mem_free(hal_dev_ctx->event_data);
 		hal_dev_ctx->event_data = NULL;
 		hal_dev_ctx->event_data_curr = NULL;
 		hal_dev_ctx->event_data_len = 0;
@@ -465,8 +429,7 @@ static unsigned int hal_rpu_event_get_all(struct nrf_wifi_hal_dev_ctx *hal_dev_c
 					     &event_addr);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Failed to get event addr",
+			nrf_wifi_osal_log_err("%s: Failed to get event addr",
 					      __func__);
 			goto out;
 		}
@@ -484,8 +447,7 @@ static unsigned int hal_rpu_event_get_all(struct nrf_wifi_hal_dev_ctx *hal_dev_c
 					   event_addr);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Failed to queue event",
+			nrf_wifi_osal_log_err("%s: Failed to queue event",
 					      __func__);
 			goto out;
 		}
@@ -506,27 +468,22 @@ static enum nrf_wifi_status hal_rpu_process_wdog(struct nrf_wifi_hal_dev_ctx *ha
 	unsigned long flags = 0;
 #endif
 
-	nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-			      "Processing watchdog interrupt");
+	nrf_wifi_osal_log_dbg("Processing watchdog interrupt");
 
 	/* Check if host has asserted WAKEUP_NOW */
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->rpu_ps_lock,
 					&flags);
 
 	if (hal_dev_ctx->rpu_ps_state == RPU_PS_STATE_AWAKE) {
-		nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-					       hal_dev_ctx->rpu_ps_lock,
+		nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
 					       &flags);
-		nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-				      "Host has asserted WAKEUP_NOW, ignoring watchdog interrupt");
+		nrf_wifi_osal_log_dbg("Host has asserted WAKEUP_NOW, ignoring watchdog interrupt");
 		goto out;
 	}
 
 	rpu_recovery = true;
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
 				       &flags);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
@@ -535,8 +492,7 @@ static enum nrf_wifi_status hal_rpu_process_wdog(struct nrf_wifi_hal_dev_ctx *ha
 		goto out;
 	}
 
-	nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-			      "Host has not asserted WAKEUP_NOW, start RPU recovery");
+	nrf_wifi_osal_log_dbg("Host has not asserted WAKEUP_NOW, start RPU recovery");
 out:
 	nrf_wifi_status = NRF_WIFI_STATUS_SUCCESS;
 	*do_rpu_recovery = rpu_recovery;
@@ -565,22 +521,19 @@ enum nrf_wifi_status hal_rpu_irq_process(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 	num_events = hal_rpu_event_get_all(hal_dev_ctx);
 
 	if (hal_rpu_irq_wdog_chk(hal_dev_ctx)) {
-		nrf_wifi_osal_log_dbg(hal_dev_ctx->hpriv->opriv,
-						"Received watchdog interrupt");
+		nrf_wifi_osal_log_dbg("Received watchdog interrupt");
 
 		status = hal_rpu_process_wdog(hal_dev_ctx, do_rpu_recovery);
 		if (status == NRF_WIFI_STATUS_FAIL) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							"%s: hal_rpu_process_wdog failed",
-							__func__);
+			nrf_wifi_osal_log_err("%s: hal_rpu_process_wdog failed",
+					      __func__);
 			goto out;
 		}
 
 		status = hal_rpu_irq_wdog_ack(hal_dev_ctx);
 		if (status == NRF_WIFI_STATUS_FAIL) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-							"%s: hal_rpu_irq_wdog_ack failed",
-							__func__);
+			nrf_wifi_osal_log_err("%s: hal_rpu_irq_wdog_ack failed",
+					      __func__);
 			goto out;
 		}
 	}
@@ -588,8 +541,7 @@ enum nrf_wifi_status hal_rpu_irq_process(struct nrf_wifi_hal_dev_ctx *hal_dev_ct
 	status = hal_rpu_irq_ack(hal_dev_ctx);
 
 	if (status == NRF_WIFI_STATUS_FAIL) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: hal_rpu_irq_ack failed",
+		nrf_wifi_osal_log_err("%s: hal_rpu_irq_ack failed",
 				      __func__);
 		goto out;
 	}

--- a/nrf_wifi/hw_if/hal/src/hal_mem.c
+++ b/nrf_wifi/hw_if/hal/src/hal_mem.c
@@ -84,28 +84,24 @@ static enum nrf_wifi_status rpu_mem_read_ram(struct nrf_wifi_hal_dev_ctx *hal_de
 	unsigned long flags = 0;
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
-	status = pal_rpu_addr_offset_get(hal_dev_ctx->hpriv->opriv,
-					 ram_addr_val,
+	status = pal_rpu_addr_offset_get(ram_addr_val,
 					 &addr_offset,
 					 hal_dev_ctx->curr_proc);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed",
+		nrf_wifi_osal_log_err("%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		return status;
 	}
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->rpu_ps_lock,
 					&flags);
 
 	status = hal_rpu_ps_wake(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed",
+		nrf_wifi_osal_log_err("%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}
@@ -120,8 +116,7 @@ static enum nrf_wifi_status rpu_mem_read_ram(struct nrf_wifi_hal_dev_ctx *hal_de
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 out:
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
 				       &flags);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
@@ -140,28 +135,24 @@ static enum nrf_wifi_status rpu_mem_write_ram(struct nrf_wifi_hal_dev_ctx *hal_d
 	unsigned long flags = 0;
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
-	status = pal_rpu_addr_offset_get(hal_dev_ctx->hpriv->opriv,
-					 ram_addr_val,
+	status = pal_rpu_addr_offset_get(ram_addr_val,
 					 &addr_offset,
 					 hal_dev_ctx->curr_proc);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed",
+		nrf_wifi_osal_log_err("%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		return status;
 	}
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->rpu_ps_lock,
 					&flags);
 
 	status = hal_rpu_ps_wake(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed",
+		nrf_wifi_osal_log_err("%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}
@@ -176,8 +167,7 @@ static enum nrf_wifi_status rpu_mem_write_ram(struct nrf_wifi_hal_dev_ctx *hal_d
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 out:
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
 				       &flags);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
@@ -202,15 +192,13 @@ static enum nrf_wifi_status rpu_mem_write_core(struct nrf_wifi_hal_dev_ctx *hal_
 	 */
 	if (!hal_rpu_is_mem_core_indirect(hal_dev_ctx->curr_proc,
 				 core_addr_val)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address",
+		nrf_wifi_osal_log_err("%s: Invalid memory address",
 				      __func__);
 		goto out;
 	}
 
 	if (core_addr_val % 4 != 0) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Address not multiple of 4 bytes",
+		nrf_wifi_osal_log_err("%s: Address not multiple of 4 bytes",
 				      __func__);
 		goto out;
 	}
@@ -234,8 +222,7 @@ static enum nrf_wifi_status rpu_mem_write_core(struct nrf_wifi_hal_dev_ctx *hal_
 				   addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Writing to address reg failed",
+		nrf_wifi_osal_log_err("%s: Writing to address reg failed",
 				      __func__);
 		goto out;
 	}
@@ -248,8 +235,7 @@ static enum nrf_wifi_status rpu_mem_write_core(struct nrf_wifi_hal_dev_ctx *hal_
 					   data);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing to data reg failed",
+			nrf_wifi_osal_log_err("%s: Writing to data reg failed",
 					      __func__);
 			goto out;
 		}
@@ -294,8 +280,7 @@ static enum nrf_wifi_status rpu_mem_write_bev(struct nrf_wifi_hal_dev_ctx *hal_d
 	if ((bev_addr_val < RPU_ADDR_BEV_START) ||
 	    (bev_addr_val > RPU_ADDR_BEV_END) ||
 	    (bev_addr_val % 4 != 0)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Address not in range or not a multiple of 4 bytes",
+		nrf_wifi_osal_log_err("%s: Address not in range or not a multiple of 4 bytes",
 				      __func__);
 		goto out;
 	}
@@ -315,8 +300,7 @@ static enum nrf_wifi_status rpu_mem_write_bev(struct nrf_wifi_hal_dev_ctx *hal_d
 					   data);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: Writing to BEV reg failed",
+			nrf_wifi_osal_log_err("%s: Writing to BEV reg failed",
 					      __func__);
 			goto out;
 		}
@@ -339,15 +323,13 @@ enum nrf_wifi_status hal_rpu_mem_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	}
 
 	if (!src_addr) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params",
+		nrf_wifi_osal_log_err("%s: Invalid params",
 				      __func__);
 		goto out;
 	}
 
 	if (!hal_rpu_is_mem_readable(hal_dev_ctx->curr_proc, rpu_mem_addr_val)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address 0x%X",
+		nrf_wifi_osal_log_err("%s: Invalid memory address 0x%X",
 				      __func__,
 				      rpu_mem_addr_val);
 		goto out;
@@ -374,16 +356,14 @@ enum nrf_wifi_status hal_rpu_mem_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	}
 
 	if (!src_addr) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params",
+		nrf_wifi_osal_log_err("%s: Invalid params",
 				      __func__);
 		return status;
 	}
 
 	if (!hal_rpu_is_mem_writable(hal_dev_ctx->curr_proc,
 				     rpu_mem_addr_val)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address 0x%X",
+		nrf_wifi_osal_log_err("%s: Invalid memory address 0x%X",
 				      __func__,
 				      rpu_mem_addr_val);
 		return status;
@@ -407,8 +387,7 @@ enum nrf_wifi_status hal_rpu_mem_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 					   src_addr,
 					   len);
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid memory address 0x%X",
+		nrf_wifi_osal_log_err("%s: Invalid memory address 0x%X",
 				      __func__,
 				      rpu_mem_addr_val);
 		goto out;
@@ -447,10 +426,9 @@ enum nrf_wifi_status hal_rpu_mem_clr(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 		start_addr = region->start;
 		end_addr = region->end;
 	} else {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-			"%s: Invalid mem_type(%d)",
-			__func__,
-			mem_type);
+		nrf_wifi_osal_log_err("%s: Invalid mem_type(%d)",
+				      __func__,
+				      mem_type);
 		goto out;
 	}
 
@@ -463,8 +441,7 @@ enum nrf_wifi_status hal_rpu_mem_clr(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 					   sizeof(mem_val));
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-					      "%s: hal_rpu_mem_write failed",
+			nrf_wifi_osal_log_err("%s: hal_rpu_mem_write failed",
 					      __func__);
 			goto out;
 		}

--- a/nrf_wifi/hw_if/hal/src/hal_reg.c
+++ b/nrf_wifi/hw_if/hal/src/hal_reg.c
@@ -44,36 +44,31 @@ enum nrf_wifi_status hal_rpu_reg_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 	if ((val == NULL) ||
 	    !hal_rpu_is_reg(rpu_reg_addr)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params, val = %p, rpu_reg (0x%x)",
+		nrf_wifi_osal_log_err("%s: Invalid params, val = %p, rpu_reg (0x%x)",
 				      __func__,
 				      val,
 				      rpu_reg_addr);
 		return status;
 	}
 
-	status = pal_rpu_addr_offset_get(hal_dev_ctx->hpriv->opriv,
-					 rpu_reg_addr,
+	status = pal_rpu_addr_offset_get(rpu_reg_addr,
 					 &addr_offset,
 					 hal_dev_ctx->curr_proc);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_addr_offset_get failed",
+		nrf_wifi_osal_log_err("%s: pal_rpu_addr_offset_get failed",
 				      __func__);
 		return status;
 	}
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->rpu_ps_lock,
 					&flags);
 
 	status = hal_rpu_ps_wake(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed",
+		nrf_wifi_osal_log_err("%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}
@@ -83,8 +78,7 @@ enum nrf_wifi_status hal_rpu_reg_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 				      addr_offset);
 
 	if (*val == 0xFFFFFFFF) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Error !! Value read at addr_offset = %lx is = %X",
+		nrf_wifi_osal_log_err("%s: Error !! Value read at addr_offset = %lx is = %X",
 				      __func__,
 				      addr_offset,
 				      *val);
@@ -95,8 +89,7 @@ enum nrf_wifi_status hal_rpu_reg_read(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	status = NRF_WIFI_STATUS_SUCCESS;
 out:
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
 				       &flags);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
@@ -119,35 +112,30 @@ enum nrf_wifi_status hal_rpu_reg_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 	}
 
 	if (!hal_rpu_is_reg(rpu_reg_addr)) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: Invalid params, rpu_reg_addr (0x%X)",
+		nrf_wifi_osal_log_err("%s: Invalid params, rpu_reg_addr (0x%X)",
 				      __func__,
 				      rpu_reg_addr);
 		return status;
 	}
 
-	status = pal_rpu_addr_offset_get(hal_dev_ctx->hpriv->opriv,
-					 rpu_reg_addr,
+	status = pal_rpu_addr_offset_get(rpu_reg_addr,
 					 &addr_offset,
 					 hal_dev_ctx->curr_proc);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: pal_rpu_get_region_offset failed",
+		nrf_wifi_osal_log_err("%s: pal_rpu_get_region_offset failed",
 				      __func__);
 		return status;
 	}
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->hpriv->opriv,
-					hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_take(hal_dev_ctx->rpu_ps_lock,
 					&flags);
 
 	status = hal_rpu_ps_wake(hal_dev_ctx);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_dev_ctx->hpriv->opriv,
-				      "%s: RPU wake failed",
+		nrf_wifi_osal_log_err("%s: RPU wake failed",
 				      __func__);
 		goto out;
 	}
@@ -161,8 +149,7 @@ enum nrf_wifi_status hal_rpu_reg_write(struct nrf_wifi_hal_dev_ctx *hal_dev_ctx,
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
 out:
-	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->hpriv->opriv,
-				       hal_dev_ctx->rpu_ps_lock,
+	nrf_wifi_osal_spinlock_irq_rel(hal_dev_ctx->rpu_ps_lock,
 				       &flags);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 

--- a/nrf_wifi/hw_if/hal/src/hpqm.c
+++ b/nrf_wifi/hw_if/hal/src/hpqm.c
@@ -24,8 +24,7 @@ enum nrf_wifi_status hal_rpu_hpq_enqueue(struct nrf_wifi_hal_dev_ctx *hal_ctx,
 				   val);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_ctx->hpriv->opriv,
-				      "%s: Writing to enqueue address failed",
+		nrf_wifi_osal_log_err("%s: Writing to enqueue address failed",
 				      __func__);
 		goto out;
 	}
@@ -46,8 +45,7 @@ enum nrf_wifi_status hal_rpu_hpq_dequeue(struct nrf_wifi_hal_dev_ctx *hal_ctx,
 				  hpq->dequeue_addr);
 
 	if (status != NRF_WIFI_STATUS_SUCCESS) {
-		nrf_wifi_osal_log_err(hal_ctx->hpriv->opriv,
-				      "%s: Dequeue failed, val (0x%X)",
+		nrf_wifi_osal_log_err("%s: Dequeue failed, val (0x%X)",
 				      __func__,
 				      *val);
 		goto out;
@@ -60,8 +58,7 @@ enum nrf_wifi_status hal_rpu_hpq_dequeue(struct nrf_wifi_hal_dev_ctx *hal_ctx,
 					   *val);
 
 		if (status != NRF_WIFI_STATUS_SUCCESS) {
-			nrf_wifi_osal_log_err(hal_ctx->hpriv->opriv,
-					      "%s: Writing to dequeue address failed, val (0x%X)",
+			nrf_wifi_osal_log_err("%s: Writing to dequeue address failed, val (0x%X)",
 					      __func__,
 					      *val);
 			goto out;

--- a/nrf_wifi/hw_if/hal/src/pal.c
+++ b/nrf_wifi/hw_if/hal/src/pal.c
@@ -32,10 +32,9 @@ bool pal_check_rpu_mcu_regions(enum RPU_PROC_TYPE proc, unsigned int addr_val)
 	return false;
 }
 
-enum nrf_wifi_status pal_rpu_addr_offset_get(struct nrf_wifi_osal_priv *opriv,
-					     unsigned int rpu_addr,
+enum nrf_wifi_status pal_rpu_addr_offset_get(unsigned int rpu_addr,
 					     unsigned long *addr,
-						 enum RPU_PROC_TYPE proc)
+					     enum RPU_PROC_TYPE proc)
 {
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 	unsigned int addr_base = (rpu_addr & RPU_ADDR_MASK_BASE);
@@ -53,8 +52,7 @@ enum nrf_wifi_status pal_rpu_addr_offset_get(struct nrf_wifi_osal_priv *opriv,
 	} else if (pal_check_rpu_mcu_regions(proc, rpu_addr)) {
 		region_offset = SOC_MMAP_ADDR_OFFSETS_MCU[proc];
 	} else {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Invalid rpu_addr 0x%X",
+		nrf_wifi_osal_log_err("%s: Invalid rpu_addr 0x%X",
 				      __func__,
 				      rpu_addr);
 		goto out;
@@ -76,8 +74,7 @@ unsigned long pal_rpu_ps_ctrl_reg_addr_get(void)
 }
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
-char *pal_ops_get_fw_loc(struct nrf_wifi_osal_priv *opriv,
-			 enum nrf_wifi_fw_type fw_type,
+char *pal_ops_get_fw_loc(enum nrf_wifi_fw_type fw_type,
 			 enum nrf_wifi_fw_subtype fw_subtype)
 {
 	char *fw_loc = NULL;
@@ -89,8 +86,7 @@ char *pal_ops_get_fw_loc(struct nrf_wifi_osal_priv *opriv,
 		} else if (fw_subtype == NRF_WIFI_FW_SUBTYPE_SEC) {
 			fw_loc = NRF_WIFI_FW_LMAC_PATCH_LOC_SEC;
 		} else {
-			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid LMAC FW sub-type = %d",
+			nrf_wifi_osal_log_err("%s: Invalid LMAC FW sub-type = %d",
 					      __func__,
 					      fw_subtype);
 			goto out;
@@ -102,16 +98,14 @@ char *pal_ops_get_fw_loc(struct nrf_wifi_osal_priv *opriv,
 		} else if (fw_subtype == NRF_WIFI_FW_SUBTYPE_SEC) {
 			fw_loc = NRF_WIFI_FW_UMAC_PATCH_LOC_SEC;
 		} else {
-			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid UMAC FW sub-type = %d",
+			nrf_wifi_osal_log_err("%s: Invalid UMAC FW sub-type = %d",
 					      __func__,
 					      fw_subtype);
 			goto out;
 		}
 		break;
 	default:
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Invalid FW type = %d",
+		nrf_wifi_osal_log_err("%s: Invalid FW type = %d",
 				      __func__,
 				      fw_type);
 		goto out;

--- a/nrf_wifi/os_if/inc/osal_api.h
+++ b/nrf_wifi/os_if/inc/osal_api.h
@@ -24,142 +24,135 @@
 #endif /* CONFIG_NRF700X_LOG_VERBOSE */
 
 /**
- * @brief the OSAL layer.
+ * @brief Initialize the OSAL layer.
+ * @param ops: Pointer to the OSAL operations structure.
  *
- * Initialize the OSAL layer and is expected to be called
- * before using the OSAL layer. Returns a pointer to the OSAL context
- * which might need to be passed to further API calls.
+ * Initializes the OSAL layer and is expected to be called
+ * before using the OSAL layer.
  *
- * @return Pointer to instance of OSAL context.
+ * @return None.
  */
-struct nrf_wifi_osal_priv *nrf_wifi_osal_init(void);
+void nrf_wifi_osal_init(const struct nrf_wifi_osal_ops *ops);
 
 /**
  * @brief Deinitialize the OSAL layer.
- * @param opriv: Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  *
  * Deinitialize the OSAL layer and is expected to be called after done using
  * the OSAL layer.
  *
  * @return None.
  */
-void nrf_wifi_osal_deinit(struct nrf_wifi_osal_priv *opriv);
+void nrf_wifi_osal_deinit(void);
 
 /**
  * @brief Allocate memory.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param size Size of the memory to be allocated in bytes.
+ *
+ * Allocates memory of @size bytes and returns a pointer to the start
+ * of the memory allocated.
+ *
  * @return Pointer to start of allocated memory on success, NULL on error.
  */
-void *nrf_wifi_osal_mem_alloc(struct nrf_wifi_osal_priv *opriv,
-							  size_t size);
+void *nrf_wifi_osal_mem_alloc(size_t size);
 
 /**
  * @brief Allocated zero-initialized memory.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param size Size of the memory to be allocated in bytes.
+ *
+ * Allocates zero-initialized memory of @size bytes and returns a pointer to the start
+ * of the memory allocated.
  *
  * @return Pointer to start of allocated memory on success, NULL on error.
  */
-void *nrf_wifi_osal_mem_zalloc(struct nrf_wifi_osal_priv *opriv,
-							   size_t size);
+void *nrf_wifi_osal_mem_zalloc(size_t size);
 
 /**
  * @brief Free previously allocated memory.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param buf Pointer to the memory to be freed.
  *
  * Free up memory which has been allocated using  nrf_wifi_osal_mem_alloc or
- *  nrf_wifi_osal_mem_zalloc.
+ * nrf_wifi_osal_mem_zalloc.
  *
  * @return None.
  */
-void nrf_wifi_osal_mem_free(struct nrf_wifi_osal_priv *opriv,
-							void *buf);
+void nrf_wifi_osal_mem_free(void *buf);
 
 /**
  * @brief Copy contents from one memory location to another.
  *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param dest Pointer to the memory location where contents are to be copied.
  * @param src Pointer to the memory location from where contents are to be copied.
  * @param count Number of bytes to be copied.
+ *
+ * Copies @count number of bytes from @src location in memory to @dest
+ * location in memory.
+ *
  * @return Pointer to destination memory if successful, NULL otherwise.
  */
-void *nrf_wifi_osal_mem_cpy(struct nrf_wifi_osal_priv *opriv,
-							void *dest,
-							const void *src,
-							size_t count);
+void *nrf_wifi_osal_mem_cpy(void *dest,
+			    const void *src,
+			    size_t count);
 
 /**
  * @brief Fill a block of memory with a particular value.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param start Pointer to the memory location whose contents are to be set.
  * @param val Value to be set.
  * @param size Number of bytes to be set.
+ *
+ * Fills a block of memory of @size bytes, starting at @start with a value specified by @val. 
+ *
  * @return Pointer to memory location which was set on success, NULL on error.
  */
-void *nrf_wifi_osal_mem_set(struct nrf_wifi_osal_priv *opriv,
-							void *start,
-							int val,
-							size_t size);
+void *nrf_wifi_osal_mem_set(void *start,
+			    int val,
+			    size_t size);
+
 
 /**
  * @brief Memory map IO memory into CPU space.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param addr Address of the IO memory to be mapped.
  * @param size Size of the IO memory in bytes.
+ *
+ * Maps IO memory of @size bytes pointed to by @addr into CPU space.
+ *
  * @return Pointer to the mapped IO memory on success, NULL on error.
  */
-void *nrf_wifi_osal_iomem_mmap(struct nrf_wifi_osal_priv *opriv,
-							   unsigned long addr,
-							   unsigned long size);
+void *nrf_wifi_osal_iomem_mmap(unsigned long addr,
+			       unsigned long size);
 
 /**
  * @brief Unmap previously mapped IO memory from CPU space.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param addr Pointer to mapped IO memory to be unmapped.
  *
  * Unmaps IO memory from CPU space that was mapped using nrf_wifi_osal_iomem_mmap.
+ *
+ * @return None.
  */
-void nrf_wifi_osal_iomem_unmap(struct nrf_wifi_osal_priv *opriv,
-							   volatile void *addr);
+void nrf_wifi_osal_iomem_unmap(volatile void *addr);
 
 /**
  * @brief Read value from a 32 bit IO memory mapped register.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param addr Pointer to the IO memory mapped register address.
  *
  * @return 32 bit value read from register.
  */
-unsigned int nrf_wifi_osal_iomem_read_reg32(struct nrf_wifi_osal_priv *opriv,
-				const volatile void *addr);
+unsigned int nrf_wifi_osal_iomem_read_reg32(const volatile void *addr);
 
 /**
  * @brief Write a 32 bit value to a IO memory mapped register.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param addr Pointer to the IO memory mapped register address.
  * @param val Value to be written to the register.
  *
  * Writes a 32 bit value (val) to a 32 bit device register using a memory
  * mapped address (addr).
+ *
+ * @return None.
  */
-void nrf_wifi_osal_iomem_write_reg32(struct nrf_wifi_osal_priv *opriv,
-									 volatile void *addr,
-									 unsigned int val);
+void nrf_wifi_osal_iomem_write_reg32(volatile void *addr,
+				     unsigned int val);
 
 /**
  * @brief Copy data from the memory of a memory mapped IO device to host memory.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param dest Pointer to the host memory where data is to be copied.
  * @param src Pointer to the memory of the memory mapped IO device from where data is to be copied.
  * @param count The size of the data to be copied in bytes.
@@ -169,277 +162,256 @@ void nrf_wifi_osal_iomem_write_reg32(struct nrf_wifi_osal_priv *opriv,
  *
  * @return None.
  */
-void nrf_wifi_osal_iomem_cpy_from(struct nrf_wifi_osal_priv *opriv,
-								  void *dest,
-								  const volatile void *src,
-								  size_t count);
+void nrf_wifi_osal_iomem_cpy_from(void *dest,
+				  const volatile void *src,
+				  size_t count);
 
 /**
  * @brief Copy data to the memory of a memory mapped IO device from host memory.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param dest Pointer to the memory of the memory mapped IO device where data is to be copied.
- * @param src Pointer to the host memory from where data is to be copied.
- * @param count The size of the data to be copied in bytes.
+ * @param dest: Pointer to the memory of the memory mapped IO device where data is to be copied.
+ * @param src: Pointer to the host memory from where data is to be copied.
+ * @param count: The size of the data to be copied in bytes.
  *
  * Copies a block of data of size  count bytes from host memory (src) to memory mapped
  * device memory(dest).
  *
  * @return None.
  */
-void nrf_wifi_osal_iomem_cpy_to(struct nrf_wifi_osal_priv *opriv,
-								volatile void *dest,
-								const void *src,
-								size_t count);
+void nrf_wifi_osal_iomem_cpy_to(volatile void *dest,
+				const void *src,
+				size_t count);
+
 
 /**
  * @brief Allocate a busy lock.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  *
  * Allocates a busy lock.
  *
  * @return Pointer to the busy lock instance on success, NULL on error.
  */
-void *nrf_wifi_osal_spinlock_alloc(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_osal_spinlock_alloc(void);
 
 /**
  * @brief Free a busy lock.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param lock Pointer to a busy lock instance.
  *
- * Frees a busy lock (lock) allocated by  nrf_wifi_osal_spinlock_alloc.
+ * Frees a busy lock (lock) allocated by nrf_wifi_osal_spinlock_alloc.
  *
  * @return None.
  */
-void nrf_wifi_osal_spinlock_free(struct nrf_wifi_osal_priv *opriv,
-								 void *lock);
+void nrf_wifi_osal_spinlock_free(void *lock);
+
 
 /**
  * @brief Initialize a busy lock.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param lock Pointer to a busy lock instance.
  *
  * Initialize a busy lock (lock) allocated by  nrf_wifi_osal_spinlock_alloc.
  *
  * @return None.
  */
-void nrf_wifi_osal_spinlock_init(struct nrf_wifi_osal_priv *opriv,
-								 void *lock);
+void nrf_wifi_osal_spinlock_init(void *lock);
+
 
 /**
  * @brief Acquire a busy lock.
+ * @param lock: Pointer to a busy lock instance.
  *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param lock Pointer to a busy lock instance.
- *
- * Acquires a busy lock (lock) allocated by  nrf_wifi_osal_spinlock_alloc.
+ * Acquires a busy lock (lock) allocated by nrf_wifi_osal_spinlock_alloc.
  *
  * @return None.
  */
-void nrf_wifi_osal_spinlock_take(struct nrf_wifi_osal_priv *opriv,
-								 void *lock);
+void nrf_wifi_osal_spinlock_take(void *lock);
+
 
 /**
  * @brief Releases a busy lock.
+ * @param lock: Pointer to a busy lock instance.
  *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param lock Pointer to a busy lock instance.
- *
- * Releases a busy lock (lock) acquired by  nrf_wifi_osal_spinlock_take.
+ * Releases a busy lock (lock) acquired by nrf_wifi_osal_spinlock_take.
  *
  * @return None.
  */
-void nrf_wifi_osal_spinlock_rel(struct nrf_wifi_osal_priv *opriv,
-								void *lock);
+void nrf_wifi_osal_spinlock_rel(void *lock);
+
 
 /**
  * @brief Acquire a busy lock and disable interrupts.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param lock Pointer to a busy lock instance.
  * @param flags Interrupt state flags.
  *
- * Saves interrupt states ( flags), disable interrupts and take a
- * busy lock (lock).
+ * Saves interrupt states (@flags), disable interrupts and takes a
+ * busy lock (@lock).
  *
  * @return None.
  */
-void nrf_wifi_osal_spinlock_irq_take(struct nrf_wifi_osal_priv *opriv,
-									 void *lock,
-									 unsigned long *flags);
+void nrf_wifi_osal_spinlock_irq_take(void *lock,
+				     unsigned long *flags);
+
 
 /**
  * @brief Release a busy lock and enable interrupts.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param lock Pointer to a busy lock instance.
  * @param flags Interrupt state flags.
  *
- * Restores interrupt states ( flags) and releases busy lock (lock) acquired
- * using  nrf_wifi_osal_spinlock_irq_take.
+ * Restores interrupt states (@flags) and releases busy lock (@lock) acquired
+ * using nrf_wifi_osal_spinlock_irq_take.
  *
  * @return None.
  */
-void nrf_wifi_osal_spinlock_irq_rel(struct nrf_wifi_osal_priv *opriv,
-									void *lock,
-									unsigned long *flags);
+void nrf_wifi_osal_spinlock_irq_rel(void *lock,
+				    unsigned long *flags);
+
 
 #if CONFIG_WIFI_NRF700X_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_DBG
 /**
  * @brief Log a debug message.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param fmt Format string.
- * @param ... Variable arguments.
+ * @param fmt: Format string.
+ * @param ...: Variable arguments.
  *
  * Logs a debug message.
  *
  * @return Number of characters of the message logged.
  */
-int nrf_wifi_osal_log_dbg(struct nrf_wifi_osal_priv *opriv,
-						  const char *fmt, ...);
+int nrf_wifi_osal_log_dbg(const char *fmt, ...);
 #else
-#define nrf_wifi_osal_log_dbg(level, fmt, ...)
+#define nrf_wifi_osal_log_dbg(fmt, ...)
 #endif
 
 #if CONFIG_WIFI_NRF700X_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_INF
 /**
  * @brief Logs an informational message.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param fmt Format string.
  * @param ... Variable arguments.
+ *
+ * Logs an informational message.
+ *
  * @return Number of characters of the message logged.
  */
-int nrf_wifi_osal_log_info(struct nrf_wifi_osal_priv *opriv,
-						   const char *fmt, ...);
+int nrf_wifi_osal_log_info(const char *fmt, ...);
 #else
-#define nrf_wifi_osal_log_info(level, fmt, ...)
+#define nrf_wifi_osal_log_info(fmt, ...)
 #endif
 
 #if CONFIG_WIFI_NRF700X_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_ERR
 /**
  * @brief Logs an error message.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param fmt Format string.
  * @param ... Variable arguments.
+ *
+ * Logs an error message.
+ *
  * @return Number of characters of the message logged.
  */
-int nrf_wifi_osal_log_err(struct nrf_wifi_osal_priv *opriv,
-						  const char *fmt, ...);
+int nrf_wifi_osal_log_err(const char *fmt, ...);
 #else
-#define nrf_wifi_osal_log_err(level, fmt, ...)
+#define nrf_wifi_osal_log_err(fmt, ...)
 #endif
 
 /**
  * @brief Allocate a linked list node.
  *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * Allocate a linked list node.
  *
  * @return Pointer to the linked list node allocated.
  *         NULL if there is an error.
  */
-void *nrf_wifi_osal_llist_node_alloc(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_osal_llist_node_alloc(void);
 
 /**
  * @brief Free a linked list node.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param node Pointer to a linked list node.
  *
- * Frees a linked list node(node) which was allocated by  nrf_wifi_osal_llist_node_alloc.
+ * Frees a linked list node(node) which was allocated by nrf_wifi_osal_llist_node_alloc.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_llist_node_free(struct nrf_wifi_osal_priv *opriv, void *node);
+void nrf_wifi_osal_llist_node_free(void *node);
 
 /**
  * @brief Get data stored in a linked list node.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param node Pointer to a linked list node.
+ *
+ * Get the data from a linked list node.
  *
  * @return Pointer to the data stored in the linked list node.
  *         NULL if there is an error.
  */
-void *nrf_wifi_osal_llist_node_data_get(struct nrf_wifi_osal_priv *opriv, void *node);
+void *nrf_wifi_osal_llist_node_data_get(void *node);
+
 
 /**
  * @brief Set data in a linked list node.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param node Pointer to a linked list node.
  * @param data Pointer to the data to be stored in the linked list node.
  *
  * Stores the pointer to the data(data) in a linked list node(node).
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_llist_node_data_set(struct nrf_wifi_osal_priv *opriv, void *node, void *data);
+void nrf_wifi_osal_llist_node_data_set(void *node,
+				       void *data);
+
 
 /**
  * @brief Allocate a linked list.
  *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * Allocate a linked list.
  *
  * @return Pointer to the allocated linked list on success, NULL on error.
  */
-void *nrf_wifi_osal_llist_alloc(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_osal_llist_alloc(void);
 
 /**
  * @brief Free a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
  *
  * Frees a linked list (llist) allocated by  nrf_wifi_osal_llist_alloc.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_llist_free(struct nrf_wifi_osal_priv *opriv,
-							  void *llist);
+void nrf_wifi_osal_llist_free(void *llist);
+
 
 /**
  * @brief Initialize a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
  *
  * Initialize a linked list (llist) allocated by  nrf_wifi_osal_llist_alloc.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_llist_init(struct nrf_wifi_osal_priv *opriv,
-							  void *llist);
+void nrf_wifi_osal_llist_init(void *llist);
+
 
 /**
  * @brief Add a node to the tail of a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
  * @param llist_node Pointer to a linked list node.
  *
  * Adds a linked list node ( llist_node) allocated by  nrf_wifi_osal_llist_node_alloc
  * to the tail of a linked list (llist) allocated by  nrf_wifi_osal_llist_alloc.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_llist_add_node_tail(struct nrf_wifi_osal_priv *opriv,
-									   void *llist,
-									   void *llist_node);
+void nrf_wifi_osal_llist_add_node_tail(void *llist,
+				       void *llist_node);
+
 
 /**
  * @brief Add a node to the head of a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
  * @param llist_node Pointer to a linked list node.
  *
  * Adds a linked list node ( llist_node) allocated by  nrf_wifi_osal_llist_node_alloc
  * to the head of a linked list (llist) allocated by  nrf_wifi_osal_llist_alloc.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_llist_add_node_head(struct nrf_wifi_osal_priv *opriv,
-									   void *llist,
-									   void *llist_node);
-
+void nrf_wifi_osal_llist_add_node_head(void *llist,
+				       void *llist_node);
 /**
  * @brief Get the head of a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
  *
  * Returns the head node from a linked list (llist) while still leaving the
@@ -447,208 +419,235 @@ void nrf_wifi_osal_llist_add_node_head(struct nrf_wifi_osal_priv *opriv,
  *
  * @return Pointer to the head of the linked list on success, NULL on error.
  */
-void *nrf_wifi_osal_llist_get_node_head(struct nrf_wifi_osal_priv *opriv,
-										void *llist);
+void *nrf_wifi_osal_llist_get_node_head(void *llist);
+
 
 /**
  * @brief Get the next node in a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
  * @param llist_node Pointer to a linked list node.
+ *
+ * Return the node next to the node passed in the @llist_node parameter.
+ * The node returned is not removed from the linked list.
+ *
  * @return Pointer to the next node in the linked list if successful, NULL otherwise.
  */
-void *nrf_wifi_osal_llist_get_node_nxt(struct nrf_wifi_osal_priv *opriv,
-									   void *llist,
-									   void *llist_node);
+void *nrf_wifi_osal_llist_get_node_nxt(void *llist,
+				       void *llist_node);
+
 
 /**
  * @brief Delete node from a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
  * @param llist_node Pointer to a linked list node.
+ *
+ * Removes the node passed in the @llist_node parameter from the linked list
+ * passed in the @llist parameter.
+ *
  * @return None.
  */
-void nrf_wifi_osal_llist_del_node(struct nrf_wifi_osal_priv *opriv,
-								  void *llist,
-								  void *llist_node);
+void nrf_wifi_osal_llist_del_node(void *llist,
+				  void *llist_node);
+
 
 /**
  * @brief Get length of a linked list.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param llist Pointer to a linked list.
+ *
+ * Returns the length of the linked list(@llist).
+ *
  * @return Linked list length in bytes.
  */
-unsigned int nrf_wifi_osal_llist_len(struct nrf_wifi_osal_priv *opriv,
-									 void *llist);
+unsigned int nrf_wifi_osal_llist_len(void *llist);
+
 
 /**
- * @brief Allocate a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * @brief Allocate a network buffer
  * @param size Size in bytes of the network buffer to be allocated.
+ *
+ * Allocate a network buffer.
+ *
  * @return Pointer to the allocated network buffer if successful, NULL otherwise.
  */
-void *nrf_wifi_osal_nbuf_alloc(struct nrf_wifi_osal_priv *opriv,
-							   unsigned int size);
+void *nrf_wifi_osal_nbuf_alloc(unsigned int size);
+
 
 /**
  * @brief Free a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
+ *
+ * Frees a network buffer(@nbuf) which was allocated by
+ * @nrf_wifi_osal_nbuf_alloc.
+ *
  * @return None.
  */
-void nrf_wifi_osal_nbuf_free(struct nrf_wifi_osal_priv *opriv,
-							 void *nbuf);
+void nrf_wifi_osal_nbuf_free(void *nbuf);
+
 
 /**
  * @brief Reserve headroom space in a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
  * @param size Size in bytes of the headroom to be reserved.
+ *
+ * Reserves headroom of size(@size) bytes at the beginning of the data area of
+ * a network buffer(@nbuf).
+ *
  * @return None.
  */
-void nrf_wifi_osal_nbuf_headroom_res(struct nrf_wifi_osal_priv *opriv,
-									 void *nbuf,
-									 unsigned int size);
+void nrf_wifi_osal_nbuf_headroom_res(void *nbuf,
+				     unsigned int size);
+
+
 
 /**
  * @brief Get the size of the headroom in a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
+ *
+ * Gets the size of the reserved headroom at the beginning
+ * of the data area of a network buffer(@nbuf).
+ *
  * @return Size of the network buffer data headroom in bytes.
  */
-unsigned int nrf_wifi_osal_nbuf_headroom_get(struct nrf_wifi_osal_priv *opriv,
-			void *nbuf);
+unsigned int nrf_wifi_osal_nbuf_headroom_get(void *nbuf);
 
 /**
  * @brief Get the size of data in a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
+ *
+ * Gets the size of the data area of a network buffer (@nbuf).
+ *
  * @return Size of the network buffer data in bytes.
  */
-unsigned int nrf_wifi_osal_nbuf_data_size(struct nrf_wifi_osal_priv *opriv,
-										  void *nbuf);
+unsigned int nrf_wifi_osal_nbuf_data_size(void *nbuf);
+
 
 /**
  * @brief Get a handle to the data in a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
+ *
+ * Gets the pointer to the data area of a network buffer(@nbuf).
+ *
  * @return Pointer to the data in the network buffer if successful, otherwise NULL.
  */
-void *nrf_wifi_osal_nbuf_data_get(struct nrf_wifi_osal_priv *opriv,
-								  void *nbuf);
+void *nrf_wifi_osal_nbuf_data_get(void *nbuf);
+
 
 /**
  * @brief Extend the tail portion of the data in a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
  * @param size Size in bytes of the extension.
+ *
+ * Increases the data area of a network buffer(@nbuf) by @size bytes at the
+ * end of the area and returns the pointer to the beginning of
+ * the data area.
+ *
  * @return Updated pointer to the data in the network buffer if successful, otherwise NULL.
  */
-void *nrf_wifi_osal_nbuf_data_put(struct nrf_wifi_osal_priv *opriv,
-								  void *nbuf,
-								  unsigned int size);
+void *nrf_wifi_osal_nbuf_data_put(void *nbuf,
+				  unsigned int size);
+
 
 /**
  * @brief Extend the head portion of the data in a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
  * @param size Size in bytes, of the extension.
+ *
+ * Increases the data area of a network buffer(@nbuf) by @size bytes at the
+ * start of the area and returns the pointer to the beginning of
+ * the data area.
+ *
  * @return Updated pointer to the data in the network buffer if successful, NULL otherwise.
  */
-void *nrf_wifi_osal_nbuf_data_push(struct nrf_wifi_osal_priv *opriv,
-								   void *nbuf,
-								   unsigned int size);
+void *nrf_wifi_osal_nbuf_data_push(void *nbuf,
+				   unsigned int size);
+
 
 /**
  * @brief Reduce the head portion of the data in a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
  * @param size Size in bytes, of the reduction.
+ *
+ * Decreases the data area of a network buffer(@nbuf) by @size bytes at the
+ * start of the area and returns the pointer to the beginning
+ * of the data area.
+ *
  * @return Updated pointer to the data in the network buffer if successful, NULL otherwise.
  */
-void *nrf_wifi_osal_nbuf_data_pull(struct nrf_wifi_osal_priv *opriv,
-								   void *nbuf,
-								   unsigned int size);
+void *nrf_wifi_osal_nbuf_data_pull(void *nbuf,
+				   unsigned int size);
+
 
 /**
  * @brief Get the priority of a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
+ *
+ * Gets the priority of a network buffer.
  *
  * @return Priority of the network buffer.
  */
-unsigned char nrf_wifi_osal_nbuf_get_priority(struct nrf_wifi_osal_priv *opriv,
-			void *nbuf);
+unsigned char nrf_wifi_osal_nbuf_get_priority(void *nbuf);
 
 /**
  * @brief Get the checksum status of a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
+ *
+ * Get the checksum status of a network buffer.
  *
  * @return Checksum status of the network buffer.
  */
-unsigned char nrf_wifi_osal_nbuf_get_chksum_done(struct nrf_wifi_osal_priv *opriv,
-			void *nbuf);
+unsigned char nrf_wifi_osal_nbuf_get_chksum_done(void *nbuf);
 
 /**
  * @brief Set the checksum status of a network buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param nbuf Pointer to a network buffer.
  * @param chksum_done Checksum status of the network buffer.
  *
+ * Set the checksum status of a network buffer.
+ *
  * @return None
  */
-void nrf_wifi_osal_nbuf_set_chksum_done(struct nrf_wifi_osal_priv *opriv,
-			void *nbuf, unsigned char chksum_done);
+void nrf_wifi_osal_nbuf_set_chksum_done(void *nbuf,
+					unsigned char chksum_done);
+
 /**
  * @brief Allocate a tasklet.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param type Type of tasklet.
+ *
+ * Allocates a tasklet structure and returns a pointer to it.
+ *
  * @return Pointer to the tasklet instance allocated if successful, otherwise NULL.
  */
-void *nrf_wifi_osal_tasklet_alloc(struct nrf_wifi_osal_priv *opriv, int type);
+void *nrf_wifi_osal_tasklet_alloc(int type);
 
 /**
  * @brief Free a tasklet.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param tasklet Pointer to a tasklet.
+ *
+ * Frees a tasklet structure that had been allocated using
+ * @nrf_wifi_osal_tasklet_alloc.
+ *
  * @return None.
  */
-void nrf_wifi_osal_tasklet_free(struct nrf_wifi_osal_priv *opriv, void *tasklet);
+void nrf_wifi_osal_tasklet_free(void *tasklet);
+
 
 /**
- * @brief Initialize a tasklet.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * @brief - Initialize a tasklet.
  * @param tasklet Pointer to a tasklet.
  * @param callbk_fn Callback function to be invoked by the tasklet.
  * @param data Data to be passed to the callback function when the tasklet invokes it.
+ *
+ * Initializes a tasklet.
+ *
  * @return None.
  */
-void nrf_wifi_osal_tasklet_init(struct nrf_wifi_osal_priv *opriv, void *tasklet,
-		void (*callbk_fn)(unsigned long), unsigned long data);
+void nrf_wifi_osal_tasklet_init(void *tasklet,
+				void (*callbk_fn)(unsigned long),
+				unsigned long data);
+
 
 /**
  * @brief Schedule a tasklet.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param tasklet Pointer to a tasklet.
  *
  * Schedules a tasklet that had been allocated using
@@ -657,40 +656,34 @@ void nrf_wifi_osal_tasklet_init(struct nrf_wifi_osal_priv *opriv, void *tasklet,
  *
  * @return None.
  */
-void nrf_wifi_osal_tasklet_schedule(struct nrf_wifi_osal_priv *opriv,
-									void *tasklet);
+void nrf_wifi_osal_tasklet_schedule(void *tasklet);
+
 
 /**
  * @brief Terminate a tasklet.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param tasklet Pointer to a tasklet.
  *
  * Terminates a tasklet(tasklet) that had been scheduled by
- *  nrf_wifi_osal_tasklet_schedule.
+ * nrf_wifi_osal_tasklet_schedule.
  *
  * @return None.
  */
-void nrf_wifi_osal_tasklet_kill(struct nrf_wifi_osal_priv *opriv,
-								void *tasklet);
+void nrf_wifi_osal_tasklet_kill(void *tasklet);
+
 
 /**
  * @brief Sleep for a specified duration in milliseconds.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param msecs Sleep duration in milliseconds.
+ * @param msecs: Sleep duration in milliseconds.
  *
  * Puts the calling thread to sleep for at least msecs milliseconds.
  *
  * @return None.
  */
-void nrf_wifi_osal_sleep_ms(struct nrf_wifi_osal_priv *opriv,
-							unsigned int msecs);
+void nrf_wifi_osal_sleep_ms(unsigned int msecs);
+
 
 /**
  * @brief Delay for a specified duration in microseconds.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param usecs Delay duration in microseconds.
  *
  * Delays execution of calling thread for usecs microseconds. This is
@@ -699,230 +692,239 @@ void nrf_wifi_osal_sleep_ms(struct nrf_wifi_osal_priv *opriv,
  *
  * @return None.
  */
-void nrf_wifi_osal_delay_us(struct nrf_wifi_osal_priv *opriv,
-							unsigned long usecs);
+void nrf_wifi_osal_delay_us(unsigned long usecs);
+
 
 /**
  * @brief Get current system uptime in microseconds.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  *
  * Get the current system uptime in microseconds.
  *
  * @return System uptime in microseconds.
  */
-unsigned long nrf_wifi_osal_time_get_curr_us(struct nrf_wifi_osal_priv *opriv);
+unsigned long nrf_wifi_osal_time_get_curr_us(void);
 
 /**
  * @brief Get elapsed time in microseconds.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param start_time_us The timestamp in microseconds from which elapsed time is to be measured.
+ *
+ * Get the elapsed system uptime in microseconds.
  *
  * @return Elapsed time in microseconds.
  */
-unsigned int nrf_wifi_osal_time_elapsed_us(struct nrf_wifi_osal_priv *opriv,
-		unsigned long start_time_us);
+unsigned int nrf_wifi_osal_time_elapsed_us(unsigned long start_time_us);
 
 /**
  * @brief Initialize a PCIe driver.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param dev_name Name of the PCIe device.
  * @param vendor_id Vendor ID of the PCIe device.
  * @param sub_vendor_id Sub-vendor ID of the PCIE device.
  * @param device_id Device ID of the PCIe device.
  * @param sub_device_id Sub-device ID of the PCIe device.
  *
+ * Initializes a PCIe device.
+ *
  * @return OS specific PCIe device context.
  */
-void *nrf_wifi_osal_bus_pcie_init(struct nrf_wifi_osal_priv *opriv,
-								  const char *dev_name,
-								  unsigned int vendor_id,
-								  unsigned int sub_vendor_id,
-								  unsigned int device_id,
-								  unsigned int sub_device_id);
+void *nrf_wifi_osal_bus_pcie_init(const char *dev_name,
+				  unsigned int vendor_id,
+				  unsigned int sub_vendor_id,
+				  unsigned int device_id,
+				  unsigned int sub_device_id);
+
 
 /**
  * @brief Deinitialize a PCIe device driver.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_priv OS specific PCIe context.
  *
  * This API should be called when the PCIe device driver is to be unregistered from
  * the OS's PCIe core.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_bus_pcie_deinit(struct nrf_wifi_osal_priv *opriv,
-								   void *os_pcie_priv);
+void nrf_wifi_osal_bus_pcie_deinit(void *os_pcie_priv);
+
 
 /**
- * @brief Add a PCIe device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * brief Add a PCIe device instance.
  * @param os_pcie_priv OS specific PCIe context.
- * @param osal_pcie_dev_ctx Pointer to the OSAL PCIe device context.
- *
- * Function to be invoked when a matching PCIe device is added to the system.
- * It expects the pointer to a OS specific PCIe device context to be returned.
+ * @param osal_pcie_dev_ctx: Pointer to the OSAL PCIe device context.
  *
  * @return OS specific PCIe device context.
  */
-void *nrf_wifi_osal_bus_pcie_dev_add(struct nrf_wifi_osal_priv *opriv,
-									 void *os_pcie_priv,
-									 void *osal_pcie_dev_ctx);
+void *nrf_wifi_osal_bus_pcie_dev_add(void *os_pcie_priv,
+				     void *osal_pcie_dev_ctx);
+
 
 /**
  * @brief Remove a PCIe device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx Pointer to the OS specific PCIe device context which was
  *	returned by  nrf_wifi_osal_bus_pcie_dev_add.
  *
  * Function to be invoked when a matching PCIe device is removed from the system.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_bus_pcie_dev_rem(struct nrf_wifi_osal_priv *opriv,
-									void *os_pcie_dev_ctx);
+void nrf_wifi_osal_bus_pcie_dev_rem(void *os_pcie_dev_ctx);
+
 
 /**
  * @brief Initialize a PCIe device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx Pointer to the OS specific PCIe device context which was
  *                        returned by  nrf_wifi_osal_bus_pcie_dev_add.
+ *
+ * Function to be invoked when a PCIe device is to be initialized.
+ *
  * @return NRF_WIFI_STATUS_SUCCESS if successful, NRF_WIFI_STATUS_FAIL otherwise.
  */
-enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_init(struct nrf_wifi_osal_priv *opriv,
-			void *os_pcie_dev_ctx);
+enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_init(void *os_pcie_dev_ctx);
+
 
 /**
  * @brief Deinitialize a PCIe device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx Pointer to the OS specific PCIe device context which was
  *                        returned by  nrf_wifi_osal_bus_pcie_dev_add.
+ *
+ * Function to be invoked when a PCIe device is to be deinitialized.
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_bus_pcie_dev_deinit(struct nrf_wifi_osal_priv *opriv,
-									   void *os_pcie_dev_ctx);
+void nrf_wifi_osal_bus_pcie_dev_deinit(void *os_pcie_dev_ctx);
+
 
 /**
  * @brief Register an interrupt handler for a PCIe device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx OS specific PCIe device context.
  * @param callbk_data Data to be passed to the ISR.
  * @param callbk_fn ISR to be invoked on receiving an interrupt.
+ *
+ * Registers an interrupt handler to the OS. This API also passes the callback
+ * data to be passed to the ISR when an interrupt is received.
+ *
  * @return NRF_WIFI_STATUS_SUCCESS if successful, NRF_WIFI_STATUS_FAIL otherwise.
  */
-enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_intr_reg(struct nrf_wifi_osal_priv *opriv,
-		void *os_pcie_dev_ctx, void *callbk_data, int (*callbk_fn)(void *callbk_data));
+enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_intr_reg(void *os_pcie_dev_ctx,
+							 void *callbk_data,
+							 int (*callbk_fn)(void *callbk_data));
+
 
 /**
  * @brief Unregister an interrupt handler for a PCIe device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx OS specific PCIe device context.
+ *
+ * Unregisters the interrupt handler that was registered using
+ *
+ * @return None. 
  */
-void nrf_wifi_osal_bus_pcie_dev_intr_unreg(struct nrf_wifi_osal_priv *opriv,
-			void *os_pcie_dev_ctx);
+void nrf_wifi_osal_bus_pcie_dev_intr_unreg(void *os_pcie_dev_ctx);
+
 
 /**
  * @brief Map host memory for DMA access.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx Pointer to a OS specific PCIe device handle.
  * @param virt_addr Virtual host address to be DMA mapped.
  * @param size Size in bytes of the host memory to be DMA mapped.
  * @param dir DMA direction.
+ *
+ * Maps host memory of @size bytes pointed to by the virtual address
+ * @virt_addr to be used by the device(@dma_dev) for DMAing contents.
+ * The contents are available for DMAing to the device if @dir has a
+ * value of @NRF_WIFI_OSAL_DMA_DIR_TO_DEV. Conversely the device can DMA
+ * contents to the host memory if @dir has a value of
+ * @NRF_WIFI_OSAL_DMA_DIR_FROM_DEV. The function returns the DMA address
+ * of the mapped memory.
+ *
  * @return Pointer to the DMA mapped physical address if successful, NULL otherwise.
  */
-void *nrf_wifi_osal_bus_pcie_dev_dma_map(struct nrf_wifi_osal_priv *opriv,
-		void *os_pcie_dev_ctx,
-		void *virt_addr,
-		size_t size,
-		enum nrf_wifi_osal_dma_dir dir);
+void *nrf_wifi_osal_bus_pcie_dev_dma_map(void *os_pcie_dev_ctx,
+					 void *virt_addr,
+					 size_t size,
+					 enum nrf_wifi_osal_dma_dir dir);
+
 
 /**
  * @brief Unmap DMA mapped host memory.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx Pointer to a OS specific PCIe device handle.
  * @param dma_addr DMA mapped physical host memory address.
  * @param size Size in bytes of the DMA mapped host memory.
  * @param dir DMA direction.
+ *
+ * Unmaps the host memory which was mapped for DMA using @nrf_wifi_osal_dma_map.
+ *
  * @return None.
  */
-void nrf_wifi_osal_bus_pcie_dev_dma_unmap(struct nrf_wifi_osal_priv *opriv,
-		void *os_pcie_dev_ctx,
-		void *dma_addr,
-		size_t size,
-		enum nrf_wifi_osal_dma_dir dir);
+void nrf_wifi_osal_bus_pcie_dev_dma_unmap(void *os_pcie_dev_ctx,
+					  void *dma_addr,
+					  size_t size,
+					  enum nrf_wifi_osal_dma_dir dir);
+
 
 /**
  * @brief Get host mapped address for a PCIe device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_pcie_dev_ctx OS specific PCIe device context.
  * @param host_map Host map address information.
+ *
+ * Get host mapped address for a PCIe device.
+ *
  * @return None.
  */
-void nrf_wifi_osal_bus_pcie_dev_host_map_get(struct nrf_wifi_osal_priv *opriv,
-		void *os_pcie_dev_ctx,
-		struct nrf_wifi_osal_host_map *host_map);
+void nrf_wifi_osal_bus_pcie_dev_host_map_get(void *os_pcie_dev_ctx,
+					     struct nrf_wifi_osal_host_map *host_map);
+
+
+
 
 /**
  * @brief Initialize a qspi driver.
  *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * Registers a qspi device driver to the OS's qspi core.
+ *
  * @return OS specific qspi device context.
  */
-void *nrf_wifi_osal_bus_qspi_init(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_osal_bus_qspi_init(void);
 
 /**
  * @brief Deinitialize a qspi device driver.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_qspi_priv OS specific qspi context.
+ *
+ * This API should be called when the qspi device driver is
+ * to be unregistered from the OS's qspi core.
+ *
  * @return None.
  */
-void nrf_wifi_osal_bus_qspi_deinit(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_priv);
+void nrf_wifi_osal_bus_qspi_deinit(void *os_qspi_priv);
+
 
 /**
- * @brief Add a qspi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param os_qspi_priv Pointer to the OS specific qspi device context.
- * @param osal_qspi_dev_ctx Pointer to the OSAL qspi device context.
+ * brief Add a qspi device instance.
+ * @param os_qspi_priv OS specific qspi context.
+ * @param osal_qspi_dev_ctx: Pointer to the OSAL qspi device context.
  *
  * Function to be invoked when a matching qspi device is added to the system.
  * It expects the pointer to an OS specific qspi device context to be returned.
  *
  * @return OS specific qspi device context.
  */
-void *nrf_wifi_osal_bus_qspi_dev_add(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_priv,
-		void *osal_qspi_dev_ctx);
+void *nrf_wifi_osal_bus_qspi_dev_add(void *os_qspi_priv,
+				     void *osal_qspi_dev_ctx);
+
 
 /**
- * @brief Remove a qspi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param os_qspi_dev_ctx Pointer to the OS specific qspi device context which was
- *                        returned by  nrf_wifi_osal_bus_qspi_dev_add.
+ * brief Remove a qspi device instance.
+ * @param os_qspi_dev_ctx: Pointer to the OS specific qspi device context which was
+ *                         returned by @nrf_wifi_osal_bus_qspi_dev_add.
  *
  * Function to be invoked when a matching qspi device is removed from the system.
  *
  * @return None.
  */
-void nrf_wifi_osal_bus_qspi_dev_rem(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_dev_ctx);
+void nrf_wifi_osal_bus_qspi_dev_rem(void *os_qspi_dev_ctx);
+
 
 /**
  * @brief Initialize a qspi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param os_qspi_dev_ctx Pointer to the OS specific qspi device context which was
- *                        returned by  nrf_wifi_osal_bus_qspi_dev_add.
+ * @param os_qspi_dev_ctx: Pointer to the OS specific qspi device context which was
+ *                         returned by @nrf_wifi_osal_bus_qspi_dev_add.
  *
  * Function to be invoked when a qspi device is to be initialized.
  *
@@ -930,89 +932,85 @@ void nrf_wifi_osal_bus_qspi_dev_rem(struct nrf_wifi_osal_priv *opriv,
  *     - Pass: NRF_WIFI_STATUS_SUCCESS.
  *     - Fail: NRF_WIFI_STATUS_FAIL.
  */
-enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_init(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_dev_ctx);
+enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_init(void *os_qspi_dev_ctx);
+
 
 /**
- * @brief Deinitialize a qspi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param os_qspi_dev_ctx Pointer to the OS specific qspi device context which was
- *                        returned by  nrf_wifi_osal_bus_qspi_dev_add.
+ * brief Deinitialize a qspi device instance.
+ * @param os_qspi_dev_ctx: Pointer to the OS specific qspi device context which was
+ *                         returned by @nrf_wifi_osal_bus_qspi_dev_add.
  *
  * Function to be invoked when a qspi device is to be deinitialized.
  *
  * @return None.
  */
-void nrf_wifi_osal_bus_qspi_dev_deinit(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_dev_ctx);
+void nrf_wifi_osal_bus_qspi_dev_deinit(void *os_qspi_dev_ctx);
+
 
 /**
- * @brief Register a interrupt handler for a qspi device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * brief Register a interrupt handler for a qspi device.
  * @param os_qspi_dev_ctx OS specific qspi device context.
  * @param callbk_data Data to be passed to the ISR.
  * @param callbk_fn ISR to be invoked on receiving an interrupt.
+ *
+ * Registers an interrupt handler to the OS. This API also passes the callback
+ * data to be passed to the ISR when an interrupt is received.
+ *
  * @return NRF_WIFI_STATUS_SUCCESS if successful, NRF_WIFI_STATUS_FAIL otherwise.
  */
-enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_intr_reg(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_dev_ctx,
-		void *callbk_data,
-		int (*callbk_fn)(void *callbk_data));
+enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_intr_reg(void *os_qspi_dev_ctx,
+							 void *callbk_data,
+							 int (*callbk_fn)(void *callbk_data));
+
 
 /**
- * @brief Unregister an interrupt handler for a qspi device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * brief Unregister an interrupt handler for a qspi device.
  * @param os_qspi_dev_ctx OS specific qspi device context.
+ *
+ * Unregisters the interrupt handler that was registered using
+ * @nrf_wifi_osal_bus_qspi_dev_intr_reg.
+ *
+ * @return None.
  */
-void nrf_wifi_osal_bus_qspi_dev_intr_unreg(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_dev_ctx);
+void nrf_wifi_osal_bus_qspi_dev_intr_unreg(void *os_qspi_dev_ctx);
+
 
 /**
  * @brief Get host mapped address for a qspi device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_qspi_dev_ctx OS specific qspi device context.
  * @param host_map Host map address information.
+ *
+ * Gets the host map address for a qspi device.
+ *
+ * @return None.
  */
-void nrf_wifi_osal_bus_qspi_dev_host_map_get(struct nrf_wifi_osal_priv *opriv,
-		void *os_qspi_dev_ctx,
-		struct nrf_wifi_osal_host_map *host_map);
+void nrf_wifi_osal_bus_qspi_dev_host_map_get(void *os_qspi_dev_ctx,
+					     struct nrf_wifi_osal_host_map *host_map);
 
 /**
  * @brief Read value from a 32 bit register on a QSPI slave device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param priv
  * @param addr Address of the register to read from.
  *
  * @return 32 bit value read from register.
  */
-unsigned int nrf_wifi_osal_qspi_read_reg32(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		unsigned long addr);
+unsigned int nrf_wifi_osal_qspi_read_reg32(void *priv,
+					   unsigned long addr);
 
 /**
  * @brief Writes a 32 bit value to a 32 bit device register on a QSPI slave device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param priv
  * @param addr Address of the register to write to.
  * @param val Value to be written to the register.
  *
  * @return None.
  */
-void nrf_wifi_osal_qspi_write_reg32(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		unsigned long addr,
-		unsigned int val);
+void nrf_wifi_osal_qspi_write_reg32(void *priv,
+				    unsigned long addr,
+				    unsigned int val);
 
 /**
  * @brief Copies data from a QSPI slave device to a destination buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param priv
  * @param dest Destination buffer.
  * @param addr Address of the data to be copied.
@@ -1020,16 +1018,13 @@ void nrf_wifi_osal_qspi_write_reg32(struct nrf_wifi_osal_priv *opriv,
  *
  * @return None.
  */
-void nrf_wifi_osal_qspi_cpy_from(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		void *dest,
-		unsigned long addr,
-		size_t count);
+void nrf_wifi_osal_qspi_cpy_from(void *priv,
+				 void *dest,
+				 unsigned long addr,
+				 size_t count);
 
 /**
  * @brief Copies data from a source buffer to a QSPI slave device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param priv
  * @param addr Address of the data to be written.
  * @param src Source buffer.
@@ -1037,27 +1032,22 @@ void nrf_wifi_osal_qspi_cpy_from(struct nrf_wifi_osal_priv *opriv,
  *
  * @return None.
  */
-void nrf_wifi_osal_qspi_cpy_to(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		unsigned long addr,
-		const void *src,
-		size_t count);
+void nrf_wifi_osal_qspi_cpy_to(void *priv,
+			       unsigned long addr,
+			       const void *src,
+			       size_t count);
 
 /**
  * @brief Initialize a spi driver.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  *
  * Registers a spi device driver to the OS's spi core.
  *
  * @return OS specific spi device context.
  */
-void *nrf_wifi_osal_bus_spi_init(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_osal_bus_spi_init(void);
 
 /**
  * @brief Deinitialize a spi device driver.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_spi_priv OS specific spi context.
  *
  * This API should be called when the spi device driver is
@@ -1065,14 +1055,11 @@ void *nrf_wifi_osal_bus_spi_init(struct nrf_wifi_osal_priv *opriv);
  *
  * @return None.
  */
-void nrf_wifi_osal_bus_spi_deinit(struct nrf_wifi_osal_priv *opriv,
-		void *os_spi_priv);
+void nrf_wifi_osal_bus_spi_deinit(void *os_spi_priv);
+
 
 /**
- * @brief Add a spi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param os_spi_priv Pointer to the OS specific spi context.
+ * brief Add a spi device instance.
  * @param osal_spi_dev_ctx Pointer to the OSAL spi device context.
  *
  * Function to be invoked when a matching spi device is added to the system.
@@ -1080,30 +1067,26 @@ void nrf_wifi_osal_bus_spi_deinit(struct nrf_wifi_osal_priv *opriv,
  *
  * @return OS specific spi device context.
  */
-void *nrf_wifi_osal_bus_spi_dev_add(struct nrf_wifi_osal_priv *opriv,
-		void *os_spi_priv,
-		void *osal_spi_dev_ctx);
+void *nrf_wifi_osal_bus_spi_dev_add(void *os_spi_priv,
+				    void *osal_spi_dev_ctx);
+
 
 /**
  * @brief Remove a spi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_spi_dev_ctx Pointer to the OS specific spi device context which was
- *                       returned by  nrf_wifi_osal_bus_spi_dev_add.
+ *                       returned by @nrf_wifi_osal_bus_spi_dev_add.
  *
  * Function to be invoked when a matching spi device is removed from the system.
  *
  * @return None.
  */
-void nrf_wifi_osal_bus_spi_dev_rem(struct nrf_wifi_osal_priv *opriv,
-		void *os_spi_dev_ctx);
+void nrf_wifi_osal_bus_spi_dev_rem(void *os_spi_dev_ctx);
+
 
 /**
  * @brief Initialize a spi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_spi_dev_ctx Pointer to the OS specific spi device context which was
- *                       returned by  nrf_wifi_osal_bus_spi_dev_add.
+ *                       returned by @nrf_wifi_osal_bus_spi_dev_add.
  *
  * Function to be invoked when a spi device is to be initialized.
  *
@@ -1111,27 +1094,23 @@ void nrf_wifi_osal_bus_spi_dev_rem(struct nrf_wifi_osal_priv *opriv,
  *      - Pass: nrf_wifi_STATUS_SUCCESS.
  *      - Fail: nrf_wifi_STATUS_FAIL.
  */
-enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_init(struct nrf_wifi_osal_priv *opriv,
-			void *os_spi_dev_ctx);
+enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_init(void *os_spi_dev_ctx);
+
 
 /**
  * @brief Deinitialize a spi device instance.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_spi_dev_ctx Pointer to the OS specific spi device context which was
- *                       returned by  nrf_wifi_osal_bus_spi_dev_add.
+ *                       returned by @nrf_wifi_osal_bus_spi_dev_add.
  *
  * Function to be invoked when a spi device is to be deinitialized.
  *
  * @return None.
  */
-void nrf_wifi_osal_bus_spi_dev_deinit(struct nrf_wifi_osal_priv *opriv,
-			void *os_spi_dev_ctx);
+void nrf_wifi_osal_bus_spi_dev_deinit(void *os_spi_dev_ctx);
+
 
 /**
- * @brief Register an interrupt handler for a spi device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * @brief Register a interrupt handler for a spi device.
  * @param os_spi_dev_ctx OS specific spi device context.
  * @param callbk_data Data to be passed to the ISR.
  * @param callbk_fn ISR to be invoked on receiving an interrupt.
@@ -1143,15 +1122,13 @@ void nrf_wifi_osal_bus_spi_dev_deinit(struct nrf_wifi_osal_priv *opriv,
  *     Pass: nrf_wifi_STATUS_SUCCESS.
  *     Fail: nrf_wifi_STATUS_FAIL.
  */
-enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_intr_reg(struct nrf_wifi_osal_priv *opriv,
-		void *os_spi_dev_ctx,
-		void *callbk_data,
-		int (*callbk_fn)(void *callbk_data));
+enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_intr_reg(void *os_spi_dev_ctx,
+							void *callbk_data,
+							int (*callbk_fn)(void *callbk_data));
+
 
 /**
  * @brief Unregister an interrupt handler for a spi device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_spi_dev_ctx OS specific spi device context.
  *
  * Unregisters the interrupt handler that was registered using
@@ -1159,13 +1136,11 @@ enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_intr_reg(struct nrf_wifi_osal_pri
  *
  * @return None.
  */
-void nrf_wifi_osal_bus_spi_dev_intr_unreg(struct nrf_wifi_osal_priv *opriv,
-		void *os_spi_dev_ctx);
+void nrf_wifi_osal_bus_spi_dev_intr_unreg(void *os_spi_dev_ctx);
+
 
 /**
  * @brief Get host mapped address for a spi device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param os_spi_dev_ctx OS specific spi device context.
  * @param host_map Host map address information.
  *
@@ -1173,42 +1148,33 @@ void nrf_wifi_osal_bus_spi_dev_intr_unreg(struct nrf_wifi_osal_priv *opriv,
  *
  * @return None.
  */
-void nrf_wifi_osal_bus_spi_dev_host_map_get(struct nrf_wifi_osal_priv *opriv,
-		void *os_spi_dev_ctx,
-		struct nrf_wifi_osal_host_map *host_map);
+void nrf_wifi_osal_bus_spi_dev_host_map_get(void *os_spi_dev_ctx,
+					    struct nrf_wifi_osal_host_map *host_map);
 
 /**
- * @brief Read value from a 32 bit register on a Linux SPI slave device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * @brief Read value from a 32 bit register on a SPI slave device.
  * @param priv
  * @param addr Address of the register to read from.
  *
  * @return 32 bit value read from register.
  */
-unsigned int nrf_wifi_osal_spi_read_reg32(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		unsigned long addr);
+unsigned int nrf_wifi_osal_spi_read_reg32(void *priv,
+					  unsigned long addr);
 
 /**
- * @brief Writes a 32 bit value to a 32 bit device register on a Linux SPI slave device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * @brief Writes a 32 bit value to a 32 bit device register on a SPI slave device.
  * @param priv
  * @param addr Address of the register to write to.
  * @param val Value to be written to the register.
  *
  * @return None.
  */
-void nrf_wifi_osal_spi_write_reg32(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		unsigned long addr,
-		unsigned int val);
+void nrf_wifi_osal_spi_write_reg32(void *priv,
+				   unsigned long addr,
+				   unsigned int val);
 
 /**
  * @brief Copies data from a SPI slave device to a destination buffer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param priv
  * @param dest Destination buffer.
  * @param addr Address of the register to read from.
@@ -1216,16 +1182,13 @@ void nrf_wifi_osal_spi_write_reg32(struct nrf_wifi_osal_priv *opriv,
  *
  * @return None.
  */
-void nrf_wifi_osal_spi_cpy_from(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		void *dest,
-		unsigned long addr,
-		size_t count);
+void nrf_wifi_osal_spi_cpy_from(void *priv,
+				void *dest,
+				unsigned long addr,
+				size_t count);
 
 /**
  * @brief Copies data from a source buffer to a SPI slave device.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param priv
  * @param addr Address of the register to write to.
  * @param src Source buffer.
@@ -1233,155 +1196,137 @@ void nrf_wifi_osal_spi_cpy_from(struct nrf_wifi_osal_priv *opriv,
  *
  * @return None.
  */
-void nrf_wifi_osal_spi_cpy_to(struct nrf_wifi_osal_priv *opriv,
-		void *priv,
-		unsigned long addr,
-		const void *src,
-		size_t count);
+void nrf_wifi_osal_spi_cpy_to(void *priv,
+			      unsigned long addr,
+			      const void *src,
+			      size_t count);
+
 
 #if defined(CONFIG_NRF_WIFI_LOW_POWER) || defined(__DOXYGEN__)
 /**
  * @brief Allocate a timer.
  *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * Allocates a timer instance and returns a pointer to it.
+ *
  * @return Pointer to the allocated timer instance.
  */
-void *nrf_wifi_osal_timer_alloc(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_osal_timer_alloc(void);
 
 /**
  * @brief Free a timer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param timer Pointer to a timer instance.
+ *
+ * Frees/Deallocates a timer that has been allocated using @nrf_wifi_osal_timer_alloc
+ *
  * @return None.
  */
-void nrf_wifi_osal_timer_free(struct nrf_wifi_osal_priv *opriv,
-							  void *timer);
+void nrf_wifi_osal_timer_free(void *timer);
+
 
 /**
  * @brief Initialize a timer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param timer Pointer to a timer instance.
  * @param callbk_fn Callback function to be invoked when the timer expires.
  * @param data Data to be passed to the callback function.
+ *
+ * Initializes a timer that has been allocated using @nrf_wifi_osal_timer_alloc
+ * Need to pass (@callbk_fn) callback function with the data(@data) to be
+ * passed to the callback function, whenever the timer expires.
+ *
  * @return None.
  */
-void nrf_wifi_osal_timer_init(struct nrf_wifi_osal_priv *opriv,
-							  void *timer,
-							  void (*callbk_fn)(unsigned long),
-							  unsigned long data);
+void nrf_wifi_osal_timer_init(void *timer,
+			      void (*callbk_fn)(unsigned long),
+			      unsigned long data);
+
 
 /**
  * @brief Schedule a timer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
  * @param timer Pointer to a timer instance.
  * @param duration Duration of the timer in seconds.
+ *
+ * Schedules a timer with a @duration seconds that has been allocated using
+ * @nrf_wifi_osal_timer_alloc and initialized with @nrf_wifi_osal_timer_init.
+ *
  * @return None.
  */
-void nrf_wifi_osal_timer_schedule(struct nrf_wifi_osal_priv *opriv,
-								  void *timer,
-								  unsigned long duration);
+void nrf_wifi_osal_timer_schedule(void *timer,
+				  unsigned long duration);
+
 
 /**
- * @brief Kill a timer.
- *
- * @param opriv Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * @brief Kills a timer.
  * @param timer Pointer to a timer instance.
+ *
  * @return None.
  */
-/**
- * @brief Kills a timer.
- *
- * @param opriv Pointer to the nrf_wifi_osal_priv structure.
- * @param timer Pointer to the timer to be killed.
- */
-void nrf_wifi_osal_timer_kill(struct nrf_wifi_osal_priv *opriv,
-							  void *timer);
+void nrf_wifi_osal_timer_kill(void *timer);
 
 /**
  * @brief Puts the QSPI interface to sleep.
- *
- * @param opriv Pointer to the nrf_wifi_osal_priv structure.
  * @param os_qspi_priv Pointer to the QSPI private data.
  *
  * @return 0 on success, negative error code on failure.
  */
-int nrf_wifi_osal_bus_qspi_ps_sleep(struct nrf_wifi_osal_priv *opriv,
-									void *os_qspi_priv);
+int nrf_wifi_osal_bus_qspi_ps_sleep(void *os_qspi_priv);
 
 /**
  * @brief Wakes up the QSPI interface from sleep.
- *
- * @param opriv Pointer to the nrf_wifi_osal_priv structure.
  * @param os_qspi_priv Pointer to the QSPI private data.
  *
  * @return 0 on success, negative error code on failure.
  */
-int nrf_wifi_osal_bus_qspi_ps_wake(struct nrf_wifi_osal_priv *opriv,
-								   void *os_qspi_priv);
+int nrf_wifi_osal_bus_qspi_ps_wake(void *os_qspi_priv);
 
 /**
- * @brief Get the power status of the QSPI interface.
- *
- * @param opriv Pointer to the nrf_wifi_osal_priv structure.
+ * @brief Get the power status of a QSPI interface.
  * @param os_qspi_priv Pointer to the QSPI private data.
  *
  * @return 0 if the QSPI interface is in sleep mode,
- *		1 if it is awake, negative error code on failure.
+ *         1 if it is awake,
+ *         Negative error code on failure.
  */
-int nrf_wifi_osal_bus_qspi_ps_status(struct nrf_wifi_osal_priv *opriv,
-									 void *os_qspi_priv);
+int nrf_wifi_osal_bus_qspi_ps_status(void *os_qspi_priv);
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
 /**
  * @brief nrf_wifi_osal_assert() - Assert a condition with a value.
- *
- * @param opriv: Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param test: Variable to be tested.
- * @param val: Value to be checked for the @test
- * @param op: Type of operation to be done during assertion check.
- * @param msg: Assertion message.
+ * @param test Variable to be tested.
+ * @param val Value to be checked for the @test
+ * @param op Type of operation to be done during assertion check.
+ * @param msg Assertion message.
  *
  * Compares @test with @val. If true, prints assert message.
  *
  * @return None.
  */
-void nrf_wifi_osal_assert(struct nrf_wifi_osal_priv *opriv,
-						  int test,
-						  int val,
-						  enum nrf_wifi_assert_op_type op,
-						  char *msg);
+void nrf_wifi_osal_assert(int test,
+			  int val,
+			  enum nrf_wifi_assert_op_type op,
+			  char *msg);
 
 /**
- * @brief nrf_wifi_osal_strlen() - Gives the length of the string str.
- *
- * @param opriv: Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
+ * @brief Gives the length of the string @str.
  * @param str: Pointer to the memory location of the string.
  *
  * Calculates the length of the string pointed to by str.
  *
  * @return The number of bytes of the string str.
  */
-unsigned int nrf_wifi_osal_strlen(struct nrf_wifi_osal_priv *opriv,
-								  const void *str);
+unsigned int nrf_wifi_osal_strlen(const void *str);
 
 /**
- * @brief nrf_wifi_osal_mem_cmp() - Compare contents from one memory location to another.
- *
- * @param opriv: Pointer to the OSAL context returned by the  nrf_wifi_osal_init API.
- * @param addr1: Pointer to the memory location of the first address.
- * @param addr2: Pointer to the memory location of the second address.
- * @param count: Number of bytes to be compared.
+ * @brief Compare contents from one memory location to another.
+ * @param addr1 Pointer to the memory location of first address.
+ * @param addr2 Pointer to the memory location of second address.
+ * @param count Number of bytes to be compared.
  *
  * Compares count number of bytes from addr1 location in memory to addr2
  * location in memory.
  *
  * @return An integer less than, equal to, or greater than zero.
  */
-int nrf_wifi_osal_mem_cmp(struct nrf_wifi_osal_priv *opriv,
-						  const void *addr1,
-						  const void *addr2,
-						  size_t count);
+int nrf_wifi_osal_mem_cmp(const void *addr1,
+			  const void *addr2,
+			  size_t count);
 #endif /* __OSAL_API_H__ */

--- a/nrf_wifi/os_if/inc/osal_ops.h
+++ b/nrf_wifi/os_if/inc/osal_ops.h
@@ -896,16 +896,4 @@ struct nrf_wifi_osal_ops {
 	 */
 	unsigned int (*strlen)(const void *str);
 };
-
-
-/**
- * @brief get_os_ops() - The OSAL layer expects this Op return a initialized instance
- *                      of OS specific Ops.
- *
- * This Op is expected to be implemented by a specific OS shim and is expected
- * to return a pointer to a initialized instance of struct nrf_wifi_osal_ops.
- *
- * @return Pointer to instance of OS specific Ops.
- */
-const struct nrf_wifi_osal_ops *get_os_ops(void);
 #endif /* __OSAL_OPS_H__ */

--- a/nrf_wifi/os_if/src/osal.c
+++ b/nrf_wifi/os_if/src/osal.c
@@ -11,198 +11,163 @@
 #include "osal_api.h"
 #include "osal_ops.h"
 
-struct nrf_wifi_osal_priv *nrf_wifi_osal_init(void)
+const struct nrf_wifi_osal_ops *os_ops;
+
+void nrf_wifi_osal_init(const struct nrf_wifi_osal_ops *ops)
 {
-	struct nrf_wifi_osal_priv *opriv = NULL;
-	const struct nrf_wifi_osal_ops *ops = NULL;
-
-	ops = get_os_ops();
-
-	opriv = ops->mem_zalloc(sizeof(struct nrf_wifi_osal_priv));
-
-	if (!opriv) {
-		goto out;
-	}
-
-	opriv->ops = ops;
-
-out:
-	return opriv;
+	os_ops = ops;
 }
 
 
-void nrf_wifi_osal_deinit(struct nrf_wifi_osal_priv *opriv)
+void nrf_wifi_osal_deinit(void)
 {
-	const struct nrf_wifi_osal_ops *ops = NULL;
-
-	ops = opriv->ops;
-
-	ops->mem_free(opriv);
+	os_ops = NULL;
 }
 
 
-void *nrf_wifi_osal_mem_alloc(struct nrf_wifi_osal_priv *opriv,
-			      size_t size)
+void *nrf_wifi_osal_mem_alloc(size_t size)
 {
-	return opriv->ops->mem_alloc(size);
+	return os_ops->mem_alloc(size);
 }
 
 
-void *nrf_wifi_osal_mem_zalloc(struct nrf_wifi_osal_priv *opriv,
-			       size_t size)
+void *nrf_wifi_osal_mem_zalloc(size_t size)
 {
-	return opriv->ops->mem_zalloc(size);
+	return os_ops->mem_zalloc(size);
 }
 
 
-void nrf_wifi_osal_mem_free(struct nrf_wifi_osal_priv *opriv,
-			    void *buf)
+void nrf_wifi_osal_mem_free(void *buf)
 {
-	opriv->ops->mem_free(buf);
+	os_ops->mem_free(buf);
 }
 
 
-void *nrf_wifi_osal_mem_cpy(struct nrf_wifi_osal_priv *opriv,
-			    void *dest,
+void *nrf_wifi_osal_mem_cpy(void *dest,
 			    const void *src,
 			    size_t count)
 {
-	return opriv->ops->mem_cpy(dest,
-				   src,
-				   count);
+	return os_ops->mem_cpy(dest,
+			       src,
+			       count);
 }
 
 
-void *nrf_wifi_osal_mem_set(struct nrf_wifi_osal_priv *opriv,
-			    void *start,
+void *nrf_wifi_osal_mem_set(void *start,
 			    int val,
 			    size_t size)
 {
-	return opriv->ops->mem_set(start,
-				   val,
-				   size);
+	return os_ops->mem_set(start,
+			       val,
+			       size);
 }
 
 
-int nrf_wifi_osal_mem_cmp(struct nrf_wifi_osal_priv *opriv,
-			  const void *addr1,
+int nrf_wifi_osal_mem_cmp(const void *addr1,
 			  const void *addr2,
 			  size_t size)
 {
-	return opriv->ops->mem_cmp(addr1,
-				   addr2,
-				   size);
+	return os_ops->mem_cmp(addr1,
+			       addr2,
+			       size);
 }
 
 
-void *nrf_wifi_osal_iomem_mmap(struct nrf_wifi_osal_priv *opriv,
-			       unsigned long addr,
+void *nrf_wifi_osal_iomem_mmap(unsigned long addr,
 			       unsigned long size)
 {
-	return opriv->ops->iomem_mmap(addr,
-				      size);
+	return os_ops->iomem_mmap(addr,
+				  size);
 }
 
 
-void nrf_wifi_osal_iomem_unmap(struct nrf_wifi_osal_priv *opriv,
-			       volatile void *addr)
+void nrf_wifi_osal_iomem_unmap(volatile void *addr)
 {
-	opriv->ops->iomem_unmap(addr);
+	os_ops->iomem_unmap(addr);
 }
 
 
-unsigned int nrf_wifi_osal_iomem_read_reg32(struct nrf_wifi_osal_priv *opriv,
-					    const volatile void *addr)
+unsigned int nrf_wifi_osal_iomem_read_reg32(const volatile void *addr)
 {
-	return opriv->ops->iomem_read_reg32(addr);
+	return os_ops->iomem_read_reg32(addr);
 }
 
 
-void nrf_wifi_osal_iomem_write_reg32(struct nrf_wifi_osal_priv *opriv,
-				     volatile void *addr,
+void nrf_wifi_osal_iomem_write_reg32(volatile void *addr,
 				     unsigned int val)
 {
-	opriv->ops->iomem_write_reg32(addr,
-				      val);
+	os_ops->iomem_write_reg32(addr,
+				  val);
 }
 
 
-void nrf_wifi_osal_iomem_cpy_from(struct nrf_wifi_osal_priv *opriv,
-				  void *dest,
+void nrf_wifi_osal_iomem_cpy_from(void *dest,
 				  const volatile void *src,
 				  size_t count)
 {
-	opriv->ops->iomem_cpy_from(dest,
-				   src,
-				   count);
+	os_ops->iomem_cpy_from(dest,
+			       src,
+			       count);
 }
 
 
-void nrf_wifi_osal_iomem_cpy_to(struct nrf_wifi_osal_priv *opriv,
-				volatile void *dest,
+void nrf_wifi_osal_iomem_cpy_to(volatile void *dest,
 				const void *src,
 				size_t count)
 {
-	opriv->ops->iomem_cpy_to(dest,
-				 src,
-				 count);
+	os_ops->iomem_cpy_to(dest,
+			     src,
+			     count);
 }
 
 
-void *nrf_wifi_osal_spinlock_alloc(struct nrf_wifi_osal_priv *opriv)
+void *nrf_wifi_osal_spinlock_alloc(void)
 {
-	return opriv->ops->spinlock_alloc();
+	return os_ops->spinlock_alloc();
 }
 
 
-void nrf_wifi_osal_spinlock_free(struct nrf_wifi_osal_priv *opriv,
-				 void *lock)
+void nrf_wifi_osal_spinlock_free(void *lock)
 {
-	opriv->ops->spinlock_free(lock);
+	os_ops->spinlock_free(lock);
 }
 
 
-void nrf_wifi_osal_spinlock_init(struct nrf_wifi_osal_priv *opriv,
-				 void *lock)
+void nrf_wifi_osal_spinlock_init(void *lock)
 {
-	opriv->ops->spinlock_init(lock);
+	os_ops->spinlock_init(lock);
 }
 
 
-void nrf_wifi_osal_spinlock_take(struct nrf_wifi_osal_priv *opriv,
-				 void *lock)
+void nrf_wifi_osal_spinlock_take(void *lock)
 {
-	opriv->ops->spinlock_take(lock);
+	os_ops->spinlock_take(lock);
 }
 
 
-void nrf_wifi_osal_spinlock_rel(struct nrf_wifi_osal_priv *opriv,
-				void *lock)
+void nrf_wifi_osal_spinlock_rel(void *lock)
 {
-	opriv->ops->spinlock_rel(lock);
+	os_ops->spinlock_rel(lock);
 }
 
-void nrf_wifi_osal_spinlock_irq_take(struct nrf_wifi_osal_priv *opriv,
-				     void *lock,
+void nrf_wifi_osal_spinlock_irq_take(void *lock,
 				     unsigned long *flags)
 {
-	opriv->ops->spinlock_irq_take(lock,
-				      flags);
+	os_ops->spinlock_irq_take(lock,
+				  flags);
 }
 
 
-void nrf_wifi_osal_spinlock_irq_rel(struct nrf_wifi_osal_priv *opriv,
-				    void *lock,
+void nrf_wifi_osal_spinlock_irq_rel(void *lock,
 				    unsigned long *flags)
 {
-	opriv->ops->spinlock_irq_rel(lock,
-				     flags);
+	os_ops->spinlock_irq_rel(lock,
+				 flags);
 }
 
 
 #if CONFIG_WIFI_NRF700X_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_DBG
-int nrf_wifi_osal_log_dbg(struct nrf_wifi_osal_priv *opriv,
-			  const char *fmt,
+int nrf_wifi_osal_log_dbg(const char *fmt,
 			  ...)
 {
 	va_list args;
@@ -210,7 +175,7 @@ int nrf_wifi_osal_log_dbg(struct nrf_wifi_osal_priv *opriv,
 
 	va_start(args, fmt);
 
-	ret = opriv->ops->log_dbg(fmt, args);
+	ret = os_ops->log_dbg(fmt, args);
 
 	va_end(args);
 
@@ -220,8 +185,7 @@ int nrf_wifi_osal_log_dbg(struct nrf_wifi_osal_priv *opriv,
 
 
 #if CONFIG_WIFI_NRF700X_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_INF
-int nrf_wifi_osal_log_info(struct nrf_wifi_osal_priv *opriv,
-			   const char *fmt,
+int nrf_wifi_osal_log_info(const char *fmt,
 			   ...)
 {
 	va_list args;
@@ -229,7 +193,7 @@ int nrf_wifi_osal_log_info(struct nrf_wifi_osal_priv *opriv,
 
 	va_start(args, fmt);
 
-	ret = opriv->ops->log_info(fmt, args);
+	ret = os_ops->log_info(fmt, args);
 
 	va_end(args);
 
@@ -239,8 +203,7 @@ int nrf_wifi_osal_log_info(struct nrf_wifi_osal_priv *opriv,
 
 
 #if CONFIG_WIFI_NRF700X_LOG_LEVEL >= NRF_WIFI_LOG_LEVEL_ERR
-int nrf_wifi_osal_log_err(struct nrf_wifi_osal_priv *opriv,
-			  const char *fmt,
+int nrf_wifi_osal_log_err(const char *fmt,
 			  ...)
 {
 	va_list args;
@@ -248,7 +211,7 @@ int nrf_wifi_osal_log_err(struct nrf_wifi_osal_priv *opriv,
 
 	va_start(args, fmt);
 
-	ret = opriv->ops->log_err(fmt, args);
+	ret = os_ops->log_err(fmt, args);
 
 	va_end(args);
 
@@ -257,668 +220,595 @@ int nrf_wifi_osal_log_err(struct nrf_wifi_osal_priv *opriv,
 #endif /* CONFIG_WIFI_NRF700X_LOG_LEVEL_ERR */
 
 
-void *nrf_wifi_osal_llist_node_alloc(struct nrf_wifi_osal_priv *opriv)
+void *nrf_wifi_osal_llist_node_alloc(void)
 {
-	return opriv->ops->llist_node_alloc();
+	return os_ops->llist_node_alloc();
 }
 
 
-void nrf_wifi_osal_llist_node_free(struct nrf_wifi_osal_priv *opriv,
-				   void *node)
+void nrf_wifi_osal_llist_node_free(void *node)
 {
-	opriv->ops->llist_node_free(node);
+	os_ops->llist_node_free(node);
 }
 
 
-void *nrf_wifi_osal_llist_node_data_get(struct nrf_wifi_osal_priv *opriv,
-					void *node)
+void *nrf_wifi_osal_llist_node_data_get(void *node)
 {
-	return opriv->ops->llist_node_data_get(node);
+	return os_ops->llist_node_data_get(node);
 }
 
 
-void nrf_wifi_osal_llist_node_data_set(struct nrf_wifi_osal_priv *opriv,
-				       void *node,
+void nrf_wifi_osal_llist_node_data_set(void *node,
 				       void *data)
 {
-	opriv->ops->llist_node_data_set(node,
-					data);
+	os_ops->llist_node_data_set(node,
+				    data);
 }
 
 
-void *nrf_wifi_osal_llist_alloc(struct nrf_wifi_osal_priv *opriv)
+void *nrf_wifi_osal_llist_alloc(void)
 {
-	return opriv->ops->llist_alloc();
+	return os_ops->llist_alloc();
 }
 
 
-void nrf_wifi_osal_llist_free(struct nrf_wifi_osal_priv *opriv,
-			      void *llist)
+void nrf_wifi_osal_llist_free(void *llist)
 {
-	return opriv->ops->llist_free(llist);
+	return os_ops->llist_free(llist);
 }
 
 
-void nrf_wifi_osal_llist_init(struct nrf_wifi_osal_priv *opriv,
-			      void *llist)
+void nrf_wifi_osal_llist_init(void *llist)
 {
-	return opriv->ops->llist_init(llist);
+	return os_ops->llist_init(llist);
 }
 
 
-void nrf_wifi_osal_llist_add_node_tail(struct nrf_wifi_osal_priv *opriv,
-				       void *llist,
+void nrf_wifi_osal_llist_add_node_tail(void *llist,
 				       void *llist_node)
 {
-	return opriv->ops->llist_add_node_tail(llist,
-					       llist_node);
+	return os_ops->llist_add_node_tail(llist,
+					   llist_node);
 }
 
-void nrf_wifi_osal_llist_add_node_head(struct nrf_wifi_osal_priv *opriv,
-				       void *llist,
+void nrf_wifi_osal_llist_add_node_head(void *llist,
 				       void *llist_node)
 {
-	return opriv->ops->llist_add_node_head(llist,
-					       llist_node);
+	return os_ops->llist_add_node_head(llist,
+					   llist_node);
 }
 
 
-void *nrf_wifi_osal_llist_get_node_head(struct nrf_wifi_osal_priv *opriv,
-					void *llist)
+void *nrf_wifi_osal_llist_get_node_head(void *llist)
 {
-	return opriv->ops->llist_get_node_head(llist);
+	return os_ops->llist_get_node_head(llist);
 }
 
 
-void *nrf_wifi_osal_llist_get_node_nxt(struct nrf_wifi_osal_priv *opriv,
-				       void *llist,
+void *nrf_wifi_osal_llist_get_node_nxt(void *llist,
 				       void *llist_node)
 {
-	return opriv->ops->llist_get_node_nxt(llist,
-					      llist_node);
+	return os_ops->llist_get_node_nxt(llist,
+					  llist_node);
 }
 
 
-void nrf_wifi_osal_llist_del_node(struct nrf_wifi_osal_priv *opriv,
-				  void *llist,
+void nrf_wifi_osal_llist_del_node(void *llist,
 				  void *llist_node)
 {
-	opriv->ops->llist_del_node(llist,
-				   llist_node);
+	os_ops->llist_del_node(llist,
+			       llist_node);
 }
 
 
-unsigned int nrf_wifi_osal_llist_len(struct nrf_wifi_osal_priv *opriv,
-				     void *llist)
+unsigned int nrf_wifi_osal_llist_len(void *llist)
 {
-	return opriv->ops->llist_len(llist);
+	return os_ops->llist_len(llist);
 }
 
 
-void *nrf_wifi_osal_nbuf_alloc(struct nrf_wifi_osal_priv *opriv,
-			       unsigned int size)
+void *nrf_wifi_osal_nbuf_alloc(unsigned int size)
 {
-	return opriv->ops->nbuf_alloc(size);
+	return os_ops->nbuf_alloc(size);
 }
 
 
-void nrf_wifi_osal_nbuf_free(struct nrf_wifi_osal_priv *opriv,
-			     void *nbuf)
+void nrf_wifi_osal_nbuf_free(void *nbuf)
 {
-	opriv->ops->nbuf_free(nbuf);
+	os_ops->nbuf_free(nbuf);
 }
 
 
-void nrf_wifi_osal_nbuf_headroom_res(struct nrf_wifi_osal_priv *opriv,
-				     void *nbuf,
+void nrf_wifi_osal_nbuf_headroom_res(void *nbuf,
 				     unsigned int size)
 {
-	opriv->ops->nbuf_headroom_res(nbuf,
+	os_ops->nbuf_headroom_res(nbuf,
+				  size);
+}
+
+
+unsigned int nrf_wifi_osal_nbuf_headroom_get(void *nbuf)
+{
+	return os_ops->nbuf_headroom_get(nbuf);
+}
+
+
+unsigned int nrf_wifi_osal_nbuf_data_size(void *nbuf)
+{
+	return os_ops->nbuf_data_size(nbuf);
+}
+
+
+void *nrf_wifi_osal_nbuf_data_get(void *nbuf)
+{
+	return os_ops->nbuf_data_get(nbuf);
+}
+
+
+void *nrf_wifi_osal_nbuf_data_put(void *nbuf,
+				  unsigned int size)
+{
+	return os_ops->nbuf_data_put(nbuf,
+				     size);
+}
+
+
+void *nrf_wifi_osal_nbuf_data_push(void *nbuf,
+				   unsigned int size)
+{
+	return os_ops->nbuf_data_push(nbuf,
 				      size);
 }
 
 
-unsigned int nrf_wifi_osal_nbuf_headroom_get(struct nrf_wifi_osal_priv *opriv,
-					     void *nbuf)
-{
-	return opriv->ops->nbuf_headroom_get(nbuf);
-}
-
-
-unsigned int nrf_wifi_osal_nbuf_data_size(struct nrf_wifi_osal_priv *opriv,
-					  void *nbuf)
-{
-	return opriv->ops->nbuf_data_size(nbuf);
-}
-
-
-void *nrf_wifi_osal_nbuf_data_get(struct nrf_wifi_osal_priv *opriv,
-				  void *nbuf)
-{
-	return opriv->ops->nbuf_data_get(nbuf);
-}
-
-
-void *nrf_wifi_osal_nbuf_data_put(struct nrf_wifi_osal_priv *opriv,
-				  void *nbuf,
-				  unsigned int size)
-{
-	return opriv->ops->nbuf_data_put(nbuf,
-					 size);
-}
-
-
-void *nrf_wifi_osal_nbuf_data_push(struct nrf_wifi_osal_priv *opriv,
-				   void *nbuf,
+void *nrf_wifi_osal_nbuf_data_pull(void *nbuf,
 				   unsigned int size)
 {
-	return opriv->ops->nbuf_data_push(nbuf,
-					  size);
+	return os_ops->nbuf_data_pull(nbuf,
+				      size);
 }
 
-
-void *nrf_wifi_osal_nbuf_data_pull(struct nrf_wifi_osal_priv *opriv,
-				   void *nbuf,
-				   unsigned int size)
+unsigned char nrf_wifi_osal_nbuf_get_priority(void *nbuf)
 {
-	return opriv->ops->nbuf_data_pull(nbuf,
-					  size);
+	return os_ops->nbuf_get_priority(nbuf);
 }
 
-unsigned char nrf_wifi_osal_nbuf_get_priority(struct nrf_wifi_osal_priv *opriv,
-					      void *nbuf)
+unsigned char nrf_wifi_osal_nbuf_get_chksum_done(void *nbuf)
 {
-	return opriv->ops->nbuf_get_priority(nbuf);
+	return os_ops->nbuf_get_chksum_done(nbuf);
 }
 
-unsigned char nrf_wifi_osal_nbuf_get_chksum_done(struct nrf_wifi_osal_priv *opriv,
-						 void *nbuf)
+void nrf_wifi_osal_nbuf_set_chksum_done(void *nbuf,
+					unsigned char chksum_done)
 {
-	return opriv->ops->nbuf_get_chksum_done(nbuf);
+	return os_ops->nbuf_set_chksum_done(nbuf, chksum_done);
 }
 
-void nrf_wifi_osal_nbuf_set_chksum_done(struct nrf_wifi_osal_priv *opriv,
-						 void *nbuf, unsigned char chksum_done)
+
+void *nrf_wifi_osal_tasklet_alloc(int type)
 {
-	return opriv->ops->nbuf_set_chksum_done(nbuf, chksum_done);
+	return os_ops->tasklet_alloc(type);
 }
 
 
-void *nrf_wifi_osal_tasklet_alloc(struct nrf_wifi_osal_priv *opriv, int type)
+void nrf_wifi_osal_tasklet_free(void *tasklet)
 {
-	return opriv->ops->tasklet_alloc(type);
+	os_ops->tasklet_free(tasklet);
 }
 
 
-void nrf_wifi_osal_tasklet_free(struct nrf_wifi_osal_priv *opriv,
-				void *tasklet)
-{
-	opriv->ops->tasklet_free(tasklet);
-}
-
-
-void nrf_wifi_osal_tasklet_init(struct nrf_wifi_osal_priv *opriv,
-				void *tasklet,
+void nrf_wifi_osal_tasklet_init(void *tasklet,
 				void (*callbk_fn)(unsigned long),
 				unsigned long data)
 {
-	opriv->ops->tasklet_init(tasklet,
-				 callbk_fn,
-				 data);
+	os_ops->tasklet_init(tasklet,
+			     callbk_fn,
+			     data);
 }
 
 
-void nrf_wifi_osal_tasklet_schedule(struct nrf_wifi_osal_priv *opriv,
-				    void *tasklet)
+void nrf_wifi_osal_tasklet_schedule(void *tasklet)
 {
-	opriv->ops->tasklet_schedule(tasklet);
+	os_ops->tasklet_schedule(tasklet);
 }
 
 
-void nrf_wifi_osal_tasklet_kill(struct nrf_wifi_osal_priv *opriv,
-				void *tasklet)
+void nrf_wifi_osal_tasklet_kill(void *tasklet)
 {
-	opriv->ops->tasklet_kill(tasklet);
+	os_ops->tasklet_kill(tasklet);
 }
 
 
-void nrf_wifi_osal_sleep_ms(struct nrf_wifi_osal_priv *opriv,
-			    unsigned int msecs)
+void nrf_wifi_osal_sleep_ms(unsigned int msecs)
 {
-	opriv->ops->sleep_ms(msecs);
+	os_ops->sleep_ms(msecs);
 }
 
 
-void nrf_wifi_osal_delay_us(struct nrf_wifi_osal_priv *opriv,
-			    unsigned long usecs)
+void nrf_wifi_osal_delay_us(unsigned long usecs)
 {
-	opriv->ops->delay_us(usecs);
+	os_ops->delay_us(usecs);
 }
 
 
-unsigned long nrf_wifi_osal_time_get_curr_us(struct nrf_wifi_osal_priv *opriv)
+unsigned long nrf_wifi_osal_time_get_curr_us(void)
 {
-	return opriv->ops->time_get_curr_us();
+	return os_ops->time_get_curr_us();
 }
 
 
-unsigned int nrf_wifi_osal_time_elapsed_us(struct nrf_wifi_osal_priv *opriv,
-					   unsigned long start_time_us)
+unsigned int nrf_wifi_osal_time_elapsed_us(unsigned long start_time_us)
 {
-	return opriv->ops->time_elapsed_us(start_time_us);
+	return os_ops->time_elapsed_us(start_time_us);
 }
 
 
-void *nrf_wifi_osal_bus_pcie_init(struct nrf_wifi_osal_priv *opriv,
-				  const char *dev_name,
+void *nrf_wifi_osal_bus_pcie_init(const char *dev_name,
 				  unsigned int vendor_id,
 				  unsigned int sub_vendor_id,
 				  unsigned int device_id,
 				  unsigned int sub_device_id)
 {
-	return opriv->ops->bus_pcie_init(dev_name,
-					 vendor_id,
-					 sub_vendor_id,
-					 device_id,
-					 sub_device_id);
+	return os_ops->bus_pcie_init(dev_name,
+				     vendor_id,
+				     sub_vendor_id,
+				     device_id,
+				     sub_device_id);
 }
 
 
-void nrf_wifi_osal_bus_pcie_deinit(struct nrf_wifi_osal_priv *opriv,
-				   void *os_pcie_priv)
+void nrf_wifi_osal_bus_pcie_deinit(void *os_pcie_priv)
 {
-	opriv->ops->bus_pcie_deinit(os_pcie_priv);
+	os_ops->bus_pcie_deinit(os_pcie_priv);
 }
 
 
-void *nrf_wifi_osal_bus_pcie_dev_add(struct nrf_wifi_osal_priv *opriv,
-				     void *os_pcie_priv,
+void *nrf_wifi_osal_bus_pcie_dev_add(void *os_pcie_priv,
 				     void *osal_pcie_dev_ctx)
 {
-	return opriv->ops->bus_pcie_dev_add(os_pcie_priv,
-					    osal_pcie_dev_ctx);
+	return os_ops->bus_pcie_dev_add(os_pcie_priv,
+					osal_pcie_dev_ctx);
 
 }
 
 
-void nrf_wifi_osal_bus_pcie_dev_rem(struct nrf_wifi_osal_priv *opriv,
-				    void *os_pcie_dev_ctx)
+void nrf_wifi_osal_bus_pcie_dev_rem(void *os_pcie_dev_ctx)
 {
-	return opriv->ops->bus_pcie_dev_rem(os_pcie_dev_ctx);
+	return os_ops->bus_pcie_dev_rem(os_pcie_dev_ctx);
 }
 
 
-enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_init(struct nrf_wifi_osal_priv *opriv,
-						     void *os_pcie_dev_ctx)
+enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_init(void *os_pcie_dev_ctx)
 {
-	return opriv->ops->bus_pcie_dev_init(os_pcie_dev_ctx);
+	return os_ops->bus_pcie_dev_init(os_pcie_dev_ctx);
 
 }
 
 
-void nrf_wifi_osal_bus_pcie_dev_deinit(struct nrf_wifi_osal_priv *opriv,
-				       void *os_pcie_dev_ctx)
+void nrf_wifi_osal_bus_pcie_dev_deinit(void *os_pcie_dev_ctx)
 {
-	return opriv->ops->bus_pcie_dev_deinit(os_pcie_dev_ctx);
+	return os_ops->bus_pcie_dev_deinit(os_pcie_dev_ctx);
 }
 
 
-enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_intr_reg(struct nrf_wifi_osal_priv *opriv,
-							 void *os_pcie_dev_ctx,
+enum nrf_wifi_status nrf_wifi_osal_bus_pcie_dev_intr_reg(void *os_pcie_dev_ctx,
 							 void *callbk_data,
 							 int (*callbk_fn)(void *callbk_data))
 {
-	return opriv->ops->bus_pcie_dev_intr_reg(os_pcie_dev_ctx,
-						 callbk_data,
-						 callbk_fn);
+	return os_ops->bus_pcie_dev_intr_reg(os_pcie_dev_ctx,
+					     callbk_data,
+					     callbk_fn);
 }
 
 
-void nrf_wifi_osal_bus_pcie_dev_intr_unreg(struct nrf_wifi_osal_priv *opriv,
-					   void *os_pcie_dev_ctx)
+void nrf_wifi_osal_bus_pcie_dev_intr_unreg(void *os_pcie_dev_ctx)
 {
-	opriv->ops->bus_pcie_dev_intr_unreg(os_pcie_dev_ctx);
+	os_ops->bus_pcie_dev_intr_unreg(os_pcie_dev_ctx);
 }
 
 
-void *nrf_wifi_osal_bus_pcie_dev_dma_map(struct nrf_wifi_osal_priv *opriv,
-					 void *os_pcie_dev_ctx,
+void *nrf_wifi_osal_bus_pcie_dev_dma_map(void *os_pcie_dev_ctx,
 					 void *virt_addr,
 					 size_t size,
 					 enum nrf_wifi_osal_dma_dir dir)
 {
-	return opriv->ops->bus_pcie_dev_dma_map(os_pcie_dev_ctx,
-						virt_addr,
-						size,
-						dir);
+	return os_ops->bus_pcie_dev_dma_map(os_pcie_dev_ctx,
+					    virt_addr,
+					    size,
+					    dir);
 }
 
 
-void nrf_wifi_osal_bus_pcie_dev_dma_unmap(struct nrf_wifi_osal_priv *opriv,
-					  void *os_pcie_dev_ctx,
+void nrf_wifi_osal_bus_pcie_dev_dma_unmap(void *os_pcie_dev_ctx,
 					  void *dma_addr,
 					  size_t size,
 					  enum nrf_wifi_osal_dma_dir dir)
 {
-	opriv->ops->bus_pcie_dev_dma_unmap(os_pcie_dev_ctx,
-					   dma_addr,
-					   size,
-					   dir);
+	os_ops->bus_pcie_dev_dma_unmap(os_pcie_dev_ctx,
+				       dma_addr,
+				       size,
+				       dir);
 }
 
 
-void nrf_wifi_osal_bus_pcie_dev_host_map_get(struct nrf_wifi_osal_priv *opriv,
-					     void *os_pcie_dev_ctx,
+void nrf_wifi_osal_bus_pcie_dev_host_map_get(void *os_pcie_dev_ctx,
 					     struct nrf_wifi_osal_host_map *host_map)
 {
-	opriv->ops->bus_pcie_dev_host_map_get(os_pcie_dev_ctx,
-					      host_map);
+	os_ops->bus_pcie_dev_host_map_get(os_pcie_dev_ctx,
+					  host_map);
 }
 
 
-void *nrf_wifi_osal_bus_qspi_init(struct nrf_wifi_osal_priv *opriv)
+void *nrf_wifi_osal_bus_qspi_init(void)
 {
-	return opriv->ops->bus_qspi_init();
+	return os_ops->bus_qspi_init();
 }
 
 
-void nrf_wifi_osal_bus_qspi_deinit(struct nrf_wifi_osal_priv *opriv,
-				   void *os_qspi_priv)
+void nrf_wifi_osal_bus_qspi_deinit(void *os_qspi_priv)
 {
-	opriv->ops->bus_qspi_deinit(os_qspi_priv);
+	os_ops->bus_qspi_deinit(os_qspi_priv);
 }
 
 
-void *nrf_wifi_osal_bus_qspi_dev_add(struct nrf_wifi_osal_priv *opriv,
-				     void *os_qspi_priv,
+void *nrf_wifi_osal_bus_qspi_dev_add(void *os_qspi_priv,
 				     void *osal_qspi_dev_ctx)
 {
-	return opriv->ops->bus_qspi_dev_add(os_qspi_priv,
-					    osal_qspi_dev_ctx);
+	return os_ops->bus_qspi_dev_add(os_qspi_priv,
+					osal_qspi_dev_ctx);
 }
 
 
-void nrf_wifi_osal_bus_qspi_dev_rem(struct nrf_wifi_osal_priv *opriv,
-				    void *os_qspi_dev_ctx)
+void nrf_wifi_osal_bus_qspi_dev_rem(void *os_qspi_dev_ctx)
 {
-	opriv->ops->bus_qspi_dev_rem(os_qspi_dev_ctx);
+	os_ops->bus_qspi_dev_rem(os_qspi_dev_ctx);
 }
 
 
-enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_init(struct nrf_wifi_osal_priv *opriv,
-						     void *os_qspi_dev_ctx)
+enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_init(void *os_qspi_dev_ctx)
 {
-	return opriv->ops->bus_qspi_dev_init(os_qspi_dev_ctx);
+	return os_ops->bus_qspi_dev_init(os_qspi_dev_ctx);
 }
 
 
-void nrf_wifi_osal_bus_qspi_dev_deinit(struct nrf_wifi_osal_priv *opriv,
-				       void *os_qspi_dev_ctx)
+void nrf_wifi_osal_bus_qspi_dev_deinit(void *os_qspi_dev_ctx)
 {
-	opriv->ops->bus_qspi_dev_deinit(os_qspi_dev_ctx);
+	os_ops->bus_qspi_dev_deinit(os_qspi_dev_ctx);
 }
 
 
-enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_intr_reg(struct nrf_wifi_osal_priv *opriv,
-							 void *os_qspi_dev_ctx,
+enum nrf_wifi_status nrf_wifi_osal_bus_qspi_dev_intr_reg(void *os_qspi_dev_ctx,
 							 void *callbk_data,
 							 int (*callbk_fn)(void *callbk_data))
 {
-	return opriv->ops->bus_qspi_dev_intr_reg(os_qspi_dev_ctx,
-						 callbk_data,
-						 callbk_fn);
+	return os_ops->bus_qspi_dev_intr_reg(os_qspi_dev_ctx,
+					     callbk_data,
+					     callbk_fn);
 }
 
 
-void nrf_wifi_osal_bus_qspi_dev_intr_unreg(struct nrf_wifi_osal_priv *opriv,
-					   void *os_qspi_dev_ctx)
+void nrf_wifi_osal_bus_qspi_dev_intr_unreg(void *os_qspi_dev_ctx)
 {
-	opriv->ops->bus_qspi_dev_intr_unreg(os_qspi_dev_ctx);
+	os_ops->bus_qspi_dev_intr_unreg(os_qspi_dev_ctx);
 }
 
 
-void nrf_wifi_osal_bus_qspi_dev_host_map_get(struct nrf_wifi_osal_priv *opriv,
-					     void *os_qspi_dev_ctx,
+void nrf_wifi_osal_bus_qspi_dev_host_map_get(void *os_qspi_dev_ctx,
 					     struct nrf_wifi_osal_host_map *host_map)
 {
-	opriv->ops->bus_qspi_dev_host_map_get(os_qspi_dev_ctx,
-					      host_map);
+	os_ops->bus_qspi_dev_host_map_get(os_qspi_dev_ctx,
+					  host_map);
 }
 
 
-unsigned int nrf_wifi_osal_qspi_read_reg32(struct nrf_wifi_osal_priv *opriv,
-					   void *priv,
+unsigned int nrf_wifi_osal_qspi_read_reg32(void *priv,
 					   unsigned long addr)
 {
-	return opriv->ops->qspi_read_reg32(priv,
-					   addr);
+	return os_ops->qspi_read_reg32(priv,
+				       addr);
 }
 
 
-void nrf_wifi_osal_qspi_write_reg32(struct nrf_wifi_osal_priv *opriv,
-				    void *priv,
+void nrf_wifi_osal_qspi_write_reg32(void *priv,
 				    unsigned long addr,
 				    unsigned int val)
 {
-	opriv->ops->qspi_write_reg32(priv,
-				     addr,
-				     val);
+	os_ops->qspi_write_reg32(priv,
+				 addr,
+				 val);
 }
 
 
-void nrf_wifi_osal_qspi_cpy_from(struct nrf_wifi_osal_priv *opriv,
-				 void *priv,
+void nrf_wifi_osal_qspi_cpy_from(void *priv,
 				 void *dest,
 				 unsigned long addr,
 				 size_t count)
 {
-	opriv->ops->qspi_cpy_from(priv,
-				  dest,
-				  addr,
-				  count);
+	os_ops->qspi_cpy_from(priv,
+			      dest,
+			      addr,
+			      count);
 }
 
 
-void nrf_wifi_osal_qspi_cpy_to(struct nrf_wifi_osal_priv *opriv,
-			       void *priv,
+void nrf_wifi_osal_qspi_cpy_to(void *priv,
 			       unsigned long addr,
 			       const void *src,
 			       size_t count)
 {
-	opriv->ops->qspi_cpy_to(priv,
+	os_ops->qspi_cpy_to(priv,
+			    addr,
+			    src,
+			    count);
+}
+
+
+void *nrf_wifi_osal_bus_spi_init(void)
+{
+	return os_ops->bus_spi_init();
+}
+
+
+void nrf_wifi_osal_bus_spi_deinit(void *os_spi_priv)
+{
+	os_ops->bus_spi_deinit(os_spi_priv);
+}
+
+
+void *nrf_wifi_osal_bus_spi_dev_add(void *os_spi_priv,
+				    void *osal_spi_dev_ctx)
+{
+	return os_ops->bus_spi_dev_add(os_spi_priv,
+				       osal_spi_dev_ctx);
+}
+
+
+void nrf_wifi_osal_bus_spi_dev_rem(void *os_spi_dev_ctx)
+{
+	os_ops->bus_spi_dev_rem(os_spi_dev_ctx);
+}
+
+
+enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_init(void *os_spi_dev_ctx)
+{
+	return os_ops->bus_spi_dev_init(os_spi_dev_ctx);
+}
+
+
+void nrf_wifi_osal_bus_spi_dev_deinit(void *os_spi_dev_ctx)
+{
+	os_ops->bus_spi_dev_deinit(os_spi_dev_ctx);
+}
+
+
+enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_intr_reg(void *os_spi_dev_ctx,
+							void *callbk_data,
+							int (*callbk_fn)(void *callbk_data))
+{
+	return os_ops->bus_spi_dev_intr_reg(os_spi_dev_ctx,
+					    callbk_data,
+					    callbk_fn);
+}
+
+
+void nrf_wifi_osal_bus_spi_dev_intr_unreg(void *os_spi_dev_ctx)
+{
+	os_ops->bus_spi_dev_intr_unreg(os_spi_dev_ctx);
+}
+
+
+void nrf_wifi_osal_bus_spi_dev_host_map_get(void *os_spi_dev_ctx,
+					    struct nrf_wifi_osal_host_map *host_map)
+{
+	os_ops->bus_spi_dev_host_map_get(os_spi_dev_ctx,
+					 host_map);
+}
+
+unsigned int nrf_wifi_osal_spi_read_reg32(void *os_spi_dev_ctx,
+					  unsigned long addr)
+{
+	return os_ops->spi_read_reg32(os_spi_dev_ctx, addr);
+}
+
+
+void nrf_wifi_osal_spi_write_reg32(void *os_spi_dev_ctx,
+				   unsigned long addr,
+				   unsigned int val)
+{
+	os_ops->spi_write_reg32(os_spi_dev_ctx,
 				addr,
-				src,
-				count);
+				val);
 }
 
 
-void *nrf_wifi_osal_bus_spi_init(struct nrf_wifi_osal_priv *opriv)
+void nrf_wifi_osal_spi_cpy_from(void *os_spi_dev_ctx,
+				void *dest,
+				unsigned long addr,
+				size_t count)
 {
-	return opriv->ops->bus_spi_init();
+	os_ops->spi_cpy_from(os_spi_dev_ctx,
+			     dest,
+			     addr,
+			     count);
 }
 
 
-void nrf_wifi_osal_bus_spi_deinit(struct nrf_wifi_osal_priv *opriv,
-				   void *os_spi_priv)
+void nrf_wifi_osal_spi_cpy_to(void *os_spi_dev_ctx,
+			      unsigned long addr,
+			      const void *src,
+			      size_t count)
 {
-	opriv->ops->bus_spi_deinit(os_spi_priv);
-}
-
-
-void *nrf_wifi_osal_bus_spi_dev_add(struct nrf_wifi_osal_priv *opriv,
-					 void *os_spi_priv,
-					 void *osal_spi_dev_ctx)
-{
-	return opriv->ops->bus_spi_dev_add(os_spi_priv,
-						osal_spi_dev_ctx);
-}
-
-
-void nrf_wifi_osal_bus_spi_dev_rem(struct nrf_wifi_osal_priv *opriv,
-					void *os_spi_dev_ctx)
-{
-	opriv->ops->bus_spi_dev_rem(os_spi_dev_ctx);
-}
-
-
-enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_init(struct nrf_wifi_osal_priv *opriv,
-							 void *os_spi_dev_ctx)
-{
-	return opriv->ops->bus_spi_dev_init(os_spi_dev_ctx);
-}
-
-
-void nrf_wifi_osal_bus_spi_dev_deinit(struct nrf_wifi_osal_priv *opriv,
-					   void *os_spi_dev_ctx)
-{
-	opriv->ops->bus_spi_dev_deinit(os_spi_dev_ctx);
-}
-
-
-enum nrf_wifi_status nrf_wifi_osal_bus_spi_dev_intr_reg(struct nrf_wifi_osal_priv *opriv,
-							 void *os_spi_dev_ctx,
-							 void *callbk_data,
-							 int (*callbk_fn)(void *callbk_data))
-{
-	return opriv->ops->bus_spi_dev_intr_reg(os_spi_dev_ctx,
-						 callbk_data,
-						 callbk_fn);
-}
-
-
-void nrf_wifi_osal_bus_spi_dev_intr_unreg(struct nrf_wifi_osal_priv *opriv,
-					   void *os_spi_dev_ctx)
-{
-	opriv->ops->bus_spi_dev_intr_unreg(os_spi_dev_ctx);
-}
-
-
-void nrf_wifi_osal_bus_spi_dev_host_map_get(struct nrf_wifi_osal_priv *opriv,
-						 void *os_spi_dev_ctx,
-						 struct nrf_wifi_osal_host_map *host_map)
-{
-	opriv->ops->bus_spi_dev_host_map_get(os_spi_dev_ctx,
-						  host_map);
-}
-
-unsigned int nrf_wifi_osal_spi_read_reg32(struct nrf_wifi_osal_priv *opriv,
-						void *os_spi_dev_ctx,
-						unsigned long addr)
-{
-		return opriv->ops->spi_read_reg32(os_spi_dev_ctx, addr);
-}
-
-
-void nrf_wifi_osal_spi_write_reg32(struct nrf_wifi_osal_priv *opriv,
-									void *os_spi_dev_ctx,
-									unsigned long addr,
-									unsigned int val)
-{
-		opriv->ops->spi_write_reg32(os_spi_dev_ctx,
-									 addr,
-									 val);
-}
-
-
-void nrf_wifi_osal_spi_cpy_from(struct nrf_wifi_osal_priv *opriv,
-								 void *os_spi_dev_ctx,
-								 void *dest,
-								 unsigned long addr,
-								 size_t count)
-{
-		opriv->ops->spi_cpy_from(os_spi_dev_ctx,
-								  dest,
-								  addr,
-								  count);
-}
-
-
-void nrf_wifi_osal_spi_cpy_to(struct nrf_wifi_osal_priv *opriv,
-							   void *os_spi_dev_ctx,
-							   unsigned long addr,
-							   const void *src,
-							   size_t count)
-{
-		opriv->ops->spi_cpy_to(os_spi_dev_ctx,
-								addr,
-								src,
-								count);
+		os_ops->spi_cpy_to(os_spi_dev_ctx,
+				   addr,
+				   src,
+				   count);
 }
 
 #ifdef CONFIG_NRF_WIFI_LOW_POWER
-void *nrf_wifi_osal_timer_alloc(struct nrf_wifi_osal_priv *opriv)
+void *nrf_wifi_osal_timer_alloc(void)
 {
-	return opriv->ops->timer_alloc();
+	return os_ops->timer_alloc();
 }
 
 
-void nrf_wifi_osal_timer_free(struct nrf_wifi_osal_priv *opriv,
-			      void *timer)
+void nrf_wifi_osal_timer_free(void *timer)
 {
-	opriv->ops->timer_free(timer);
+	os_ops->timer_free(timer);
 }
 
 
-void nrf_wifi_osal_timer_init(struct nrf_wifi_osal_priv *opriv,
-			      void *timer,
+void nrf_wifi_osal_timer_init(void *timer,
 			      void (*callbk_fn)(unsigned long),
 			      unsigned long data)
 {
-	opriv->ops->timer_init(timer,
-			       callbk_fn,
-			       data);
+	os_ops->timer_init(timer,
+			   callbk_fn,
+			   data);
 }
 
 
-void nrf_wifi_osal_timer_schedule(struct nrf_wifi_osal_priv *opriv,
-				  void *timer,
+void nrf_wifi_osal_timer_schedule(void *timer,
 				  unsigned long duration)
 {
-	opriv->ops->timer_schedule(timer,
-				   duration);
+	os_ops->timer_schedule(timer,
+			       duration);
 }
 
 
-void nrf_wifi_osal_timer_kill(struct nrf_wifi_osal_priv *opriv,
-			      void *timer)
+void nrf_wifi_osal_timer_kill(void *timer)
 {
-	opriv->ops->timer_kill(timer);
+	os_ops->timer_kill(timer);
 }
 
 
 
-int nrf_wifi_osal_bus_qspi_ps_sleep(struct nrf_wifi_osal_priv *opriv,
-				    void *os_qspi_priv)
+int nrf_wifi_osal_bus_qspi_ps_sleep(void *os_qspi_priv)
 {
-	return opriv->ops->bus_qspi_ps_sleep(os_qspi_priv);
+	return os_ops->bus_qspi_ps_sleep(os_qspi_priv);
 }
 
 
-int nrf_wifi_osal_bus_qspi_ps_wake(struct nrf_wifi_osal_priv *opriv,
-				   void *os_qspi_priv)
+int nrf_wifi_osal_bus_qspi_ps_wake(void *os_qspi_priv)
 {
-	return opriv->ops->bus_qspi_ps_wake(os_qspi_priv);
+	return os_ops->bus_qspi_ps_wake(os_qspi_priv);
 }
 
 
-int nrf_wifi_osal_bus_qspi_ps_status(struct nrf_wifi_osal_priv *opriv,
-				     void *os_qspi_priv)
+int nrf_wifi_osal_bus_qspi_ps_status(void *os_qspi_priv)
 {
-	return opriv->ops->bus_qspi_ps_status(os_qspi_priv);
+	return os_ops->bus_qspi_ps_status(os_qspi_priv);
 }
 #endif /* CONFIG_NRF_WIFI_LOW_POWER */
 
-void nrf_wifi_osal_assert(struct nrf_wifi_osal_priv *opriv,
-			  int test_val,
+void nrf_wifi_osal_assert(int test_val,
 			  int val,
 			  enum nrf_wifi_assert_op_type op,
 			  char *msg)
 {
-	return opriv->ops->assert(test_val, val, op, msg);
+	return os_ops->assert(test_val, val, op, msg);
 }
 
-unsigned int nrf_wifi_osal_strlen(struct nrf_wifi_osal_priv *opriv,
-				  const void *str)
+unsigned int nrf_wifi_osal_strlen(const void *str)
 {
-	return opriv->ops->strlen(str);
+	return os_ops->strlen(str);
 }

--- a/nrf_wifi/utils/inc/list.h
+++ b/nrf_wifi/utils/inc/list.h
@@ -14,35 +14,27 @@
 
 #include "osal_api.h"
 
-void *nrf_wifi_utils_list_alloc(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_utils_list_alloc(void);
 
-void nrf_wifi_utils_list_free(struct nrf_wifi_osal_priv *opriv,
-			      void *list);
+void nrf_wifi_utils_list_free(void *list);
 
-enum nrf_wifi_status nrf_wifi_utils_list_add_tail(struct nrf_wifi_osal_priv *opriv,
-						  void *list,
+enum nrf_wifi_status nrf_wifi_utils_list_add_tail(void *list,
 						  void *data);
 
-enum nrf_wifi_status nrf_wifi_utils_list_add_head(struct nrf_wifi_osal_priv *opriv,
-						  void *list,
+enum nrf_wifi_status nrf_wifi_utils_list_add_head(void *list,
 						  void *data);
 
-void nrf_wifi_utils_list_del_node(struct nrf_wifi_osal_priv *opriv,
-				  void *list,
+void nrf_wifi_utils_list_del_node(void *list,
 				  void *data);
 
-void *nrf_wifi_utils_list_del_head(struct nrf_wifi_osal_priv *opriv,
-				   void *list);
+void *nrf_wifi_utils_list_del_head(void *list);
 
-void *nrf_wifi_utils_list_peek(struct nrf_wifi_osal_priv *opriv,
-			       void *list);
+void *nrf_wifi_utils_list_peek(void *list);
 
-unsigned int nrf_wifi_utils_list_len(struct nrf_wifi_osal_priv *opriv,
-				     void *list);
+unsigned int nrf_wifi_utils_list_len(void *list);
 
 enum nrf_wifi_status
-nrf_wifi_utils_list_traverse(struct nrf_wifi_osal_priv *opriv,
-			     void *list,
+nrf_wifi_utils_list_traverse(void *list,
 			     void *callbk_data,
 			     enum nrf_wifi_status (*callbk_func)(void *callbk_data,
 								 void *data));

--- a/nrf_wifi/utils/inc/queue.h
+++ b/nrf_wifi/utils/inc/queue.h
@@ -14,25 +14,19 @@
 
 #include "osal_ops.h"
 
-void *nrf_wifi_utils_q_alloc(struct nrf_wifi_osal_priv *opriv);
+void *nrf_wifi_utils_q_alloc(void);
 
-void nrf_wifi_utils_q_free(struct nrf_wifi_osal_priv *opriv,
-			   void *q);
+void nrf_wifi_utils_q_free(void *q);
 
-enum nrf_wifi_status nrf_wifi_utils_q_enqueue(struct nrf_wifi_osal_priv *opriv,
-					      void *q,
+enum nrf_wifi_status nrf_wifi_utils_q_enqueue(void *q,
 					      void *q_node);
 
-enum nrf_wifi_status nrf_wifi_utils_q_enqueue_head(struct nrf_wifi_osal_priv *opriv,
-						   void *q,
+enum nrf_wifi_status nrf_wifi_utils_q_enqueue_head(void *q,
 						   void *q_node);
 
-void *nrf_wifi_utils_q_dequeue(struct nrf_wifi_osal_priv *opriv,
-			       void *q);
+void *nrf_wifi_utils_q_dequeue(void *q);
 
-void *nrf_wifi_utils_q_peek(struct nrf_wifi_osal_priv *opriv,
-			    void *q);
+void *nrf_wifi_utils_q_peek(void *q);
 
-unsigned int nrf_wifi_utils_q_len(struct nrf_wifi_osal_priv *opriv,
-				  void *q);
+unsigned int nrf_wifi_utils_q_len(void *q);
 #endif /* __QUEUE_H__ */

--- a/nrf_wifi/utils/inc/util.h
+++ b/nrf_wifi/utils/inc/util.h
@@ -22,15 +22,12 @@
 /* Convert power from mBm to dBm */
 #define MBM_TO_DBM(gain) ((gain) / 100)
 
-int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
-				  unsigned char *hex_arr,
+int nrf_wifi_utils_hex_str_to_val(unsigned char *hex_arr,
 				  unsigned int hex_arr_sz,
 				  unsigned char *str);
 
-bool nrf_wifi_utils_is_mac_addr_valid(struct nrf_wifi_osal_priv *opriv,
-				      const char *mac_addr);
+bool nrf_wifi_utils_is_mac_addr_valid(const char *mac_addr);
 
-int nrf_wifi_utils_chan_to_freq(struct nrf_wifi_osal_priv *opriv,
-				enum nrf_wifi_band band,
+int nrf_wifi_utils_chan_to_freq(enum nrf_wifi_band band,
 				unsigned short chan);
 #endif /* __UTIL_H__ */

--- a/nrf_wifi/utils/src/list.c
+++ b/nrf_wifi/utils/src/list.c
@@ -12,21 +12,19 @@
 
 #include "list.h"
 
-void *nrf_wifi_utils_list_alloc(struct nrf_wifi_osal_priv *opriv)
+void *nrf_wifi_utils_list_alloc(void)
 {
 	void *list = NULL;
 
-	list = nrf_wifi_osal_llist_alloc(opriv);
+	list = nrf_wifi_osal_llist_alloc();
 
 	if (!list) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate list",
+		nrf_wifi_osal_log_err("%s: Unable to allocate list",
 				      __func__);
 		goto out;
 	}
 
-	nrf_wifi_osal_llist_init(opriv,
-				 list);
+	nrf_wifi_osal_llist_init(list);
 
 out:
 	return list;
@@ -34,157 +32,130 @@ out:
 }
 
 
-void nrf_wifi_utils_list_free(struct nrf_wifi_osal_priv *opriv,
-			      void *list)
+void nrf_wifi_utils_list_free(void *list)
 {
-	nrf_wifi_osal_llist_free(opriv,
-				 list);
+	nrf_wifi_osal_llist_free(list);
 }
 
 
-enum nrf_wifi_status nrf_wifi_utils_list_add_tail(struct nrf_wifi_osal_priv *opriv,
-						  void *list,
+enum nrf_wifi_status nrf_wifi_utils_list_add_tail(void *list,
 						  void *data)
 {
 	void *list_node = NULL;
 
-	list_node = nrf_wifi_osal_llist_node_alloc(opriv);
+	list_node = nrf_wifi_osal_llist_node_alloc();
 
 	if (!list_node) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate list node",
+		nrf_wifi_osal_log_err("%s: Unable to allocate list node",
 				      __func__);
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
-	nrf_wifi_osal_llist_node_data_set(opriv,
-					  list_node,
+	nrf_wifi_osal_llist_node_data_set(list_node,
 					  data);
 
-	nrf_wifi_osal_llist_add_node_tail(opriv,
-					  list,
+	nrf_wifi_osal_llist_add_node_tail(list,
 					  list_node);
 
 	return NRF_WIFI_STATUS_SUCCESS;
 }
 
-enum nrf_wifi_status nrf_wifi_utils_list_add_head(struct nrf_wifi_osal_priv *opriv,
-						  void *list,
+enum nrf_wifi_status nrf_wifi_utils_list_add_head(void *list,
 						  void *data)
 {
 	void *list_node = NULL;
 
-	list_node = nrf_wifi_osal_llist_node_alloc(opriv);
+	list_node = nrf_wifi_osal_llist_node_alloc();
 
 	if (!list_node) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Unable to allocate list node",
+		nrf_wifi_osal_log_err("%s: Unable to allocate list node",
 				      __func__);
 		return NRF_WIFI_STATUS_FAIL;
 	}
 
-	nrf_wifi_osal_llist_node_data_set(opriv,
-					  list_node,
+	nrf_wifi_osal_llist_node_data_set(list_node,
 					  data);
 
-	nrf_wifi_osal_llist_add_node_head(opriv,
-					  list,
+	nrf_wifi_osal_llist_add_node_head(list,
 					  list_node);
 
 	return NRF_WIFI_STATUS_SUCCESS;
 }
 
-void nrf_wifi_utils_list_del_node(struct nrf_wifi_osal_priv *opriv,
-				  void *list,
+void nrf_wifi_utils_list_del_node(void *list,
 				  void *data)
 {
 	void *stored_data;
 	void *list_node = NULL;
 	void *list_node_next = NULL;
 
-	list_node = nrf_wifi_osal_llist_get_node_head(opriv,
-						      list);
+	list_node = nrf_wifi_osal_llist_get_node_head(list);
 
 	while (list_node) {
-		stored_data = nrf_wifi_osal_llist_node_data_get(opriv,
-								list_node);
+		stored_data = nrf_wifi_osal_llist_node_data_get(list_node);
 
-		list_node_next = nrf_wifi_osal_llist_get_node_nxt(opriv,
-								  list,
+		list_node_next = nrf_wifi_osal_llist_get_node_nxt(list,
 								  list_node);
 
 		if (stored_data == data) {
-			nrf_wifi_osal_llist_del_node(opriv,
-						     list,
+			nrf_wifi_osal_llist_del_node(list,
 						     list_node);
 
-			nrf_wifi_osal_llist_node_free(opriv,
-						      list_node);
+			nrf_wifi_osal_llist_node_free(list_node);
 		}
 
 		list_node = list_node_next;
 	}
 }
 
-void *nrf_wifi_utils_list_del_head(struct nrf_wifi_osal_priv *opriv,
-				   void *list)
+void *nrf_wifi_utils_list_del_head(void *list)
 {
 	void *list_node = NULL;
 	void *data = NULL;
 
-	list_node = nrf_wifi_osal_llist_get_node_head(opriv,
-						      list);
+	list_node = nrf_wifi_osal_llist_get_node_head(list);
 
 	if (!list_node) {
 		goto out;
 	}
 
-	data = nrf_wifi_osal_llist_node_data_get(opriv,
-						 list_node);
+	data = nrf_wifi_osal_llist_node_data_get(list_node);
 
-	nrf_wifi_osal_llist_del_node(opriv,
-				     list,
+	nrf_wifi_osal_llist_del_node(list,
 				     list_node);
-	nrf_wifi_osal_llist_node_free(opriv,
-				      list_node);
+	nrf_wifi_osal_llist_node_free(list_node);
 
 out:
 	return data;
 }
 
 
-void *nrf_wifi_utils_list_peek(struct nrf_wifi_osal_priv *opriv,
-			       void *list)
+void *nrf_wifi_utils_list_peek(void *list)
 {
 	void *list_node = NULL;
 	void *data = NULL;
 
-	list_node = nrf_wifi_osal_llist_get_node_head(opriv,
-						      list);
+	list_node = nrf_wifi_osal_llist_get_node_head(list);
 
 	if (!list_node) {
 		goto out;
 	}
 
-	data = nrf_wifi_osal_llist_node_data_get(opriv,
-						 list_node);
+	data = nrf_wifi_osal_llist_node_data_get(list_node);
 
 out:
 	return data;
 }
 
 
-unsigned int nrf_wifi_utils_list_len(struct nrf_wifi_osal_priv *opriv,
-				     void *list)
+unsigned int nrf_wifi_utils_list_len(void *list)
 {
-	return nrf_wifi_osal_llist_len(opriv,
-				       list);
+	return nrf_wifi_osal_llist_len(list);
 }
 
 
 enum nrf_wifi_status
-nrf_wifi_utils_list_traverse(struct nrf_wifi_osal_priv *opriv,
-			     void *list,
+nrf_wifi_utils_list_traverse(void *list,
 			     void *callbk_data,
 			     enum nrf_wifi_status (*callbk_func)(void *callbk_data,
 								 void *data))
@@ -193,12 +164,10 @@ nrf_wifi_utils_list_traverse(struct nrf_wifi_osal_priv *opriv,
 	void *data = NULL;
 	enum nrf_wifi_status status = NRF_WIFI_STATUS_FAIL;
 
-	list_node = nrf_wifi_osal_llist_get_node_head(opriv,
-						      list);
+	list_node = nrf_wifi_osal_llist_get_node_head(list);
 
 	while (list_node) {
-		data = nrf_wifi_osal_llist_node_data_get(opriv,
-							 list_node);
+		data = nrf_wifi_osal_llist_node_data_get(list_node);
 
 		status = callbk_func(callbk_data,
 				     data);
@@ -207,8 +176,7 @@ nrf_wifi_utils_list_traverse(struct nrf_wifi_osal_priv *opriv,
 			goto out;
 		}
 
-		list_node = nrf_wifi_osal_llist_get_node_nxt(opriv,
-							     list,
+		list_node = nrf_wifi_osal_llist_get_node_nxt(list,
 							     list_node);
 	}
 out:

--- a/nrf_wifi/utils/src/queue.c
+++ b/nrf_wifi/utils/src/queue.c
@@ -12,58 +12,46 @@
 #include "list.h"
 #include "queue.h"
 
-void *nrf_wifi_utils_q_alloc(struct nrf_wifi_osal_priv *opriv)
+void *nrf_wifi_utils_q_alloc(void)
 {
-	return nrf_wifi_utils_list_alloc(opriv);
+	return nrf_wifi_utils_list_alloc();
 }
 
 
-void nrf_wifi_utils_q_free(struct nrf_wifi_osal_priv *opriv,
-			   void *q)
+void nrf_wifi_utils_q_free(void *q)
 {
-	nrf_wifi_utils_list_free(opriv,
-				 q);
+	nrf_wifi_utils_list_free(q);
 }
 
 
-enum nrf_wifi_status nrf_wifi_utils_q_enqueue(struct nrf_wifi_osal_priv *opriv,
-					      void *q,
+enum nrf_wifi_status nrf_wifi_utils_q_enqueue(void *q,
 					      void *data)
 {
-	return nrf_wifi_utils_list_add_tail(opriv,
-					    q,
+	return nrf_wifi_utils_list_add_tail(q,
 					    data);
 }
 
-enum nrf_wifi_status nrf_wifi_utils_q_enqueue_head(struct nrf_wifi_osal_priv *opriv,
-						   void *q,
+enum nrf_wifi_status nrf_wifi_utils_q_enqueue_head(void *q,
 						   void *data)
 {
-	return nrf_wifi_utils_list_add_head(opriv,
-					    q,
+	return nrf_wifi_utils_list_add_head(q,
 					    data);
 }
 
 
-void *nrf_wifi_utils_q_dequeue(struct nrf_wifi_osal_priv *opriv,
-			       void *q)
+void *nrf_wifi_utils_q_dequeue(void *q)
 {
-	return nrf_wifi_utils_list_del_head(opriv,
-					    q);
+	return nrf_wifi_utils_list_del_head(q);
 }
 
 
-void *nrf_wifi_utils_q_peek(struct nrf_wifi_osal_priv *opriv,
-			    void *q)
+void *nrf_wifi_utils_q_peek(void *q)
 {
-	return nrf_wifi_utils_list_peek(opriv,
-					q);
+	return nrf_wifi_utils_list_peek(q);
 }
 
 
-unsigned int nrf_wifi_utils_q_len(struct nrf_wifi_osal_priv *opriv,
-				  void *q)
+unsigned int nrf_wifi_utils_q_len(void *q)
 {
-	return nrf_wifi_utils_list_len(opriv,
-				       q);
+	return nrf_wifi_utils_list_len(q);
 }

--- a/nrf_wifi/utils/src/util.c
+++ b/nrf_wifi/utils/src/util.c
@@ -12,8 +12,7 @@
 #include <util.h>
 #include "host_rpu_data_if.h"
 
-int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
-				  unsigned char *hex_arr,
+int nrf_wifi_utils_hex_str_to_val(unsigned char *hex_arr,
 				  unsigned int hex_arr_sz,
 				  unsigned char *str)
 {
@@ -24,11 +23,10 @@ int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
 	unsigned int len = 0;
 	int ret = -1;
 
-	len = nrf_wifi_osal_strlen(opriv, str);
+	len = nrf_wifi_osal_strlen(str);
 
 	if (len / 2 > hex_arr_sz) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: String length (%d) greater than array size (%d)",
+		nrf_wifi_osal_log_err("%s: String length (%d) greater than array size (%d)",
 				      __func__,
 				      len,
 				      hex_arr_sz);
@@ -36,8 +34,7 @@ int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
 	}
 
 	if (len % 2) {
-		nrf_wifi_osal_log_err(opriv,
-				      "%s:String length = %d, is not a multiple of 2",
+		nrf_wifi_osal_log_err("%s:String length = %d, is not a multiple of 2",
 				      __func__,
 				      len);
 		goto out;
@@ -48,8 +45,7 @@ int nrf_wifi_utils_hex_str_to_val(struct nrf_wifi_osal_priv *opriv,
 		ch = ((str[i] >= 'A' && str[i] <= 'Z') ? str[i] + 32 : str[i]);
 
 		if ((ch < '0' || ch > '9') && (ch < 'a' || ch > 'f')) {
-			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid hex character in string %d",
+			nrf_wifi_osal_log_err("%s: Invalid hex character in string %d",
 					      __func__,
 					      ch);
 			goto out;
@@ -78,22 +74,19 @@ out:
 }
 
 
-bool nrf_wifi_utils_is_mac_addr_valid(struct nrf_wifi_osal_priv *opriv,
-				      const char *mac_addr)
+bool nrf_wifi_utils_is_mac_addr_valid(const char *mac_addr)
 {
 	unsigned char zero_addr[NRF_WIFI_ETH_ADDR_LEN] = {0};
 
 	return (mac_addr &&
-		(nrf_wifi_osal_mem_cmp(opriv,
-				       mac_addr,
+		(nrf_wifi_osal_mem_cmp(mac_addr,
 				       zero_addr,
 				       sizeof(zero_addr)) != 0) &&
 		!(mac_addr[0] & 0x1));
 }
 
 
-int nrf_wifi_utils_chan_to_freq(struct nrf_wifi_osal_priv *opriv,
-				enum nrf_wifi_band band,
+int nrf_wifi_utils_chan_to_freq(enum nrf_wifi_band band,
 				unsigned short chan)
 {
 	int freq = -1;
@@ -109,8 +102,7 @@ int nrf_wifi_utils_chan_to_freq(struct nrf_wifi_osal_priv *opriv,
 		} else if (chan == 14) {
 			freq = 2484;
 		} else {
-			nrf_wifi_osal_log_err(opriv,
-					      "%s: Invalid channel value %d",
+			nrf_wifi_osal_log_err("%s: Invalid channel value %d",
 					      __func__,
 					      chan);
 			goto out;
@@ -126,8 +118,7 @@ int nrf_wifi_utils_chan_to_freq(struct nrf_wifi_osal_priv *opriv,
 
 		break;
 	default:
-		nrf_wifi_osal_log_err(opriv,
-				      "%s: Invalid band value %d",
+		nrf_wifi_osal_log_err("%s: Invalid band value %d",
 				      __func__,
 				      band);
 		goto out;


### PR DESCRIPTION
Removes the requirement for the different layers in the OS agnostic parts of the driver having to maintain a handle to the OS interface layer in order to call the OS interface calls. The OS interface layer now maitains the handle to OS-specific ops internally and invokes the appropriate functions.

Fixes SHEL-2639