### PR TITLE
[Backport v2.8-branch] doc: Update doc versions in nrfxlib for 2.8.0

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -30,9 +30,7 @@
 .. _`Cellular Monitor`: https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/managing_credentials.html
 .. _`nRF Connect Serial Terminal`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
 
-.. _Radio Driver section: https://infocenter.nordicsemi.com/topic/15.4_radio_driver_v1.10.0/rd_release_notes.html
-
-.. _nRF21540: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF21540
+.. _`nRF21540`: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF21540
 
 .. _`Thread CIDs for nRF5340`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf5340/page/COMP/nrf5340/nrf5340_thread_cids.html
 .. _`Thread CIDs for nRF52840`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf52840/page/COMP/nrf52840/nrf52840_thread_cids.html

--- a/mpsl/CHANGELOG.rst
+++ b/mpsl/CHANGELOG.rst
@@ -7,8 +7,10 @@ Changelog
    :local:
    :depth: 2
 
-Main Branch
-***********
+All the notable changes to this project are documented on this page.
+
+nRF Connect SDK v2.8.0
+**********************
 
 Changes
 =======

--- a/nrf_802154/doc/CHANGELOG.rst
+++ b/nrf_802154/doc/CHANGELOG.rst
@@ -10,10 +10,6 @@ Changelog
 All notable changes to this project are documented in this file.
 See also :ref:`nrf_802154_limitations` for permanent limitations.
 
-Main branch - nRF 802.15.4 Radio Driver
-***************************************
-
-
 nRF Connect SDK v2.8.0 - nRF 802.15.4 Radio Driver
 **************************************************
 
@@ -284,7 +280,7 @@ Added
 Notable Changes
 ===============
 
-* The release notes of the legacy versions of the Radio Driver are available in the `Radio Driver section`_ of the Infocenter.
+* The release notes of the legacy versions of the Radio Driver are available in the Changelog for 802.15.4 Radio Driver v1.10.0.
 * The changelog of the previous versions of the 802.15.4 SL library is now located at the bottom of this page.
 * The Radio Driver documentation will now also include the Service Layer documentation.
 * Future versions of the Radio Driver and the Service Layer will follow NCS version tags.

--- a/nrf_fuel_gauge/CHANGELOG.rst
+++ b/nrf_fuel_gauge/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog
 
 All notable changes to this project are documented on this page.
 
-Main branch
-***********
+nRF Connect SDK v2.8.0
+**********************
 
 Changes
 =======

--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
-nrf_modem
-*********
+nrf_modem 2.8.0
+***************
 
 Core library
 ============

--- a/nrf_rpc/CHANGELOG.rst
+++ b/nrf_rpc/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog
 
 All the notable changes to this project are documented on this page.
 
-nRF Connect SDK v2.7.99
-***********************
+nRF Connect SDK v2.8.0
+**********************
 
 Changes
 =======

--- a/softdevice_controller/CHANGELOG.rst
+++ b/softdevice_controller/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog
 
 All the notable changes to this project are documented on this page.
 
-Main branch
-***********
+nRF Connect SDK v2.8.0
+**********************
 
 Added
 =====


### PR DESCRIPTION
Backport b847547bea60d5e0cd2096e291bb8ca784393da1 from #1567.