### PR TITLE
doc: remove unsupported doxygen directive attributes

### DIFF
--- a/crypto/doc/api.rst
+++ b/crypto/doc/api.rst
@@ -13,8 +13,6 @@ nRF CC310 bootloader crypto library
 ***********************************
 
 .. doxygengroup:: nrf_cc310_bl
-   :project: nrfxlib
-   :members:
 
 
 .. _crypto_api_nrf_cc3xx_platform:
@@ -23,64 +21,46 @@ nRF CC3XX platform library
 **************************
 
 .. doxygengroup:: nrf_cc3xx_platform
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - Defines
 ========================
 
 .. doxygengroup:: nrf_cc3xx_platform_defines
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - Initialization APIs
 ====================================
 
 .. doxygengroup:: nrf_cc3xx_platform_init
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - Entropy APIs
 =============================
 
 .. doxygengroup:: nrf_cc3xx_platform_entropy
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - Mutex APIs
 ===========================
 
 .. doxygengroup:: nrf_cc3xx_platform_mutex
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - Abort APIs
 ===========================
 
 .. doxygengroup:: nrf_cc3xx_platform_abort
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - KMU APIs
 =========================
 
 .. doxygengroup:: nrf_cc3xx_platform_kmu
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - CTR-DRBG APIs
 ==============================
 
 .. doxygengroup:: nrf_cc3xx_platform_ctr_drbg
-   :project: nrfxlib
-   :members:
 
 CC3XX Platform - HMAC-DRBG APIs
 ===============================
 
 .. doxygengroup:: nrf_cc3xx_platform_hmac_drbg
-   :project: nrfxlib
-   :members:
 
 .. _crypto_api_nrf_cc3xx_mbedcrypto:
 
@@ -88,15 +68,11 @@ nRF CC3XX mbedcrypto library
 ****************************
 
 .. doxygengroup:: nrf_cc3xx_mbedcrypto
-   :project: nrfxlib
-   :members:
 
 KMU/KDR APIs
 ========================
 
 .. doxygengroup:: nrf_cc3xx_mbedcrypto_kmu
-   :project: nrfxlib
-   :members:
 
 
 .. _crypto_api_nrf_oberon:
@@ -105,250 +81,174 @@ nrf_oberon crypto library
 *************************
 
 .. doxygengroup:: ocrypto
-   :project: nrfxlib
-   :members:
 
 AES - Advanced Encryption Standard
 ==================================
 
 .. doxygengroup:: ocrypto_aes
-   :project: nrfxlib
-   :members:
 
 AES-CBC - AES Cipher Block Chaining Mode
 ----------------------------------------
 
 .. doxygengroup:: ocrypto_aes_cbc
-   :project: nrfxlib
-   :members:
 
 AES-CBC - AES CCipher Block Chaining Mode with PKCS7 padding
 ------------------------------------------------------------
 
 .. doxygengroup:: ocrypto_aes_cbc_pkcs7
-   :project: nrfxlib
-   :members:
 
 AES-CTR - AES Counter Mode
 --------------------------
 
 .. doxygengroup:: ocrypto_aes_ctr
-   :project: nrfxlib
-   :members:
 
 AES EAX Mode
 ------------
 
 .. doxygengroup:: ocrypto_aes_eax
-   :project: nrfxlib
-   :members:
 
 AES-CBC - AES Electronic Code Book Mode
 ---------------------------------------
 
 .. doxygengroup:: ocrypto_aes_ecb
-   :project: nrfxlib
-   :members:
 
 AES-CCM - AES Cipher-based Message Authentication Code
 ------------------------------------------------------
 
 .. doxygengroup:: ocrypto_aes_cmac
-   :project: nrfxlib
-   :members:
 
 AES-CCM - AES Counter with CBC-MAC Mode
 ---------------------------------------
 
 .. doxygengroup:: ocrypto_aes_ccm
-   :project: nrfxlib
-   :members:
 
 AES GCM - AES Galois/Counter Mode
 ---------------------------------
 
 .. doxygengroup:: ocrypto_aes_gcm
-   :project: nrfxlib
-   :members:
 
 AES key sizes
 -------------
 
 .. doxygengroup:: ocrypto_aes_key
-   :project: nrfxlib
-   :members:
 
 ChaCha20-Poly1305
 =================
 
 .. doxygengroup:: ocrypto_chacha_poly
