### PR TITLE
nrf_rpc: detect reboot of the remote

### DIFF
--- a/nrf_rpc/include/nrf_rpc.h
+++ b/nrf_rpc/include/nrf_rpc.h
@@ -66,6 +66,7 @@ enum nrf_rpc_err_src {
 	NRF_RPC_ERR_SRC_RECV,   /**< @brief Error during receiving */
 	NRF_RPC_ERR_SRC_SEND,   /**< @brief Error during sending */
 	NRF_RPC_ERR_SRC_REMOTE, /**< @brief Error reported be the remote */
+	NRF_RPC_ERR_SRC_REBOOT, /**< @brief Error due to reboot of the remote */
 };
 
 /* Helper nRF group structure declaration needed for callback definition. */


### PR DESCRIPTION
Raise an error when the remote sends an init packet with unknown destination group ID after the group has been bound, which indicates a reboot of the peer.