### PR TITLE
[Backport v2.9-branch] doc: Documentation check for 2.9

### DIFF
--- a/mpsl/doc/cx.rst
+++ b/mpsl/doc/cx.rst
@@ -8,7 +8,7 @@ Short-Range Protocols External Radio Coexistence
    :depth: 2
 
 The radio coexistence feature allows the application to interface with several types of packet traffic arbiters (PTAs).
-PTAs arbitrate the requested radio operations between all radios to avoid interference, providing better radio performance to devices using multiple interfering radios simultaneously, like a combination of IEEE 802.15.4, Bluetooth® Low Energy (LE), and Wi-Fi.
+PTAs arbitrate the requested radio operations between all radios to avoid interference, providing better radio performance to devices using multiple interfering radios simultaneously, like a combination of IEEE 802.15.4, Bluetooth® Low Energy (LE), and Wi-Fi®.
 The arbitration algorithm used can vary between PTAs.
 
 .. note::
@@ -17,7 +17,7 @@ The arbitration algorithm used can vary between PTAs.
 Overview
 ********
 
-The radio coexistence feature allows short-range protocol drivers (e.g. IEEE 802.15.4, Bluetooth LE) to communicate with the packet traffic arbiter (PTA) using :ref:`MPSL CX API <mpsl_api_sr_cx>`.
+The radio coexistence feature allows short-range protocol drivers (for example, IEEE 802.15.4, Bluetooth LE) to communicate with the packet traffic arbiter (PTA) using :ref:`MPSL CX API <mpsl_api_sr_cx>`.
 The MPSL CX API is hardware-agnostic and separates the implementation of the protocol driver from an implementation specific to given PTA.
 To perform any radio operation, the protocol drivers must first request the appropriate access to the medium from the PTA.
 The request informs the PTA implementation about which radio operations it wants to perform at that moment or shortly after, and what is the priority of the operation.
@@ -36,7 +36,7 @@ Selecting CX Implementation
 
 The :ref:`mpsl` itself does not provide any implementation of the CX interface.
 For details on the implementations present in the |NCS|, see :ref:`nrf:ug_radio_coex`.
-An application that needs to use CX must call :c:func:`mpsl_cx_interface_set()` during the system initialization.
+An application that needs to use CX must call :c:func:`mpsl_cx_interface_set` during the system initialization.
 The initialization of any resource needed by the selected CX implementation is not in scope of :ref:`mpsl` and must also be done during the system initialization.
 
 .. note::

--- a/nfc/CHANGELOG.rst
+++ b/nfc/CHANGELOG.rst
@@ -23,7 +23,7 @@ nRF Connect SDK v2.6.0
 Added
 =====
 
-* Added functions :c:func:`nfc_platform_buffer_alloc()` and :c:func:`nfc_platform_buffer_free()` for the platform layer.
+* Added functions :c:func:`nfc_platform_buffer_alloc` and :c:func:`nfc_platform_buffer_free` for the platform layer.
   The NFCT buffer for data exchange is now outside the library implementation.
   You have to define these two functions and return a memory that is accessible by the EasyDMA utility.
 * A possibility to modify the maximum value for the Frame Wait time Integer by using the ``NFC_T4T_PARAM_FWI_MAX`` parameter.
@@ -31,7 +31,7 @@ Added
 Modified
 ========
 
-* The :c:func:`nfc_platform_setup()` function now provides a pointer to the interrupt priority of the NFCT peripheral.
+* The :c:func:`nfc_platform_setup` function now provides a pointer to the interrupt priority of the NFCT peripheral.
   Its value must be set to the requested one.
   In implementations where the operating system is responsible for setting the interrupt priority, this value is not relevant.
 
@@ -41,14 +41,14 @@ nRF Connect SDK v2.3.0
 Added
 =====
 
-* A callback requested by the :c:func:`nfc_platform_cb_request()` function to allow execution of platform-dependent code before executing the user callback.
+* A callback requested by the :c:func:`nfc_platform_cb_request` function to allow execution of platform-dependent code before executing the user callback.
 * A header file :file:`nfc_platform.h` for platform layer.
 
 Modified
 ========
 
-* The :c:func:`nfc_platform_setup()` function now provides a pointer to the callback resolution function that is used to execute the user-defined NFC callback.
-* The :c:func:`nfc_t2t_setup()` function was updated to allow coexistence of the Type 2 Tag and the Type 4 Tag libraries.
+* The :c:func:`nfc_platform_setup` function now provides a pointer to the callback resolution function that is used to execute the user-defined NFC callback.
+* The :c:func:`nfc_t2t_setup` function was updated to allow coexistence of the Type 2 Tag and the Type 4 Tag libraries.
 
 nRF Connect SDK v2.1.0
 **********************
@@ -64,7 +64,7 @@ nRF Connect SDK v2.0.0
 Bug fixes
 =========
 
-* Fixed the Type 2 Tag initialization, where the return value of the :c:func:`nfc_platform_nfcid1_default_bytes_get()` function was not converted to the local NFC error code resulting in incorrect NFCID1 values.
+* Fixed the Type 2 Tag initialization, where the return value of the :c:func:`nfc_platform_nfcid1_default_bytes_get` function was not converted to the local NFC error code resulting in incorrect NFCID1 values.
 
 nRF Connect SDK v1.9.0
 **********************