-   :project: nrfxlib
-   :members:
 
 ChaCha20-Poly1305
 -----------------
 
 .. doxygengroup:: ocrypto_chacha_poly_inc
-   :project: nrfxlib
-   :members:
 
 ChaCha20
 --------
 
 .. doxygengroup:: ocrypto_chacha
-   :project: nrfxlib
-   :members:
 
 Constant time
 =============
 
 .. doxygengroup:: ocrypto_constant_time
-   :project: nrfxlib
-   :members:
 
 ECC secp224r1 low-level
 =======================
 
 .. doxygengroup:: ocrypto_p224
-   :project: nrfxlib
-   :members:
 
 ECC secp256r1 low-level
 =======================
 
 .. doxygengroup:: ocrypto_p256
-   :project: nrfxlib
-   :members:
 
 ECC Curve25519 low-level
 ========================
 
 .. doxygengroup:: ocrypto_curve25519
-   :project: nrfxlib
-   :members:
 
 ECDH
 ====
 
 .. doxygengroup:: ocrypto_ecdh_p224
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ecdh_p256
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ecdh_p384
-   :project: nrfxlib
-   :members:
 
 ECDSA
 =====
 
 .. doxygengroup:: ocrypto_ecdsa_p224
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ecdsa_p256
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ecdsa_p384
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ecdsa_p521
-   :project: nrfxlib
-   :members:
 
 EC-JPAKE
 ========
 
 .. doxygengroup:: ocrypto_ecjpake
-   :project: nrfxlib
-   :members:
 
 
 Ed25519
 =======
 
 .. doxygengroup:: ocrypto_ed25519
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: ocrypto_ed25519ph
-   :project: nrfxlib
-   :members:
 
 HKDF - HMAC based Key Derivation Function
 =========================================
 
 .. doxygengroup:: ocrypto_hkdf
-   :project: nrfxlib
-   :members:
 
 HKDF using SHA-256
 ------------------
 
 .. doxygengroup:: ocrypto_hkdf_sha256
-   :project: nrfxlib
-   :members:
 
 HKDF using SHA-512
 ------------------
 
 .. doxygengroup:: ocrypto_hkdf_512
-   :project: nrfxlib
-   :members:
 
 HMAC - Hash-based Message Authentication Code
 =============================================
 
 .. doxygengroup:: ocrypto_hmac
-   :project: nrfxlib
-   :members:
 
 HMAC using SHA-256
 ------------------
 
 .. doxygengroup:: ocrypto_hmac_sha256
-   :project: nrfxlib
-   :members:
 
 HMAC using SHA-512
 ------------------
 
 .. doxygengroup:: ocrypto_hmac_sha512
-   :project: nrfxlib
-   :members:
 
 PBKDF2
 ===========
 
 .. doxygengroup:: ocrypto_pbkdf2
-   :project: nrfxlib
-   :members:
 
 RSA - Rivest-Shamir-Adleman algorithm
 =====================================
 
 .. doxygengroup:: ocrypto_rsa
-   :project: nrfxlib
-   :members:
 
 RSA
 --------
 
 .. doxygengroup:: ocrypto_rsa_api
-   :project: nrfxlib
-   :members:
 
 RSA key
 ------------
 
 .. doxygengroup:: ocrypto_rsa_key
-   :project: nrfxlib
-   :members:
 
 SHA Hashing algorithms
 ======================
@@ -357,61 +257,43 @@ SHA-1
 -----
 
 .. doxygengroup:: ocrypto_sha_1
-   :project: nrfxlib
-   :members:
 
 SHA-224
 -------
 
 .. doxygengroup:: ocrypto_sha_224
-   :project: nrfxlib
-   :members:
 
 SHA-256
 -------
 
 .. doxygengroup:: ocrypto_sha_256
-   :project: nrfxlib
-   :members:
 
 SHA-256
 -------
 
 .. doxygengroup:: ocrypto_sha_384
-   :project: nrfxlib
-   :members:
 
 SHA-512
 -------
 
 .. doxygengroup:: ocrypto_sha_512
-   :project: nrfxlib
-   :members:
 
 SPAKE2+
 =======
 
 .. doxygengroup:: ocrypto_spake2p
