### PR TITLE
nrf_rpc: call bound_handler after init reply

### DIFF
--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -85,24 +85,32 @@ struct init_packet_data {
 	const char *strid;   /* Remote group unique identifier. */
 };
 
-enum internal_pool_data_type {
-	NRF_RPC_INITIALIZATION,
-	NRF_RPC_ERROR
+enum internal_task_type {
+	NRF_RPC_TASK_GROUP_INIT,
+	NRF_RPC_TASK_RECV_ERROR
 };
 
-struct internal_pool_data {
-	enum internal_pool_data_type type;
-	const struct nrf_rpc_group *group;
-	int err;
-	uint8_t hdr_id;
-	uint8_t hdr_type;
+struct internal_task {
+	enum internal_task_type type;
+
+	union {
+		struct {
+			const struct nrf_rpc_group *group;
+		} group_init;
+
+		struct {
+			const struct nrf_rpc_group *group;
+			int err;
+			uint8_t hdr_id;
+			uint8_t hdr_type;
+		} recv_error;
+	};
 };
 
 /* Pool of statically allocated command contexts. */
 static struct nrf_rpc_cmd_ctx cmd_ctx_pool[CONFIG_NRF_RPC_CMD_CTX_POOL_SIZE];
 
 static struct nrf_rpc_os_event groups_init_event;
-static struct nrf_rpc_os_event error_event;
 
 /* Number of groups */
 static uint8_t group_count;
@@ -116,7 +124,8 @@ static bool is_initialized;
 /* Error handler provided to the init function. */
 static nrf_rpc_err_handler_t global_err_handler;
 
-static struct internal_pool_data internal_data;
+static struct internal_task internal_task;
+static struct nrf_rpc_os_event internal_task_consumed;
 
 /* Array with all defiend groups */
 NRF_RPC_AUTO_ARR(nrf_rpc_groups_array, "grp");
@@ -361,19 +370,23 @@ static inline bool packet_validate(const uint8_t *packet)
 
 static void internal_tx_handler(void)
 {
-	struct internal_pool_data copy = internal_data;
+	struct internal_task task = internal_task;
+	nrf_rpc_os_event_set(&internal_task_consumed);
 
-	if (copy.type == NRF_RPC_INITIALIZATION) {
-		nrf_rpc_os_event_set(&copy.group->data->decode_done_event);
-		if (group_init_send(copy.group)) {
+	switch (task.type) {
+	case NRF_RPC_TASK_GROUP_INIT: {
+		const struct nrf_rpc_group *group = task.group_init.group;
+
+		if (group_init_send(group)) {
 			NRF_RPC_ERR("Failed to send group init packet for group id: %d strid: %s",
-				    copy.group->data->src_group_id, copy.group->strid);
+				    group->data->src_group_id, group->strid);
 		}
+		break;
 	}
-
-	if (copy.type == NRF_RPC_ERROR) {
-		nrf_rpc_os_event_set(&error_event);
-		nrf_rpc_err(copy.err, NRF_RPC_ERR_SRC_RECV, copy.group, copy.hdr_id, copy.hdr_type);
+	case NRF_RPC_TASK_RECV_ERROR:
+		nrf_rpc_err(task.recv_error.err, NRF_RPC_ERR_SRC_RECV, task.recv_error.group,
+			    task.recv_error.hdr_id, task.recv_error.hdr_type);
+		break;
 	}
 }
 
@@ -547,7 +560,7 @@ static uint8_t parse_incoming_packet(struct nrf_rpc_cmd_ctx *cmd_ctx,
 /* Thread pool callback */
 static void execute_packet(const uint8_t *packet, size_t len)
 {
-	if (packet == (const uint8_t *)&internal_data) {
+	if (packet == (const uint8_t *)&internal_task) {
 		internal_tx_handler();
 	} else {
 		parse_incoming_packet(NULL, packet, len);
@@ -674,10 +687,10 @@ static int init_packet_handle(struct header *hdr, const struct nrf_rpc_group **g
 		 * If remote processor does not know our group id, send an init packet back,
 		 * since it might have missed our original init packet.
 		 */
-		internal_data.type = NRF_RPC_INITIALIZATION;
-		internal_data.group = *group;
-		nrf_rpc_os_thread_pool_send((const uint8_t *)&internal_data, sizeof(internal_data));
-		nrf_rpc_os_event_wait(&(*group)->data->decode_done_event, NRF_RPC_OS_WAIT_FOREVER);
+		internal_task.type = NRF_RPC_TASK_GROUP_INIT;
+		internal_task.group_init.group = *group;
+		nrf_rpc_os_thread_pool_send((const uint8_t *)&internal_task, sizeof(internal_task));
+		nrf_rpc_os_event_wait(&internal_task_consumed, NRF_RPC_OS_WAIT_FOREVER);
 	}
 
 	return 0;
@@ -802,13 +815,13 @@ cleanup_and_exit:
 	}
 
 	if (err < 0) {
-		internal_data.type = NRF_RPC_ERROR;
-		internal_data.group = group;
-		internal_data.err = err;
-		internal_data.hdr_id = hdr.id;
-		internal_data.hdr_type = hdr.type;
-		nrf_rpc_os_thread_pool_send((const uint8_t *)&internal_data, sizeof(internal_data));
-		nrf_rpc_os_event_wait(&error_event, NRF_RPC_OS_WAIT_FOREVER);
+		internal_task.type = NRF_RPC_TASK_RECV_ERROR;
+		internal_task.recv_error.group = group;
+		internal_task.recv_error.err = err;
+		internal_task.recv_error.hdr_type = hdr.type;
+		internal_task.recv_error.hdr_id = hdr.id;
+		nrf_rpc_os_thread_pool_send((const uint8_t *)&internal_task, sizeof(internal_task));
+		nrf_rpc_os_event_wait(&internal_task_consumed, NRF_RPC_OS_WAIT_FOREVER);
 	}
 }
 
@@ -1083,7 +1096,7 @@ int nrf_rpc_init(nrf_rpc_err_handler_t err_handler)
 		return err;
 	}
 
-	err = nrf_rpc_os_event_init(&error_event);
+	err = nrf_rpc_os_event_init(&internal_task_consumed);
 	if (err < 0) {
 		return err;
 	}


### PR DESCRIPTION
1. Ensure that the group's bound_handler is called after sending the init reply. This is to make sure that the remote knows our group ID and is able to process incoming commands when the handler is called.
2. Similarly, signal groups_init_event after sending the init reply.

---

nrf_rpc: refactor internal tasks
    
1. Rename internal_data to internal_task to better describe the purpose of the structure.
2. Use internal_task_consumed event to notify about freeing the global task object for all types of tasks.
3. Use union for different types of tasks to not bloat the internal task structure when more tasks or fields are added.
