### PR TITLE
nrf_802154: nRF54L15 use non-secure SL library for builds with `CONFIG_TRUSTED_EXECUTION_NONSECURE`

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -20,6 +20,10 @@ include_guard(GLOBAL)
 #
 # SOC_MODE:            Use the SoC name instead of the SoC architecture when calculating the path.
 #                      For example 'nrf52840' will be used for the path instead of 'cortex-m4'
+# NS_PROVIDED          Use name identifying non-secure library version for builds with
+#                      'CONFIG_TRUSTED_EXECUTION_NONSECURE' on supported SoCs.
+#                      Libraries that do not distinguish between secure and non-secure version
+#                      should not use this parameter.
 # BASE_DIR:            Base path from where the calculated path should start from.
 #                      When specifying BASE_DIR the path returned will be absolute, or
 #                      '<dir>-NOTFOUND' if the path does not exists
@@ -28,7 +32,7 @@ include_guard(GLOBAL)
 #                      This flag requires 'BASE_DIR'
 #
 function(nrfxlib_calculate_lib_path lib_path)
-  cmake_parse_arguments(CALC_LIB_PATH "SOFT_FLOAT_FALLBACK;SOC_MODE" "BASE_DIR" "" ${ARGN})
+  cmake_parse_arguments(CALC_LIB_PATH "SOFT_FLOAT_FALLBACK;SOC_MODE;NS_PROVIDED" "BASE_DIR" "" ${ARGN})
 
   if(CALC_LIB_PATH_SOFT_FLOAT_FALLBACK AND NOT DEFINED CALC_LIB_PATH_BASE_DIR)
     message(WARNING "nrfxlib_calculate_lib_path(SOFT_FLOAT_FALLBACK ...) "
@@ -46,6 +50,9 @@ function(nrfxlib_calculate_lib_path lib_path)
       set(arch_soc_dir ${arch_soc_dir}_cpunet)
     elseif(DEFINED CONFIG_SOC_NRF54L15_ENGA_CPUAPP)
       set(arch_soc_dir ${arch_soc_dir}_cpuapp)
+      if(DEFINED CONFIG_TRUSTED_EXECUTION_NONSECURE AND ${CALC_LIB_PATH_NS_PROVIDED})
+        set(arch_soc_dir ${arch_soc_dir}_ns)
+      endif()
     elseif(DEFINED CONFIG_SOC_NRF54H20_CPURAD)
       set(arch_soc_dir ${arch_soc_dir}_cpurad)
     endif()

--- a/nrf_802154/sl/sl/CMakeLists.txt
+++ b/nrf_802154/sl/sl/CMakeLists.txt
@@ -8,7 +8,7 @@ if (CONFIG_NRF_802154_RADIO_DRIVER)
 
 add_library(nrf-802154-sl INTERFACE)
 
-nrfxlib_calculate_lib_path(lib_path SOC_MODE)
+nrfxlib_calculate_lib_path(lib_path SOC_MODE NS_PROVIDED)
 
 set(NRF_802154_SL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
 


### PR DESCRIPTION
For builds with Kconfig option `CONFIG_TRUSTED_EXECUTION_NONSECURE` the non-secure binaries of nRF 802.15.4 SL library must be used.

To allow this with current `nrfxlib_calculate_lib_path` cmake function, the function is given additional parameter NS_PROVIDED.
This approach does not force other users to provide non-secure versions of their libraries (for example if their libs are secure-agnostic).
The nrfxlib_calculate_lib_path adds `_ns` suffix to the returned library path when the SoC is nRF54L15 and `CONFIG_TRUSTED_EXECUTION_NONSECURE` is enabled.
Other SoCs are out of scope now.


The nRF 802.15.4 SL library for nRF54L non-secure is deployed already with the PR:
https://github.com/nrfconnect/sdk-nrfxlib/pull/1430