@@ -103,7 +103,7 @@ Modified
 
 * Debug info is removed from the NFC T2T and T4T libraries.
 * Fixed duplicated initial Frame Waiting Time (FWT) value setting.
-* Modified the :c:func:`nfc_t2t_done()` and the :c:func:`nfc_t4t_done()` functions to uninitialize the NFCT driver to achieve symmetry in the library behaviour since the :c:func:`nfc_txt_setup()` function initializes the NFCT driver.
+* Modified the :c:func:`nfc_t2t_done` and the :c:func:`nfc_t4t_done` functions to uninitialize the NFCT driver to achieve symmetry in the library behaviour since the :c:func:`nfc_txt_setup` function initializes the NFCT driver.
 * Fixed FSDI value setting for RFU value cases.
 
 nRF Connect SDK v1.6.0

--- a/nrf_802154/doc/CHANGELOG.rst
+++ b/nrf_802154/doc/CHANGELOG.rst
@@ -287,7 +287,7 @@ Notable Changes
 * The release notes of the legacy versions of the Radio Driver are available in the Changelog for 802.15.4 Radio Driver v1.10.0.
 * The changelog of the previous versions of the 802.15.4 SL library is now located at the bottom of this page.
 * The Radio Driver documentation will now also include the Service Layer documentation.
-* Future versions of the Radio Driver and the Service Layer will follow NCS version tags.
+* Future versions of the Radio Driver and the Service Layer will follow |NCS| version tags.
 * The 802.15.4 Radio Driver API has been modified to support more than a single delayed reception window simultaneously.
   The :c:func:`nrf_802154_receive_at`, :c:func:`nrf_802154_receive_at_cancel`, and :c:func:`nrf_802154_receive_failed` functions take an additional parameter that identifies a given reception window unambiguously.
 

--- a/nrf_modem/doc/CHANGELOG.rst
+++ b/nrf_modem/doc/CHANGELOG.rst
@@ -15,7 +15,7 @@ nrf_modem
 Sockets
 =======
 
-* Updated the :c:func:`nrf_send()` and :c:func:`nrf_sendto()` functions to correctly set ``errno`` when the socket is closed during a send operation with :c:macro:`NRF_MSG_WAITACK`.
+* Updated the :c:func:`nrf_send` and :c:func:`nrf_sendto` functions to correctly set ``errno`` when the socket is closed during a send operation with :c:macro:`NRF_MSG_WAITACK`.
 
 DECT NR+
 ========
@@ -337,7 +337,7 @@ Bootloader
 nrf_modem 2.2.1
 ***************
 
-* Added the ``MODEM_DFU_RESULT_VOLTAGE_LOW`` result to :c:func:`nrf_modem_init()` function.
+* Added the ``MODEM_DFU_RESULT_VOLTAGE_LOW`` result to :c:func:`nrf_modem_init` function.
   The new value is returned when the voltage is too low for the modem firmware to execute the scheduled modem firmware update.
   The application can retry the operation by re-initializing the modem when the voltage has increased.
   Requires modem firmware v1.3.4 or newer.
@@ -346,11 +346,11 @@ nrf_modem 2.2.1
 nrf_modem 2.2.0
 ***************
 
-* Added a ``timeout`` parameter to the :c:func:`nrf_modem_trace_get()` function.
+* Added a ``timeout`` parameter to the :c:func:`nrf_modem_trace_get` function.
 * Fixed an issue when compiling the :file:`nrf_modem.h` header in C++.
 * The Delta DFU interface (:file:`nrf_modem_delta_dfu.h`) is now thread safe.
-* Fixed possible race conditions in the :c:func:`nrf_modem_init()` and :c:func:`nrf_modem_shutdown()` functions.
-* Fixed a bug in :c:func:`nrf_listen()` function that let the queue of incoming connection requests be of size one.
+* Fixed possible race conditions in the :c:func:`nrf_modem_init` and :c:func:`nrf_modem_shutdown` functions.
+* Fixed a bug in :c:func:`nrf_listen` function that let the queue of incoming connection requests be of size one.
 * The :c:data:`NRF_MODEM_GNSS_EVT_BLOCKED` event is now sent only when the GNSS stack does not get any runtime due to LTE activity, whereas earlier it could also be sent when the GNSS stack average runtime was too short.
 * Removed the usage of the application software interrupt. The library uses only the IPC peripheral interrupt now.
 * Removed the :c:func:`nrf_modem_application_irq_handler` function.

--- a/nrf_rpc/CHANGELOG.rst
+++ b/nrf_rpc/CHANGELOG.rst
@@ -16,7 +16,7 @@ Changes
 =======
 
 * Enabled zcbor's :c:member:`stop_on_error` flag before decoding the CBOR payload of an nRF RPC packet.
-  When this flag is set, zcbor stops decoding subsequent data items in the case of decoding failure unless the error is explicitly cleared with the :c:func:`zcbor_pop_error()` function.
+  When this flag is set, zcbor stops decoding subsequent data items in the case of decoding failure unless the error is explicitly cleared with the :c:func:`zcbor_pop_error` function.
 
 nRF Connect SDK v2.5.0
 **********************


### PR DESCRIPTION
Backport e1c5c7d3765829b6474da35c5b9f0986e07022e7 from #1610.