-   :project: nrfxlib
-   :members:
 
 SRP - Secure Remote Password
 ============================
 
 .. doxygengroup:: ocrypto_srp
-   :project: nrfxlib
-   :members:
 
 SRPT - Secure Real-Time Transport Protocol
 ==========================================
 
 .. doxygengroup:: ocrypto_srtp
-   :project: nrfxlib
-   :members:
 
 ocrypto internal types
 ======================
 
 .. doxygengroup:: ocrypto_types
-   :project: nrfxlib
-   :members:

--- a/gzll/doc/api.rst
+++ b/gzll/doc/api.rst
@@ -8,19 +8,13 @@ API documentation
    :depth: 2
 
 .. doxygengroup:: gzll_api
-   :project: nrfxlib
-   :members:
 
 Constants
 *********
 
 .. doxygengroup:: gzll_constants
-   :project: nrfxlib
-   :members:
 
 Glue layer
 **********
 
 .. doxygengroup:: gzll_glue
-   :project: nrfxlib
-   :members:

--- a/lc3/doc/api.rst
+++ b/lc3/doc/api.rst
@@ -14,8 +14,6 @@ Translation layer API documentation
 | Source file: :file:`lc3/src/sw_codec_lc3.c`
 
 .. doxygengroup:: LC3_translation
-   :project: nrfxlib
-   :members:
 
 LC3 API documentation
 *********************
@@ -23,5 +21,3 @@ LC3 API documentation
 | Header file: :file:`codec/inc/LC3API.h`
 
 .. doxygengroup:: LC3
-   :project: nrfxlib
-   :members:

--- a/mpsl/doc/api.rst
+++ b/mpsl/doc/api.rst
@@ -11,8 +11,6 @@ Multiprotocol Service Layer interface
 *************************************
 
 .. doxygengroup:: mpsl
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_clk:
 
@@ -20,8 +18,6 @@ MPSL Clock
 **********
 
 .. doxygengroup:: mpsl_clock
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_timeslot:
 
@@ -29,8 +25,6 @@ MPSL Timeslot
 *************
 
 .. doxygengroup:: mpsl_timeslot
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_rn:
 
@@ -38,8 +32,6 @@ MPSL TX Power
 *************
 
 .. doxygengroup:: mpsl_tx_power
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem:
 
@@ -47,8 +39,6 @@ MPSL FEM
 ********
 
 .. doxygengroup:: mpsl_fem
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_common:
 
@@ -56,8 +46,6 @@ MPSL FEM common configuration
 *****************************
 
 .. doxygengroup:: mpsl_fem_config_common
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_21540_config:
 
@@ -65,8 +53,6 @@ MPSL FEM common nRF21540 configuration
 **************************************
 
 .. doxygengroup:: mpsl_fem_nrf21540_common
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_21540_gpio:
 
@@ -74,8 +60,6 @@ MPSL FEM nRF21540 GPIO
 **********************
 
 .. doxygengroup:: mpsl_fem_nrf21540_gpio
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_21540_gpiospi:
 
@@ -83,8 +67,6 @@ MPSL FEM nRF21540 GPIO/SPI
 **************************
 
 .. doxygengroup:: mpsl_fem_nrf21540_gpio_spi
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_simple:
 
@@ -92,8 +74,6 @@ MPSL FEM Simple GPIO
 ********************
 
 .. doxygengroup:: mpsl_fem_simple_gpio
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_fem_power:
 
@@ -101,8 +81,6 @@ MPSL FEM power model
 ********************
 
 .. doxygengroup:: mpsl_fem_power_model
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_sr_cx:
 
@@ -110,8 +88,6 @@ MPSL CX (Coexistence)
 *********************
 
 .. doxygengroup:: mpsl_cx
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_temp:
 
@@ -119,8 +95,6 @@ MPSL Temp
 *********
 
 .. doxygengroup:: mpsl_temp
-   :project: nrfxlib
-   :members:
 
 .. _mpsl_api_dppi:
 
@@ -128,5 +102,3 @@ MPSL DPPI Protocol
 ******************
 
 .. doxygengroup:: mpsl_dppi_protocol_api
-   :project: nrfxlib
-   :members:

--- a/nfc/doc/type_2_tag.rst
+++ b/nfc/doc/type_2_tag.rst
@@ -398,5 +398,3 @@ API documentation
 *****************
 
 .. doxygengroup:: nfc_t2t_lib
