### PR TITLE
doc: Add nRF9151 DECT NR+ link

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -41,6 +41,7 @@
 .. _`coex interface of nRF9160`: https://docs.nordicsemi.com/bundle/ps_nrf9160/page/ip/radio_lte/doc/magpio_if.html
 
 .. _`nRF9161 DECT NR+ product specification`:  https://docs.nordicsemi.com/bundle/ps_nrf9161/page/dect.html
+.. _`nRF9151 DECT NR+ product specification`:  https://docs.nordicsemi.com/bundle/ps_nrf9151/page/dect.html
 
 .. _`nRF9160 modem firmware zip file`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#0B34B59935AF4AFCB7AB93E9646C1F53
 .. _`nRF91x1 LTE firmware zip file`: https://www.nordicsemi.com/Products/nRF9161/Download#636701B052474E5A8EB903C56678D26E

--- a/nrf_modem/doc/dectphy.rst
+++ b/nrf_modem/doc/dectphy.rst
@@ -12,7 +12,7 @@ The DECT physical layer (PHY) interface in the Modem library is used to control 
 The DECT NR+ PHY firmware is a variant of the nRF91x1 firmware with a different radio technology than the cellular firmware.
 In particular, the DECT NR+ PHY firmware does not support cellular operation or the Global Navigation Satellite System (GNSS).
 
-For details about the key hardware capabilities of the nRF9161 and its DECT NR+ PHY firmware implementation, with regards to the DECT NR+ standard, refer to the `nRF9161 DECT NR+ product specification`_.
+For details about the key hardware capabilities of the nRF91x1 DKs and its DECT NR+ PHY firmware implementation, with regards to the DECT NR+ standard, refer to the `nRF9151 DECT NR+ product specification`_ or the `nRF9161 DECT NR+ product specification`_, depending on the SiP you are using.
 
 .. note::
    To obtain the DECT NR+ PHY firmware, you must contact the Nordic Semiconductor sales department.
@@ -47,7 +47,7 @@ The whole DECT NR+ protocol stack consists of four layers:
 * Data link control (DLC), including routing, segmentation and re-assembly of messages.
 * Convergence layer (CVG), including message flow control, multiplexing and transmission service level control.
 
-For more details about the DECT NR+ protocol stack, refer to the `nRF9161 DECT NR+ product specification`_ page.
+For more details about the DECT NR+ protocol stack, refer to the `nRF9151 DECT NR+ product specification`_ or the `nRF9161 DECT NR+ product specification`_, depending on the SiP you are using.
 
 The DECT NR+ PHY firmware implements only the physical layer of the protocol stack.
 


### PR DESCRIPTION
Added nRF9151 dect NR+ link
in the nrf_modem lib docs.