### PR TITLE
workflows: Add workflow to prevent merging PRs with DNM label

### DIFF
--- a/.github/workflows/dnm.yml
+++ b/.github/workflows/dnm.yml
@@ -1,0 +1,17 @@
+name: Do Not Merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'DNM'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1


### PR DESCRIPTION
This aligns with other repositories in NCS.