-   :project: nrfxlib
-   :members:

--- a/nfc/doc/type_4_tag.rst
+++ b/nfc/doc/type_4_tag.rst
@@ -71,5 +71,3 @@ API documentation
 *****************
 
 .. doxygengroup:: nfc_t4t_lib
-   :project: nrfxlib
-   :members:

--- a/nrf_802154/doc/api.rst
+++ b/nrf_802154/doc/api.rst
@@ -13,8 +13,6 @@ Setting addresses and PAN ID of the device
 ******************************************
 
 .. doxygengroup:: nrf_802154_addresses
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_data:
 
@@ -22,8 +20,6 @@ Functions to calculate data given by the driver
 ***********************************************
 
 .. doxygengroup:: nrf_802154_data
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_transitions:
 
@@ -31,8 +27,6 @@ Functions to request FSM transitions and check the current state
 ****************************************************************
 
 .. doxygengroup:: nrf_802154_transitions
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_calls:
 
@@ -40,8 +34,6 @@ Calls to the higher layer
 *************************
 
 .. doxygengroup:: nrf_802154_calls
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_memman:
 
@@ -49,8 +41,6 @@ Driver memory management
 ************************
 
 .. doxygengroup:: nrf_802154_memman
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_rssi:
 
@@ -58,8 +48,6 @@ RSSI measurement function
 *************************
 
 .. doxygengroup:: nrf_802154_rssi
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_prom:
 
@@ -67,8 +55,6 @@ Promiscuous mode
 ****************
 
 .. doxygengroup:: nrf_802154_prom
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_autoack:
 
@@ -76,8 +62,6 @@ Auto ACK management
 *******************
 
 .. doxygengroup:: nrf_802154_autoack
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_cca:
 
@@ -85,8 +69,6 @@ CCA configuration management
 ****************************
 
 .. doxygengroup:: nrf_802154_cca
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_csma:
 
@@ -94,8 +76,6 @@ CSMA-CA procedure
 *****************
 
 .. doxygengroup:: nrf_802154_csma
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_timeout:
 
@@ -103,8 +83,6 @@ ACK timeout procedure
 *********************
 
 .. doxygengroup:: nrf_802154_timeout
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_stats:
 
@@ -112,8 +90,6 @@ Statistics and measurements
 ***************************
 
 .. doxygengroup:: nrf_802154_stats
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_ifs:
 
@@ -121,8 +97,6 @@ Inter-frame spacing feature
 ***************************
 
 .. doxygengroup:: nrf_802154_ifs
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_capabilities:
 
@@ -130,8 +104,6 @@ Radio driver run-time capabilities feature
 ******************************************
 
 .. doxygengroup:: nrf_802154_capabilities
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_security:
 
@@ -139,8 +111,6 @@ Radio driver MAC security feature
 *********************************
 
 .. doxygengroup:: nrf_802154_security
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_ie_writer:
 
@@ -148,8 +118,6 @@ Radio driver Information Element data injection feature
 *******************************************************
 
 .. doxygengroup:: nrf_802154_ie_writer
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_radio:
 
@@ -157,8 +125,6 @@ Radio driver configuration
 **************************
 
 .. doxygengroup:: nrf_802154_config_radio
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_csma:
 
@@ -166,8 +132,6 @@ CSMA/CA procedure configuration
 *******************************
 
 .. doxygengroup:: nrf_802154_config_csma
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_timeout:
 
@@ -175,8 +139,6 @@ ACK timeout feature configuration
 *********************************
 
 .. doxygengroup:: nrf_802154_config_timeout
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_config_transmission:
 
@@ -184,8 +146,6 @@ Transmission start notification feature configuration
 *****************************************************
 
 .. doxygengroup:: nrf_802154_config_transmission
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_ie:
 
@@ -193,8 +153,6 @@ Information Elements configuration
 **********************************
 
 .. doxygengroup:: nrf_802154_ie
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_other:
 
@@ -202,8 +160,6 @@ Interrupt Handlers
 ******************
 
 .. doxygengroup:: nrf_802154_irq
-   :project: nrfxlib
-   :members:
 
 .. _radiodriver_api_irq:
 
@@ -211,5 +167,3 @@ Other functions
 ***************
 
 .. doxygengroup:: nrf_802154
