### PR TITLE
wifi: radio_test: Add timeout parameter for capture mode

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
@@ -1058,6 +1058,8 @@ struct rpu_conf_params {
 	unsigned char bb_gain;
 	/** Number of RX samples to be captured */
 	unsigned short int capture_length;
+	/** Capture timeout in seconds */
+	unsigned short int capture_timeout;
 	/** Configure WLAN to bypass regulatory */
 	unsigned char bypass_regulatory;
 	/** Two letter country code (00: Default for WORLD) */

--- a/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_api.h
+++ b/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_api.h
@@ -107,8 +107,10 @@ enum nrf_wifi_status nrf_wifi_fmac_rf_test_rx_cap(struct nrf_wifi_fmac_dev_ctx *
 						  enum nrf_wifi_rf_test rf_test_type,
 						  void *cap_data,
 						  unsigned short int num_samples,
+						  unsigned short int capture_timeout,
 						  unsigned char lna_gain,
-						  unsigned char bb_gain);
+						  unsigned char bb_gain,
+						  unsigned char *timeout_status);
 
 
 /**

--- a/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_structs.h
+++ b/nrf_wifi/fw_if/umac_if/inc/radio_test/fmac_structs.h
@@ -41,6 +41,8 @@ struct nrf_wifi_fmac_dev_ctx_rt {
 	bool radio_cmd_done;
 	/** Firmware RF test command status. */
 	enum nrf_wifi_radio_test_err_status radio_cmd_status;
+	/** Firmware RF test RX capture event status */
+	unsigned char capture_status;
 };
 
 /**

--- a/nrf_wifi/fw_if/umac_if/src/event.c
+++ b/nrf_wifi/fw_if/umac_if/src/event.c
@@ -722,6 +722,7 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 	struct nrf_wifi_rf_test_xo_calib xo_calib_params;
 	struct nrf_wifi_rf_get_xo_value rf_get_xo_value_params;
 	struct nrf_wifi_fmac_dev_ctx_rt *def_dev_ctx;
+	struct nrf_wifi_rf_test_capture_params rf_test_capture_params;
 
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
@@ -749,6 +750,12 @@ static enum nrf_wifi_status umac_event_rf_test_process(struct nrf_wifi_fmac_dev_
 					  def_dev_ctx->rf_test_cap_data,
 					  RPU_MEM_RF_TEST_CAP_BASE,
 					  def_dev_ctx->rf_test_cap_sz);
+					  
+		nrf_wifi_osal_mem_cpy(&rf_test_capture_params,
+				      (const unsigned char *)&rf_test_event->rf_test_info.rfevent[0],
+				      sizeof(rf_test_capture_params));
+
+		def_dev_ctx->capture_status = rf_test_capture_params.capture_status;
 
 		break;
 	case NRF_WIFI_RF_TEST_EVENT_TX_TONE_START:

--- a/nrf_wifi/hw_if/hal/inc/fw/phy_rf_params.h
+++ b/nrf_wifi/hw_if/hal/inc/fw/phy_rf_params.h
@@ -31,6 +31,7 @@
 #define NRF_WIFI_PHY_CALIB_FLAG_TXIQ 8
 #define NRF_WIFI_PHY_CALIB_FLAG_RXIQ 16
 #define NRF_WIFI_PHY_CALIB_FLAG_DPD 32
+#define NRF_WIFI_PHY_CALIB_FLAG_ENHANCED_TXDC 64
 
 #define NRF_WIFI_PHY_SCAN_CALIB_FLAG_RXDC (1<<16)
 #define NRF_WIFI_PHY_SCAN_CALIB_FLAG_TXDC (2<<16)
@@ -45,6 +46,7 @@
 				NRF_WIFI_PHY_CALIB_FLAG_TXIQ |\
 				NRF_WIFI_PHY_CALIB_FLAG_TXPOW |\
 				NRF_WIFI_PHY_CALIB_FLAG_DPD |\
+				NRF_WIFI_PHY_CALIB_FLAG_ENHANCED_TXDC |\
 				NRF_WIFI_PHY_SCAN_CALIB_FLAG_RXDC |\
 				NRF_WIFI_PHY_SCAN_CALIB_FLAG_TXDC |\
 				NRF_WIFI_PHY_SCAN_CALIB_FLAG_RXIQ |\
@@ -395,6 +397,12 @@ enum EDGE_BACKOFF_OFFSETS {
 };
 
 #ifdef CONFIG_NRF700X_RADIO_TEST
+
+#define MAX_CAPTURE_LEN 16383
+#define MIN_CAPTURE_LEN 0
+#define RX_CAPTURE_TIMEOUT_CONST 11
+#define CAPTURE_DURATION_IN_SEC 600
+
 enum nrf_wifi_rf_test {
 	NRF_WIFI_RF_TEST_RX_ADC_CAP,
 	NRF_WIFI_RF_TEST_RX_STAT_PKT_CAP,
@@ -428,6 +436,16 @@ struct nrf_wifi_rf_test_capture_params {
 
 	/* Number of samples to be captured. */
 	unsigned short int cap_len;
+
+	/* Capture timeout in seconds. */
+	unsigned short int cap_time;
+
+	/* Capture status codes:
+	 *0: Capture successful after WLAN packet detection
+	 *1: Capture failed after WLAN packet detection
+	 *2: Capture timedout as no WLAN packets are detected
+	 */
+	unsigned char capture_status;
 
 	/* LNA Gain to be configured. It is a 3 bit value. The mapping is,
 	 * '0' = 24dB


### PR DESCRIPTION
[SHEL-2811]: Added command to get user-specified timeout in seconds.Rx samples will be displayed only when the capture occurs before the timeout lapses.

[SHEL-2811]: https://nordicsemi.atlassian.net/browse/SHEL-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