### PR TITLE
nrf_wifi: Fix firmware boot check on timeout

### DIFF
--- a/nrf_wifi/hw_if/hal/src/hal_api.c
+++ b/nrf_wifi/hw_if/hal/src/hal_api.c
@@ -1557,7 +1557,7 @@ enum nrf_wifi_status nrf_wifi_hal_fw_chk_boot(struct nrf_wifi_hal_dev_ctx *hal_d
 
 	hal_dev_ctx->curr_proc = rpu_proc;
 
-	while (mcu_ready_wait_count-- > 0) {
+	while (--mcu_ready_wait_count > 0) {
 		status = hal_rpu_mem_read(hal_dev_ctx,
 					  (unsigned char *)&val,
 					  addr,


### PR DESCRIPTION
[SHEL-3027] Fix for firmware boot check, not returning failure on timeout.

[SHEL-3027]: https://nordicsemi.atlassian.net/browse/SHEL-3027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