-   :project: nrfxlib
-   :members:

--- a/nrf_dm/doc/api.rst
+++ b/nrf_dm/doc/api.rst
@@ -11,5 +11,3 @@ Distance Measurement interface
 ******************************
 
 .. doxygengroup:: nrf_dm
-   :project: nrfxlib
-   :members:

--- a/nrf_fuel_gauge/doc/api.rst
+++ b/nrf_fuel_gauge/doc/api.rst
@@ -6,5 +6,3 @@ API documentation
 | Header file: :file:`include/nrf_fuel_gauge.h`
 
 .. doxygengroup:: nrf_fuel_gauge
-   :project: nrfxlib
-   :members:

--- a/nrf_modem/doc/api.rst
+++ b/nrf_modem/doc/api.rst
@@ -11,15 +11,11 @@ Library Management
 ******************
 
 .. doxygengroup:: nrf_modem
-   :project: nrfxlib
-   :members:
 
 nrf_modem_init() return values for modem firmware updates
 =========================================================
 
 .. doxygengroup:: nrf_modem_dfu
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_trace_api:
 
@@ -27,8 +23,6 @@ Modem traces
 ============
 
 .. doxygengroup:: nrf_modem_trace
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_fault_api_reasons:
 
@@ -36,15 +30,11 @@ Modem fault reasons
 ===================
 
 .. doxygengroup:: nrf_modem_fault_handling
-   :project: nrfxlib
-   :members:
 
 Limits of the Modem library
 ***************************
 
 .. doxygengroup:: nrf_modem_limits
-   :project: nrfxlib
-   :members:
 
 Socket parameter enumerators
 ****************************
@@ -53,96 +43,68 @@ Socket families
 ===============
 
 .. doxygengroup:: nrf_socket_families
-   :project: nrfxlib
-   :members:
 
 Socket types
 ============
 
 .. doxygengroup:: nrf_socket_types
-   :project: nrfxlib
-   :members:
 
 Socket protocols
 ================
 
 .. doxygengroup:: nrf_socket_protocols
-   :project: nrfxlib
-   :members:
 
 Socket option levels
 ====================
 
 .. doxygengroup:: nrf_socket_options_levels
-   :project: nrfxlib
-   :members:
 
 Generic socket options
 ======================
 
 .. doxygengroup:: nrf_socket_options_sockets
-   :project: nrfxlib
-   :members:
 
 Socket send and recv flags
 ==========================
 
 .. doxygengroup:: nrf_socket_send_recv_flags
-   :project: nrfxlib
-   :members:
 
 fcntl parameters
 ================
 
 .. doxygengroup:: nrf_fcnt_commands
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: nrf_fcnt_flags
-   :project: nrfxlib
-   :members:
 
 Socket API
 **********
 
 .. doxygengroup:: nrf_socket_api
-   :project: nrfxlib
-   :members:
 
 TLS socket
 **********
 
 .. doxygengroup:: nrf_socket_tls
-   :project: nrfxlib
-   :members:
 
 DTLS handshake timeout values
 =============================
 
 .. doxygengroup:: nrf_socket_so_sec_handshake_timeouts
-   :project: nrfxlib
-   :members:
 
 TLS/DTLS peer verification options
 ==================================
 
 .. doxygengroup:: nrf_socket_sec_peer_verify_options
-   :project: nrfxlib
-   :members:
 
 TLS/DTLS session cache options
 ==============================
 
 .. doxygengroup:: nrf_socket_session_cache_options
-   :project: nrfxlib
-   :members:
 
 TLS/DTLS socket connection roles
 ================================
 
 .. doxygengroup:: nrf_socket_sec_roles
-   :project: nrfxlib
-   :members:
 
 .. _nrf_supported_tls_cipher_suites:
 
@@ -150,37 +112,27 @@ Supported cipher suites
 =======================
 
 .. doxygengroup:: nrf_socket_tls_cipher_suites
-   :project: nrfxlib
-   :members:
 
 DTLS connection ID settings
 ===========================
 
 .. doxygengroup:: nrf_so_sec_dtls_cid_settings
-   :project: nrfxlib
-   :members:
 
 DTLS connection ID statuses
 ===========================
 
 .. doxygengroup:: nrf_so_sec_dtls_cid_statuses
