### PR TITLE
nrf_modem: doc: Change GNSS interface name

### DIFF
--- a/nrf_modem/doc/gnss_interface.rst
+++ b/nrf_modem/doc/gnss_interface.rst
@@ -1,8 +1,8 @@
 .. _nrf_modem_gnss:
 .. _gnss_interface:
 
-Global Navigation Satellite System
-##################################
+GNSS
+####
 
 .. contents::
    :local:


### PR DESCRIPTION
Changed GNSS interface name in documentation from `Global Satellite Navigation System` to `GNSS`. The name of the interface in modemlib is `GNSS` and in general all documentation refers to `GNSS interface` or `GNSS API`.