### PR TITLE
nrf_wifi: Option for power save data retrieval

### DIFF
--- a/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
+++ b/nrf_wifi/fw_if/umac_if/inc/fw/host_rpu_sys_if.h
@@ -847,6 +847,19 @@ enum op_band {
 	BAND_24G
 };
 
+/**
+ * @brief This enum specifies the type of frames used to retrieve buffered data
+ *  from the AP in power save mode.
+ */
+enum data_retrieve_mechanism {
+	/** Retrieves data from the AP using a PS-Poll frame */
+	PS_POLL_FRAME,
+	/** Retrieves data from the AP using a QoS Null frame */
+	QOS_NULL_FRAME,
+	/** For future implementation. The RPU will decide which frame to use */
+	AUTOMATIC
+};
+
 #define TWT_EXTEND_SP_EDCA  0x1
 #define DISABLE_DFS_CHANNELS 0x2
 
@@ -891,10 +904,10 @@ struct nrf_wifi_cmd_sys_init {
 	 *  without receiving beacons before disconnection.
 	 */
 	unsigned int discon_timeout;
-	/** When set, RPU uses QoS null frames to retrieve buffered frames from the AP,
-	 *  otherwise, it initially uses PS-POLL frames.
+	/** RPU uses QoS null frame or PS-Poll frame to retrieve buffered frames
+	 * from the AP in power save @ref data_retrieve_mechanism.
 	 */
-	unsigned char nullframe_pwrsave;
+	unsigned char ps_data_retrieval_mech;
 } __NRF_WIFI_PKD;
 
 /**

--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -208,7 +208,13 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 		umac_cmd_data->disable_beamforming = 1;
 	}
 
-	 status = nrf_wifi_hal_ctrl_cmd_send(fmac_dev_ctx->hal_dev_ctx,
+#if defined(CONFIG_NRF_WIFI_QOS_NULL_BASED_RETRIEVAL)
+	umac_cmd_data->ps_data_retrieval_mech = QOS_NULL_FRAME;
+#else
+	umac_cmd_data->ps_data_retrieval_mech = PS_POLL_FRAME;
+#endif  /* CONFIG_NRF_WIFI_QOS_NULL_BASED_RETRIEVAL */
+
+	status = nrf_wifi_hal_ctrl_cmd_send(fmac_dev_ctx->hal_dev_ctx,
 					    umac_cmd,
 					    (sizeof(*umac_cmd) + len));
 


### PR DESCRIPTION
[SHEL-2947] Option to set either PS-poll or QoS null frame based power save data retrieval mechanism.

[SHEL-2947]: https://nordicsemi.atlassian.net/browse/SHEL-2947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