### PR TITLE
nrf_modem: doc: remove deprecated RAI socket options

### DIFF
--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -9,6 +9,16 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+nrf_modem
+*********
+
+Sockets
+=======
+
+* Removed:
+
+  * The deprecated RAI socket options :c:macro:`NRF_SO_RAI_NO_DATA`, :c:macro:`NRF_SO_RAI_LAST`, :c:macro:`NRF_SO_RAI_ONE_RESP`, :c:macro:`NRF_SO_RAI_ONGOING`, and :c:macro:`NRF_SO_RAI_WAIT_MORE`.
+
 nrf_modem 2.7.0
 ***************
 

--- a/nrf_modem/doc/sockets/socket_options_func.rst
+++ b/nrf_modem/doc/sockets/socket_options_func.rst
@@ -63,16 +63,6 @@ The following table shows all socket options supported by the Modem library.
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SOCKET  | NRF_SO_KEEPOPEN                 | ``int``                | get/set    | Keep the socket open when its PDN connection is lost, or the device is set to flight mode. |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_LAST                 | ``int``                | set        | Deprecated. Use :c:macro:`NRF_SO_RAI` with value ``NRF_RAI_LAST`` instead.                 |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_ONE_RESP             | ``int``                | set        | Deprecated. Use :c:macro:`NRF_SO_RAI` with value ``NRF_RAI_ONE_RESP`` instead.             |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_ONGOING              | ``int``                | set        | Deprecated. Use :c:macro:`NRF_SO_RAI` with value ``NRF_RAI_ONGOING`` instead.              |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_WAIT_MORE            | ``int``                | set        | Deprecated. Use :c:macro:`NRF_SO_RAI` with value ``NRF_RAI_WAIT_MORE`` instead.            |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
-| NRF_SOL_SOCKET  | NRF_SO_RAI_NO_DATA              | ``int``                | set        | Deprecated. Use :c:macro:`NRF_SO_RAI` with value ``NRF_RAI_NO_DATA`` instead.              |
-+-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_SOL_SOCKET  | NRF_SO_RAI                      | ``int``                | set        | Release Assistance Indication (RAI).                                                       |
 +-----------------+---------------------------------+------------------------+------------+--------------------------------------------------------------------------------------------+
 | NRF_IPPROTO_ALL | NRF_SO_SILENCE_ALL              | ``int``                | get/set    | Non-zero disables ICMP echo replies on both IPv4 and IPv6.                                 |
@@ -206,32 +196,6 @@ NRF_SO_RAI
     * ``NRF_RAI_ONE_RESP`` - After the next output operation is complete, wait for one more packet to be received from the network on this socket before entering RRC idle mode.
     * ``NRF_RAI_ONGOING`` - Keep RRC in connected mode after the next output operation on this socket (client side).
     * ``NRF_RAI_WAIT_MORE`` - Keep RRC in connected mode after the next output operation on this socket (server side).
-
-NRF_SO_RAI_LAST
-   Deprecated since v2.6.0. Use the :c:macro:`NRF_SO_RAI` socket option with value ``NRF_RAI_LAST`` instead.
-   This is a Release assistance indication (RAI) socket option.
-   Enter RRC idle mode after the next output operation on this socket is complete.
-
-NRF_SO_RAI_ONE_RESP
-   Deprecated since v2.6.0. Use the :c:macro:`NRF_SO_RAI` socket option with value ``NRF_RAI_ONE_RESP`` instead.
-   This is a Release assistance indication (RAI) socket option.
-   After the next output operation is complete, wait for one more packet to be received from the network on this socket before entering RRC idle mode.
-
-NRF_SO_RAI_ONGOING
-   Deprecated since v2.6.0. Use the :c:macro:`NRF_SO_RAI` socket option with value ``NRF_RAI_ONGOING`` instead.
-   This is a Release assistance indication (RAI) socket option.
-   Keep RRC in connected mode after the next output operation on this socket (client side).
-
-NRF_SO_RAI_WAIT_MORE
-   Deprecated since v2.6.0. Use the :c:macro:`NRF_SO_RAI` socket option with value ``NRF_RAI_WAIT_RESP`` instead.
-   This is a Release assistance indication (RAI) socket option.
-   Keep RRC in connected mode after the next output operation on this socket (server side).
-
-NRF_SO_RAI_NO_DATA
-   Deprecated since v2.6.0. Use the :c:macro:`NRF_SO_RAI` socket option with value ``NRF_RAI_NO_DATA`` instead.
-   This is a Release assistance indication (RAI) socket option.
-   Immediately enter RRC idle mode for this socket.
-   Does not require a following output operation.
 
 NRF_SO_SILENCE_ALL
    Disable ICMP echo replies on both IPv4 and IPv6.


### PR DESCRIPTION
Opened to keep track of the change. The commit will likely be cherry-picked in a release PR.