### PR TITLE
workflows: add unidiff for compliance workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -30,6 +30,7 @@ jobs:
         pip3 install -U yamllint
         pip3 install lxml==4.9.1
         pip3 install  -U python-magic junitparser==2.8.0 gitlint pylint pykwalify
+        pip3 install -U unidiff
         pip3 install --user -U west
         pip3 show -f west
 


### PR DESCRIPTION
Required due to Zephyr upstream changes.

Same change that was done for sdk-nrf:
https://github.com/nrfconnect/sdk-nrf/commit/3c7c249dd409bfb415f25336a7b15eff6871c534