### PR TITLE
doc: Updated Bluetooth Core Spec Link

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -85,7 +85,7 @@
 
 .. _`NMEA report sample`: http://aprs.gids.nl/nmea/#gsa
 
-.. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/specs/core-specification-5-4/
+.. _`Bluetooth Core Specification`: https://www.bluetooth.com/specifications/specs/core-specification-6-0/
 
 .. _`Bluetooth Specifications and Documents`: https://www.bluetooth.com/specifications/specs/
 


### PR DESCRIPTION
Updated the link for the Bluetooth Core Specification so that it points to the 6.0 revision instead of the 5.4