-   :project: nrfxlib
-   :members:
 
 TLS/DTLS handshake statuses
 ===========================
 
 .. doxygengroup:: nrf_so_sec_handshake_statuses
-   :project: nrfxlib
-   :members:
 
 
 Socket address resolution API
 *****************************
 
 .. doxygengroup:: nrf_socket_address_resolution
-   :project: nrfxlib
-   :members:
 
 Socket polling API
 ******************
@@ -189,8 +141,6 @@ Necessary data types and defines to poll for
 events on one or more sockets using :c:func:`nrf_poll`.
 
 .. doxygengroup:: nrf_socket_api_poll
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_at_api:
 
@@ -198,8 +148,6 @@ AT API
 ******
 
 .. doxygengroup:: nrf_modem_at
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_bootloader_api:
 
@@ -207,8 +155,6 @@ Bootloader API
 **************
 
 .. doxygengroup:: nrf_modem_bootloader
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_delta_dfu_api:
 
@@ -216,12 +162,8 @@ Delta DFU API
 *************
 
 .. doxygengroup:: nrf_modem_delta_dfu
-   :project: nrfxlib
-   :members:
 
 .. doxygengroup:: nrf_modem_delta_dfu_errors
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_dect_phy_api:
 
@@ -229,8 +171,6 @@ DECT NR+ PHY API
 ****************
 
 .. doxygengroup:: nrf_modem_dect_phy
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_gnss_api:
 
@@ -238,43 +178,31 @@ GNSS API
 ********
 
 .. doxygengroup:: nrf_modem_gnss
-   :project: nrfxlib
-   :members:
 
 Event types
 ===========
 
 .. doxygengroup:: nrf_modem_gnss_event_type
-   :project: nrfxlib
-   :members:
 
 Data types
 ==========
 
 .. doxygengroup:: nrf_modem_gnss_data_type
-   :project: nrfxlib
-   :members:
 
 PVT notification flags bitmask values
 =====================================
 
 .. doxygengroup:: nrf_modem_gnss_pvt_flag_bitmask
-   :project: nrfxlib
-   :members:
 
 Satellite flags bitmask values
 ==============================
 
 .. doxygengroup:: nrf_modem_gnss_sv_flag_bitmask
-   :project: nrfxlib
-   :members:
 
 A-GNSS data request bitmask values
 ==================================
 
 .. doxygengroup:: nrf_modem_gnss_agnss_data_bitmask
-   :project: nrfxlib
-   :members:
 
 .. _agnss_data_type_enum_api:
 
@@ -282,64 +210,46 @@ A-GNSS data type enumerator
 ===========================
 
 .. doxygengroup:: nrf_modem_gnss_agnss_data_type
-   :project: nrfxlib
-   :members:
 
 Delete bitmask values
 =====================
 
 .. doxygengroup:: nrf_modem_gnss_delete_bitmask
-   :project: nrfxlib
-   :members:
 
 GNSS signal bitmask values
 ==========================
 
 .. doxygengroup:: nrf_modem_gnss_signal_bitmask
-   :project: nrfxlib
-   :members:
 
 NMEA string bitmask values
 ==========================
 
 .. doxygengroup:: nrf_modem_gnss_nmea_string_bitmask
-   :project: nrfxlib
-   :members:
 
 Power save modes
 ================
 
 .. doxygengroup:: nrf_modem_gnss_power_save_modes
-   :project: nrfxlib
-   :members:
 
 Use case bitmask values
 =======================
 
 .. doxygengroup:: nrf_modem_gnss_use_case_bitmask
-   :project: nrfxlib
-   :members:
 
 Sleep timing sources
 ====================
 
 .. doxygengroup:: nrf_modem_gnss_timing_source
-   :project: nrfxlib
-   :members:
 
 QZSS NMEA modes
 ===============
 
 .. doxygengroup:: nrf_modem_gnss_qzss_nmea_mode
-   :project: nrfxlib
-   :members:
 
 Dynamics modes
 ==============
 
 .. doxygengroup:: nrf_modem_gnss_dynamics_mode
-   :project: nrfxlib
-   :members:
 
 .. _nrf_modem_softsim_api:
 
@@ -347,12 +257,8 @@ SoftSIM API
 ***********
 
 .. doxygengroup:: nrf_modem_softsim
