### PR TITLE
ci: fix compliance by using ubuntu-22.04

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   compliance_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Run compliance checks on patch series (PR)
     steps:
     - name: Checkout the code


### PR DESCRIPTION
ubuntu-latest points to 24.04 - use 22.04 instead   
manifest-pr-skip