### PR TITLE
doc: Minor updates to Modem library

### DIFF
--- a/nrf_modem/doc/at_interface.rst
+++ b/nrf_modem/doc/at_interface.rst
@@ -51,7 +51,7 @@ The following snippet shows how to use :c:func:`nrf_modem_at_printf` to send a f
 		int err;
 
 		err = nrf_modem_at_printf("AT+CFUN=%d", mode);
-		if (err = 0) {
+		if (err == 0) {
 			/* OK, success */
 		} else if (err < 0) {
 			/* Failed to send command, err is an nrf_errno */

--- a/nrf_modem/doc/gnss_interface.rst
+++ b/nrf_modem/doc/gnss_interface.rst
@@ -169,7 +169,7 @@ System mask
 ===========
 
 System mask controls which GNSSs are enabled.
-The system mask is set using the :c:func:`nrf_modem_gnss_system_mask_set` function by providing a bitmap of the selected systems.
+The system mask is set using the :c:func:`nrf_modem_gnss_signal_mask_set` function by providing a bitmap of the selected systems.
 
 By default, all supported GNSSs are enabled.
 
@@ -181,7 +181,7 @@ GPS cannot be disabled and it remains enabled even if the corresponding bit is n
 
    system_mask = NRF_MODEM_GNSS_SYSTEM_GPS_MASK | NRF_MODEM_GNSS_SYSTEM_QZSS_MASK;
 
-   err = nrf_modem_gnss_system_mask_set(system_mask);
+   err = nrf_modem_gnss_signal_mask_set(system_mask);
 
 Satellite elevation threshold
 =============================


### PR DESCRIPTION
Minor fixes to the following pages:
* nrf_modem/doc/at_interface.rst
* nrf_modem/doc/gnss_interface.rst - nrf_modem_gnss_system_mask_set is renamed to nrf_modem_gnss_signal_mask_set.

TECHDOC-3122 and TECHDOC-3107