### PR TITLE
nrf_rpc: enable zcbor stop_on_error flag for decoding

### DIFF
--- a/nrf_rpc/CHANGELOG.rst
+++ b/nrf_rpc/CHANGELOG.rst
@@ -9,6 +9,15 @@ Changelog
 
 All the notable changes to this project are documented on this page.
 
+nRF Connect SDK v2.7.99
+***********************
+
+Changes
+=======
+
+* Enabled zcbor's :c:member:`stop_on_error` flag before decoding the CBOR payload of an nRF RPC packet.
+  When this flag is set, zcbor stops decoding subsequent data items in the case of decoding failure unless the error is explicitly cleared with the :c:func:`zcbor_pop_error()` function.
+
 nRF Connect SDK v2.5.0
 **********************
 

--- a/nrf_rpc/nrf_rpc_cbor.c
+++ b/nrf_rpc/nrf_rpc_cbor.c
@@ -70,6 +70,7 @@ int nrf_rpc_cbor_cmd_rsp(const struct nrf_rpc_group *group, uint8_t cmd,
 	if (err >= 0) {
 		zcbor_new_decode_state(ctx->zs, ARRAY_SIZE(ctx->zs),
 				       ctx->out_packet, rsp_size, NRF_RPC_MAX_PARAMETERS, NULL, 0);
+		ctx->zs->constant_state->stop_on_error = true;
 	}
 
 	return err;
@@ -178,6 +179,7 @@ void _nrf_rpc_cbor_proxy_handler(const struct nrf_rpc_group *group, const uint8_
 
 	zcbor_new_decode_state(ctx.zs, ARRAY_SIZE(ctx.zs), ctx.out_packet, len,
 			       NRF_RPC_MAX_PARAMETERS, NULL, 0);
+	ctx.zs->constant_state->stop_on_error = true;
 
 	return cbor_handler->handler(group, &ctx, cbor_handler->handler_data);
 }


### PR DESCRIPTION
The zcbor's stop_on_error flag, which defaults to false, makes the decoder stop decoding any subsequent items after a decoding error occurs, meaning that all subsequent decoding attempts fail early until the error is cleared with zcbor_pop_error() function.

This flag is already set for the encoder yet it was omitted for the decoder although some nRF RPC decoder functions seem to rely the flag being set as they only check the decoding result after trying to decode all the command or response arguments.

manifest-pr-skip