### PR TITLE
nrfwifi: Implement management buffer offload

### DIFF
--- a/nrf_wifi/fw_if/umac_if/src/cmd.c
+++ b/nrf_wifi/fw_if/umac_if/src/cmd.c
@@ -142,7 +142,11 @@ enum nrf_wifi_status umac_cmd_init(struct nrf_wifi_fmac_dev_ctx *fmac_dev_ctx,
 	umac_cmd_data->tcp_ip_checksum_offload = 1;
 #endif /* CONFIG_NRF700X_TCP_IP_CHECKSUM_OFFLOAD */
 	umac_cmd_data->discon_timeout = CONFIG_NRF_WIFI_AP_DEAD_DETECT_TIMEOUT;
-
+#ifdef CONFIG_NRF_WIFI_MGMT_BUFF_OFFLOAD
+	umac_cmd_data->mgmt_buff_offload =  1;
+	nrf_wifi_osal_log_dbg(fmac_dev_ctx->fpriv->opriv,
+			       "Management buffer offload enabled\n");
+#endif /* CONFIG_NRF_WIFI_MGMT_BUFF_OFFLOAD */
 	nrf_wifi_osal_log_dbg("RPU LPM type: %s",
 		umac_cmd_data->sys_params.sleep_enable == 2 ? "HW" :
 		umac_cmd_data->sys_params.sleep_enable == 1 ? "SW" : "DISABLED");

--- a/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
+++ b/nrf_wifi/fw_if/umac_if/src/default/fmac_api.c
@@ -104,6 +104,16 @@ static enum nrf_wifi_status nrf_wifi_fmac_init_rx(struct nrf_wifi_fmac_dev_ctx *
 	def_priv = wifi_fmac_priv(fpriv);
 	def_dev_ctx = wifi_dev_priv(fmac_dev_ctx);
 
+#ifdef CONFIG_NRF_WIFI_MGMT_BUFF_OFFLOAD
+	if (!def_priv->num_rx_bufs) {
+		nrf_wifi_osal_log_dbg("%s: No RX buffers",
+				      __func__);
+		/* RX buffers are optional for scan-only use cases */
+		status = NRF_WIFI_STATUS_SUCCESS;
+		goto out;
+	}
+#endif /* CONFIG_NRF_WIFI_MGMT_BUFF_OFFLOAD */
+
 	size = (def_priv->num_rx_bufs * sizeof(struct nrf_wifi_fmac_buf_map_info));
 
 	def_dev_ctx->rx_buf_info = nrf_wifi_osal_mem_zalloc(size);


### PR DESCRIPTION
This feature helps in not needing the RX buffers for scan only operation.