### PR TITLE
nrf_rpc: Fix OS dependencies in NRF RPC.

### DIFF
--- a/nrf_rpc/include/nrf_rpc.h
+++ b/nrf_rpc/include/nrf_rpc.h
@@ -33,10 +33,10 @@ extern "C" {
 #define NRF_RPC_ID_UNKNOWN 0xFF
 
 /** @brief Flag indicating that the group does not block on initialization. */
-#define NRF_RPC_FLAGS_WAIT_ON_INIT BIT(0)
+#define NRF_RPC_FLAGS_WAIT_ON_INIT 0x01
 
 /** @brief Flag indicating that the peer must initiate group binding. */
-#define NRF_RPC_FLAGS_INITIATOR BIT(1)
+#define NRF_RPC_FLAGS_INITIATOR 0x02
 
 /** @brief Helper macro for conditional flag initialization. */
 #define NRF_RPC_FLAG_COND(_cond, _flag) ((_cond) ? (_flag) : 0UL)

--- a/nrf_rpc/nrf_rpc_cbor.c
+++ b/nrf_rpc/nrf_rpc_cbor.c
@@ -68,7 +68,7 @@ int nrf_rpc_cbor_cmd_rsp(const struct nrf_rpc_group *group, uint8_t cmd,
 			      &rsp_size);
 
 	if (err >= 0) {
-		zcbor_new_decode_state(ctx->zs, ARRAY_SIZE(ctx->zs),
+		zcbor_new_decode_state(ctx->zs, ZCBOR_ARRAY_SIZE(ctx->zs),
 				       ctx->out_packet, rsp_size, NRF_RPC_MAX_PARAMETERS, NULL, 0);
 		ctx->zs->constant_state->stop_on_error = true;
 	}
@@ -177,7 +177,7 @@ void _nrf_rpc_cbor_proxy_handler(const struct nrf_rpc_group *group, const uint8_
 	struct _nrf_rpc_cbor_decoder *cbor_handler =
 		(struct _nrf_rpc_cbor_decoder *)handler_data;
 
-	zcbor_new_decode_state(ctx.zs, ARRAY_SIZE(ctx.zs), ctx.out_packet, len,
+	zcbor_new_decode_state(ctx.zs, ZCBOR_ARRAY_SIZE(ctx.zs), ctx.out_packet, len,
 			       NRF_RPC_MAX_PARAMETERS, NULL, 0);
 	ctx.zs->constant_state->stop_on_error = true;
 
@@ -186,7 +186,7 @@ void _nrf_rpc_cbor_proxy_handler(const struct nrf_rpc_group *group, const uint8_
 
 void _nrf_rpc_cbor_prepare(struct nrf_rpc_cbor_ctx *ctx, size_t len)
 {
-	zcbor_new_encode_state(ctx->zs, ARRAY_SIZE(ctx->zs), ctx->out_packet,
+	zcbor_new_encode_state(ctx->zs, ZCBOR_ARRAY_SIZE(ctx->zs), ctx->out_packet,
 			       len, 0);
 	ctx->zs->constant_state->stop_on_error = true;
 }


### PR DESCRIPTION
According to documentation `nrfxlib/nrf_rpc/README.rst` NRF RPC should be OS independent so this commit removes `BIT` and `ARRAY_SIZE` macros that are take directly form zephyr.