### PR TITLE
zboss: transfer ownership to `ncs-zigbee`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,7 +42,7 @@ doc/*                                     @b-gent
 /nrf_802154/                              @ankuns @piotrkoziar
 /nrf_security/                            @frkv @tejlmand
 /openthread/                              @lmaciejonczyk @edmont @canisLupus1313
-/zboss/                                   @milewr
+/zboss/                                   @nrfconnect/ncs-zigbee
 /zephyr/                                  @carlescufi
 /nrf_rpc/                                 @doki-nordic @KAGA164
 /nrf_dm/                                  @Tschet1 @eriksandgren


### PR DESCRIPTION
Update CODEOWNERS for zboss.