### PR TITLE
openthread: Added nrfxlib release tag to CMAKE function

### DIFF
--- a/openthread/CMakeLists.txt
+++ b/openthread/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CONFIG_OPENTHREAD_SOURCES)
 
   set(OPENTHREAD_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/openthread_lib_configuration.txt")
 
-  openthread_libs_configuration_write(${OPENTHREAD_CONFIG_FILE})
+  openthread_libs_configuration_write(${OPENTHREAD_CONFIG_FILE} ${CONFIG_OPENTHREAD_NRFXLIB_RELEASE_TAG})
 
   openthread_calculate_lib_path("v${CONFIG_OPENTHREAD_THREAD_VERSION}" OPENTHREAD_DST_DIR)
 

--- a/openthread/Kconfig
+++ b/openthread/Kconfig
@@ -129,6 +129,13 @@ config OPENTHREAD_BUILD_OUTPUT_STRIPPED
 	help
 	  Build a stripped library versions of OpenThread in the build directory.
 
+config OPENTHREAD_NRFXLIB_RELEASE_TAG
+	string "Release tag for OpenThread libraries"
+	default "Not specified"
+	help
+	  The release tag will be added to the openthread_lib_configuration.txt file
+	  within the OpenThread library directory. 
+
 endmenu # "OpenThread"
 
 endif

--- a/openthread/cmake/extensions.cmake
+++ b/openthread/cmake/extensions.cmake
@@ -56,7 +56,7 @@ endmacro()
 
 # Store the configuration of the compiled OpenThread libraries
 # and set source and destination paths.
-function(openthread_libs_configuration_write CONFIG_FILE)
+function(openthread_libs_configuration_write CONFIG_FILE NRFXLIB_RELEASE_TAG)
   # Store all OT related variables
   get_cmake_property(_variableNames VARIABLES)
   foreach (_variableName ${_variableNames})
@@ -77,6 +77,8 @@ function(openthread_libs_configuration_write CONFIG_FILE)
 
     get_git_decribe(${ZEPHYR_OPENTHREAD_MODULE_DIR})
     list(INSERT OPENTHREAD_SETTINGS 0 "OpenThread_commit=${git_describe}")
+
+    list(INSERT OPENTHREAD_SETTINGS 0 "NRFXLIB_RELEASE_TAG=${NRFXLIB_RELEASE_TAG}\n")
   endif()
 
   # Store compiler and Zephyr SDK version


### PR DESCRIPTION
Added NRFXLIB_RELEASE_TAG to the configuration file to save information for which release tag the libraries have been generated.

manfiest-PR-skip