-   :project: nrfxlib
-   :members:
 
 OS specific definitions
 ***********************
 
 .. doxygengroup:: nrf_modem_os
-   :project: nrfxlib
-   :members:

--- a/nrf_rpc/doc/api.rst
+++ b/nrf_rpc/doc/api.rst
@@ -16,8 +16,6 @@ This API uses pointers to raw packet data.
 :ref:`nrf_rpc_cbor_api_documentation` provides serialization layer over it using zcbor.
 
 .. doxygengroup:: nrf_rpc
-   :project: nrfxlib
-   :members:
 
 .. _nrf_rpc_cbor_api_documentation:
 
@@ -28,5 +26,3 @@ This API is built on top of the core nRF RPC API and it is not independent.
 See :ref:`nrf_rpc_core_api_documentation` for more information on how to use nRF RPC together with zcbor.
 
 .. doxygengroup:: nrf_rpc_cbor
-   :project: nrfxlib
-   :members:

--- a/nrf_wifi/doc/API/fmac/low_api_common.rst
+++ b/nrf_wifi/doc/API/fmac/low_api_common.rst
@@ -8,5 +8,3 @@ The common API is used for both normal operation and Radio Test mode.
 
 
 .. doxygengroup:: nrf_wifi_api_common
-   :project: nrfxlib
-   :members:

--- a/nrf_wifi/doc/API/fmac/low_api_radio_test.rst
+++ b/nrf_wifi/doc/API/fmac/low_api_radio_test.rst
@@ -11,5 +11,3 @@ The Radio Test mode is used for testing the RF performance of the nRF70 Series d
 | Source file: :file:`nrf_wifi/fw_if/umac_if/src/radio_test/fmac_api.c`
 
 .. doxygengroup:: nrf_wifi_api_radio_test
-   :project: nrfxlib
-   :members:

--- a/nrf_wifi/doc/API/fmac/low_api_wifi.rst
+++ b/nrf_wifi/doc/API/fmac/low_api_wifi.rst
@@ -7,5 +7,3 @@ The Wi-Fi mode is used for normal operation of the nRF70 Series device in, for e
 | Source file: :file:`nrf_wifi/fw_if/umac_if/src/default/fmac_api.c`
 
 .. doxygengroup:: nrf_wifi_api
-   :project: nrfxlib
-   :members:

--- a/nrf_wifi/doc/API/fw_if.rst
+++ b/nrf_wifi/doc/API/fw_if.rst
@@ -7,5 +7,3 @@ The nRF70 Wi-Fi firmware interface (FW IF) used by the nRF70 Wi-Fi driver to com
 These header files are shared between the nRF70 Wi-Fi driver and the nRF70 Wi-Fi firmware.
 
 .. doxygengroup:: nrf_wifi_fw_if
-   :project: nrfxlib
-   :members:

--- a/softdevice_controller/doc/api.rst
+++ b/softdevice_controller/doc/api.rst
@@ -11,63 +11,45 @@ SoftDevice Controller
 ***********************
 
 .. doxygengroup:: sdc
-   :project: nrfxlib
-   :members:
 
 Memory requirement defines
 ==========================
 
 .. doxygengroup:: sdc_mem_defines
-   :project: nrfxlib
-   :members:
 
 
 SoftDevice Controller HCI
 ***************************
 
 .. doxygengroup:: sdc_hci
-   :project: nrfxlib
-   :members:
 
 
 SoftDevice Controller HCI VS
 ******************************
 
 .. doxygengroup:: sdc_hci_vs
-   :project: nrfxlib
-   :members:
 
 HCI Types
 ============
 
 .. doxygengroup:: HCI_TYPES
-   :project: nrfxlib
-   :members:
 
 HCI Events
 =============
 
 .. doxygengroup:: HCI_EVENTS
-   :project: nrfxlib
-   :members:
 
 HCI Commands
 ===============
 
 .. doxygengroup:: HCI_COMMAND_PARAMETERS
-   :project: nrfxlib
-   :members:
 
 HCI VS API
 ==========
 
 .. doxygengroup:: HCI_VS_API
-   :project: nrfxlib
-   :members:
 
 SoftDevice Controller SoC
 ***************************
 
 .. doxygengroup:: sdc_soc
-   :project: nrfxlib
-   :members:


### PR DESCRIPTION
Doxybridge does not support any attributes, so let's drop them all.