### PR TITLE
doc: remove references to removed sample `nRF5340: Multiprotocol RPMsg`

### DIFF
--- a/nrf_802154/doc/rd_limitations.rst
+++ b/nrf_802154/doc/rd_limitations.rst
@@ -13,4 +13,4 @@ KRKNWK-11204: Transmitting an 802.15.4 frame with improperly populated Auxiliary
   **Workaround:** Make sure that you populate the Auxiliary Security Header field according to the IEEE Std 802.15.4-2015 specification, section 9.4.
 
 KRKNWK-12482: Reception of correct frames will occasionally end in failure with error ``NRF_802154_RX_ERROR_RUNTIME``
-  This issue can occur for the ``nrf5340dk_nrf5340_cpunet`` target if a custom application (other than :ref:`nrf:multiprotocol-rpmsg-sample` sample or :zephyr:code-sample:`nrf_ieee802154_rpmsg` sample) is used.
+  This issue can occur for the ``nrf5340dk_nrf5340_cpunet`` target if a custom application (other than ``nRF5340: Multiprotocol RPMsg`` sample or :zephyr:code-sample:`nrf_ieee802154_rpmsg` sample) is used.


### PR DESCRIPTION
The nrf/samples/nrf5340/multiprotocol_rpmsg sample is removed. References to it in historical files are changed to text ``nRF5340: Multiprotocol RPMsg``.