### PR TITLE
nrf_802154: introduce NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US

### DIFF
--- a/nrf_802154/CMakeLists.txt
+++ b/nrf_802154/CMakeLists.txt
@@ -35,6 +35,13 @@
 add_library(nrf-802154-driver-interface INTERFACE)
 add_library(nrf-802154-serialization-interface INTERFACE)
 
+if (CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)
+  target_compile_definitions(zephyr-802154-interface
+    INTERFACE
+      NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US=${CONFIG_NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US}
+  )
+endif()
+
 add_subdirectory(common)
 
 add_subdirectory(driver)

--- a/nrf_802154/common/include/nrf_802154_config.h
+++ b/nrf_802154/common/include/nrf_802154_config.h
@@ -98,6 +98,23 @@ extern "C" {
 #endif
 
 /**
+ * @def NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US
+ *
+ * Additional time in microseconds that delays triggering of @c TXEN after the
+ * @c CCAIDLE event occurred. Default value for most use-cases is @c 0,
+ * In this scenario, the short between the @c CCAIDLE event and the
+ * @c TXEN task is used. If this value is non-zero, the short is not used.
+ * The triggering of @c TXEN occurs through (D)PPI and TIMER.
+ * A non-zero value may be necessary to ensure enough switching time for
+ * use with some Front-End Modules.
+ *
+ * This option is supported for the nRF53 Series and the nRF54L Series only.
+ */
+#ifndef NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US
+#define NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US 0U
+#endif
+
+/**
  * @def NRF_802154_INTERNAL_RADIO_IRQ_HANDLING
  *
  * If the driver is expected to internally handle the RADIO IRQ.

--- a/nrf_802154/doc/CHANGELOG.rst
+++ b/nrf_802154/doc/CHANGELOG.rst
@@ -13,6 +13,16 @@ See also :ref:`nrf_802154_limitations` for permanent limitations.
 Main branch - nRF 802.15.4 Radio Driver
 ***************************************
 
+Added
+=====
+
+* For the nRF54L Series, added the :c:macro:`NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US` configuration macro that allows to extend the time between the CCAIDLE event and the trigger of the TXEN task. (KRKNWK-19819)
+
+Bug fixes
+=========
+
+* Fixed the constant describing the time between CCAIDLE and READY events. The constant is used for calculation of the time needed for a transmission using CCA for the nRF54L Series. (KRKNWK-19819)
+
 Removed
 =======
 

--- a/nrf_802154/driver/src/nrf_802154_peripherals.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals.h
@@ -224,7 +224,7 @@ extern "C" {
  * of an interrupt by the RADIO.EVENTS_SYNC event.
  *
  */
-#define NRF_802154_EGU_SYNC_CHANNEL_NO            3
+#define NRF_802154_EGU_SYNC_CHANNEL_NO                3
 
 /**
  * @def NRF_802154_EGU_SYNC_USED_CHANNELS_MASK
@@ -232,14 +232,14 @@ extern "C" {
  * Mask of EGU channels used by the interrupt generation from the RADIO.EVENTS_SYNC event.
  * See @ref NRF_802154_EGU_USED_CHANNELS_MASK.
  */
-#define NRF_802154_EGU_SYNC_USED_CHANNELS_MASK    (1U << NRF_802154_EGU_SYNC_CHANNEL_NO)
+#define NRF_802154_EGU_SYNC_USED_CHANNELS_MASK        (1U << NRF_802154_EGU_SYNC_CHANNEL_NO)
 
 /**
  * @def NRF_802154_EGU_RAMP_UP_CHANNEL_NO
  *
  * The channel number of the @ref NRF_802154_EGU_INSTANCE used for triggering the ramp-up of the RADIO.
  */
-#define NRF_802154_EGU_RAMP_UP_CHANNEL_NO         15
+#define NRF_802154_EGU_RAMP_UP_CHANNEL_NO             15
 
 /**
  * @def NRF_802154_EGU_RAMP_UP_USED_CHANNELS_MASK
@@ -247,23 +247,31 @@ extern "C" {
  * Mask of EGU channels used for triggering the ramp-up of the RADIO.
  * See @ref NRF_802154_EGU_USED_CHANNELS_MASK.
  */
-#define NRF_802154_EGU_RAMP_UP_USED_CHANNELS_MASK (1U << NRF_802154_EGU_RAMP_UP_CHANNEL_NO)
+#define NRF_802154_EGU_RAMP_UP_USED_CHANNELS_MASK     (1U << NRF_802154_EGU_RAMP_UP_CHANNEL_NO)
 
 /**
  * @def NRF_802154_EGU_RAMP_UP_EVENT
  *
  * The EGU event used by the driver to trigger radio ramp-up.
  */
-#define NRF_802154_EGU_RAMP_UP_EVENT              NRFX_CONCAT_2(NRF_EGU_EVENT_TRIGGERED, \
-                                                                NRF_802154_EGU_RAMP_UP_CHANNEL_NO)
+#define NRF_802154_EGU_RAMP_UP_EVENT                  NRFX_CONCAT_2(NRF_EGU_EVENT_TRIGGERED, \
+                                                                    NRF_802154_EGU_RAMP_UP_CHANNEL_NO)
 
 /**
  * @def NRF_802154_EGU_RAMP_UP_TASK
  *
  * The EGU task used by the driver to trigger radio ramp-up.
  */
-#define NRF_802154_EGU_RAMP_UP_TASK               NRFX_CONCAT_2(NRF_EGU_TASK_TRIGGER, \
-                                                                NRF_802154_EGU_RAMP_UP_CHANNEL_NO)
+#define NRF_802154_EGU_RAMP_UP_TASK                   NRFX_CONCAT_2(NRF_EGU_TASK_TRIGGER, \
+                                                                    NRF_802154_EGU_RAMP_UP_CHANNEL_NO)
+
+#ifndef NRF_802154_EGU_TIMER_START_USED_CHANNELS_MASK
+#define NRF_802154_EGU_TIMER_START_USED_CHANNELS_MASK 0U
+#endif
+
+#ifndef NRF_802154_EGU_TIMER_START2_USED_CHANNELS_MASK
+#define NRF_802154_EGU_TIMER_START2_USED_CHANNELS_MASK 0U
+#endif
 
 /**
  * @def NRF_802154_EGU_USED_CHANNELS_MASK
@@ -276,6 +284,8 @@ extern "C" {
      NRF_802154_EGU_REQUEST_USED_CHANNELS_MASK |      \
      NRF_802154_EGU_SYNC_USED_CHANNELS_MASK |         \
      NRF_802154_EGU_RAMP_UP_USED_CHANNELS_MASK |      \
+     NRF_802154_EGU_TIMER_START_USED_CHANNELS_MASK |  \
+     NRF_802154_EGU_TIMER_START2_USED_CHANNELS_MASK | \
      NRF_802154_SL_EGU_USED_CHANNELS_MASK)
 
 #ifdef __cplusplus

--- a/nrf_802154/driver/src/nrf_802154_peripherals_nrf52.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals_nrf52.h
@@ -153,27 +153,12 @@ extern "C" {
 #endif
 
 /**
- * @def NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
- *
- * The PPI channel that connects RADIO_CRCERROR event to TIMER_CLEAR task.
- *
- * @note This option is used by the core module regardless of the driver configuration.
- *       The peripheral is shared with @ref NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE
- *       and @ref NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN.
- *
- */
-#ifndef NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
-#define NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR 9U
-#endif
-
-/**
  * @def NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE
  *
  * The PPI channel that connects RADIO_CCAIDLE event to the GPIOTE tasks used by the Frontend.
  *
  * @note This option is used by the core module regardless of the driver configuration.
- *       The peripheral is shared with @ref NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
- *       and @ref NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN.
+ *       The peripheral is shared with @ref NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN.
  *
  */
 #ifndef NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE
@@ -186,8 +171,7 @@ extern "C" {
  * The PPI channel that connects TIMER_COMPARE event to RADIO_TXEN task.
  *
  * @note This option is used by the core module regardless of the driver configuration.
- *       The peripheral is shared with @ref NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR
- *       and @ref NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE.
+ *       The peripheral is shared with @ref NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE.
  *
  */
 #ifndef NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN
@@ -262,7 +246,6 @@ extern "C" {
                                            (1 << NRF_802154_PPI_RADIO_RAMP_UP_TRIGG) |              \
                                            (1 << NRF_802154_PPI_EGU_TO_RADIO_RAMP_UP) |             \
                                            (1 << NRF_802154_PPI_EGU_TO_TIMER_START) |               \
-                                           (1 << NRF_802154_PPI_RADIO_CRCERROR_TO_TIMER_CLEAR) |    \
                                            (1 << NRF_802154_PPI_RADIO_CCAIDLE_TO_FEM_GPIOTE) |      \
                                            (1 << NRF_802154_PPI_TIMER_COMPARE_TO_RADIO_TXEN) |      \
                                            (1 << NRF_802154_PPI_RADIO_CCABUSY_TO_RADIO_CCASTART) |  \

--- a/nrf_802154/driver/src/nrf_802154_peripherals_nrf53.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals_nrf53.h
@@ -91,6 +91,32 @@ extern "C" {
 #define NRF_802154_EGU_USED_MASK (1 << NRF_802154_EGU_INSTANCE_NO)
 #endif
 
+#if (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__)
+
+/**
+ * @def NRF_802154_EGU_TIMER_START_CHANNEL_NO
+ *
+ * The channel number of the @ref NRF_802154_EGU_INSTANCE used for starting the TIMER.
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ */
+#define NRF_802154_EGU_TIMER_START_CHANNEL_NO 14
+
+#define NRF_802154_EGU_TIMER_START_USED_CHANNELS_MASK \
+    (1U << NRF_802154_EGU_TIMER_START_CHANNEL_NO)
+
+/**
+ * @def NRF_802154_EGU_TIMER_START2_CHANNEL_NO
+ *
+ * The channel number of the @ref NRF_802154_EGU_INSTANCE used for starting the TIMER (second source).
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ */
+#define NRF_802154_EGU_TIMER_START2_CHANNEL_NO 13
+
+#define NRF_802154_EGU_TIMER_START2_USED_CHANNELS_MASK \
+    (1U << NRF_802154_EGU_TIMER_START2_CHANNEL_NO)
+
+#endif /* (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__) */
+
 /**
  * @def NRF_802154_RTC_INSTANCE_NO
  *
@@ -206,6 +232,40 @@ extern "C" {
 #define NRF_802154_DPPI_RADIO_SYNC_TO_EGU_SYNC 12U
 #endif
 
+#if (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__)
+/**
+ * @def NRF_802154_DPPI_TIMER_START
+ *
+ * The DPPI channel that is used to trigger TIMER's START task.
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ *
+ */
+#ifndef NRF_802154_DPPI_TIMER_START
+#define NRF_802154_DPPI_TIMER_START 16U
+#endif
+
+/**
+ * @def NRF_802154_DPPI_RADIO_TXEN
+ *
+ * The DPPI channel that is used to trigger RADIO's TXEN task
+ * in the scenario where short CCAIDLE_TXEN is not used.
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ *
+ */
+#ifndef NRF_802154_DPPI_RADIO_TXEN
+#define NRF_802154_DPPI_RADIO_TXEN       17U
+#endif
+
+#define NRF_802154_DPPI_TIMER_START_MASK (1U << NRF_802154_DPPI_TIMER_START)
+#define NRF_802154_DPPI_RADIO_TXEN_MASK  (1U << NRF_802154_DPPI_RADIO_TXEN)
+
+#else
+
+#define NRF_802154_DPPI_TIMER_START_MASK 0U
+#define NRF_802154_DPPI_RADIO_TXEN_MASK  0U
+
+#endif /* (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__) */
+
 /**
  * @def NRF_802154_DPPI_RADIO_CCAIDLE
  *
@@ -255,6 +315,8 @@ extern "C" {
         (1UL << NRF_802154_DPPI_EGU_TO_RADIO_RAMP_UP) |        \
         (1UL << NRF_802154_DPPI_TIMER_COMPARE_TO_RADIO_TXEN) | \
         (1UL << NRF_802154_DPPI_RADIO_SYNC_TO_EGU_SYNC) |      \
+        (NRF_802154_DPPI_TIMER_START_MASK) |                   \
+        (NRF_802154_DPPI_RADIO_TXEN_MASK) |                    \
         (1UL << NRF_802154_DPPI_RADIO_CCAIDLE) |               \
         (1UL << NRF_802154_DPPI_RADIO_CCABUSY) |               \
         (1UL << NRF_802154_DPPI_RADIO_HW_TRIGGER) |            \

--- a/nrf_802154/driver/src/nrf_802154_peripherals_nrf54l.h
+++ b/nrf_802154/driver/src/nrf_802154_peripherals_nrf54l.h
@@ -90,6 +90,32 @@ extern "C" {
 #define NRF_802154_EGU_USED_MASK (1 << NRF_802154_EGU_INSTANCE_NO)
 #endif
 
+#if (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__)
+
+/**
+ * @def NRF_802154_EGU_TIMER_START_CHANNEL_NO
+ *
+ * The channel number of the @ref NRF_802154_EGU_INSTANCE used for starting the TIMER.
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ */
+#define NRF_802154_EGU_TIMER_START_CHANNEL_NO 14
+
+#define NRF_802154_EGU_TIMER_START_USED_CHANNELS_MASK \
+    (1U << NRF_802154_EGU_TIMER_START_CHANNEL_NO)
+
+/**
+ * @def NRF_802154_EGU_TIMER_START2_CHANNEL_NO
+ *
+ * The channel number of the @ref NRF_802154_EGU_INSTANCE used for starting the TIMER (second source).
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ */
+#define NRF_802154_EGU_TIMER_START2_CHANNEL_NO 13
+
+#define NRF_802154_EGU_TIMER_START2_USED_CHANNELS_MASK \
+    (1U << NRF_802154_EGU_TIMER_START2_CHANNEL_NO)
+
+#endif /* (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__) */
+
 /**
  * @def NRF_802154_CCM_INSTANCE_NO
  *
@@ -108,7 +134,8 @@ extern "C" {
  * @note This option is used when @ref NRF_802154_ENCRYPTION_ENABLED is set.
  *
  */
-#define NRF_802154_CCM_INSTANCE    NRFX_CONCAT_2(NRF_CCM, NRF_802154_CCM_INSTANCE_NO)
+#define NRF_802154_CCM_INSTANCE    NRFX_CONCAT_2(NRF_CCM, \
+                                                 NRF_802154_CCM_INSTANCE_NO)
 
 /**
  * @def NRF_802154_RTC_INSTANCE_NO
@@ -233,6 +260,40 @@ extern "C" {
 #define NRF_802154_DPPI_RADIO_SYNC_TO_EGU_SYNC 22U
 #endif
 
+#if (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__)
+/**
+ * @def NRF_802154_DPPI_TIMER_START
+ *
+ * The DPPI channel that is used to trigger TIMER's START task.
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ *
+ */
+#ifndef NRF_802154_DPPI_TIMER_START
+#define NRF_802154_DPPI_TIMER_START 21U
+#endif
+
+/**
+ * @def NRF_802154_DPPI_RADIO_TXEN
+ *
+ * The DPPI channel that is used to trigger RADIO's TXEN task
+ * in the scenario where short CCAIDLE_TXEN is not used.
+ * Used only when @ref NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is non-zero.
+ *
+ */
+#ifndef NRF_802154_DPPI_RADIO_TXEN
+#define NRF_802154_DPPI_RADIO_TXEN       20U
+#endif
+
+#define NRF_802154_DPPI_TIMER_START_MASK (1U << NRF_802154_DPPI_TIMER_START)
+#define NRF_802154_DPPI_RADIO_TXEN_MASK  (1U << NRF_802154_DPPI_RADIO_TXEN)
+
+#else
+
+#define NRF_802154_DPPI_TIMER_START_MASK 0U
+#define NRF_802154_DPPI_RADIO_TXEN_MASK  0U
+
+#endif /* (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0) || defined(__DOXYGEN__) */
+
 /**
  * @def NRF_802154_DPPI_RADIO_CCAIDLE
  *
@@ -275,6 +336,8 @@ extern "C" {
         (1UL << NRF_802154_DPPI_EGU_TO_RADIO_RAMP_UP) |        \
         (1UL << NRF_802154_DPPI_TIMER_COMPARE_TO_RADIO_TXEN) | \
         (1UL << NRF_802154_DPPI_RADIO_SYNC_TO_EGU_SYNC) |      \
+        (NRF_802154_DPPI_TIMER_START_MASK) |                   \
+        (NRF_802154_DPPI_RADIO_TXEN_MASK) |                    \
         (1UL << NRF_802154_DPPI_RADIO_CCAIDLE) |               \
         (1UL << NRF_802154_DPPI_RADIO_CCABUSY) |               \
         (1UL << NRF_802154_DPPI_RADIO_HW_TRIGGER) |            \

--- a/nrf_802154/driver/src/nrf_802154_procedures_duration.h
+++ b/nrf_802154/driver/src/nrf_802154_procedures_duration.h
@@ -50,7 +50,14 @@
 #define RX_RAMP_UP_TIME                   40 // us
 #define RX_RAMP_DOWN_TIME                 0  // us
 #define MAX_RAMP_DOWN_TIME                6  // us
-#define RX_TX_TURNAROUND_TIME             20 // us
+#if defined(NRF54L_SERIES)
+#define RX_TX_TURNAROUND_TIME_HW          15 // us
+#else
+#define RX_TX_TURNAROUND_TIME_HW          20 // us
+#endif
+
+#define RX_TX_TURNAROUND_TIME             (RX_TX_TURNAROUND_TIME_HW + \
+                                           NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US)
 
 #define A_CCA_DURATION_SYMBOLS            8  // sym
 #define A_TURNAROUND_TIME_SYMBOLS         12 // sym

--- a/nrf_802154/driver/src/nrf_802154_trx_ppi.c
+++ b/nrf_802154/driver/src/nrf_802154_trx_ppi.c
@@ -136,6 +136,24 @@ void nrf_802154_trx_ppi_for_ramp_up_set(nrf_radio_task_t                      ra
     nrf_802154_log_function_exit(NRF_802154_LOG_VERBOSITY_HIGH);
 }
 
+void nrf_802154_trx_ppi_for_txframe_ramp_up_set(
+    bool                                  cca,
+    nrf_802154_trx_ramp_up_trigger_mode_t trigg_mode)
+{
+    nrf_802154_log_function_enter(NRF_802154_LOG_VERBOSITY_HIGH);
+
+    nrf_802154_trx_ppi_for_ramp_up_set(
+        cca ? NRF_RADIO_TASK_RXEN : NRF_RADIO_TASK_TXEN,
+        trigg_mode,
+        false);
+
+#if (NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US != 0)
+#error NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is unsupported for the selected SoC
+#endif
+
+    nrf_802154_log_function_exit(NRF_802154_LOG_VERBOSITY_HIGH);
+}
+
 void nrf_802154_trx_ppi_for_extra_cca_attempts_set(void)
 {
     nrf_802154_log_function_enter(NRF_802154_LOG_VERBOSITY_HIGH);
@@ -184,6 +202,15 @@ void nrf_802154_trx_ppi_for_ramp_up_clear(nrf_radio_task_t ramp_up_task, bool st
     }
 
     nrf_ppi_channel_remove_from_group(NRF_PPI, PPI_EGU_RAMP_UP, PPI_CHGRP_RAMP_UP);
+
+    nrf_802154_log_function_exit(NRF_802154_LOG_VERBOSITY_HIGH);
+}
+
+void nrf_802154_trx_ppi_for_txframe_ramp_up_clear(bool cca)
+{
+    nrf_802154_log_function_enter(NRF_802154_LOG_VERBOSITY_HIGH);
+
+    nrf_802154_trx_ppi_for_ramp_up_clear(cca ? NRF_RADIO_TASK_RXEN : NRF_RADIO_TASK_TXEN, false);
 
     nrf_802154_log_function_exit(NRF_802154_LOG_VERBOSITY_HIGH);
 }

--- a/nrf_802154/driver/src/nrf_802154_trx_ppi_api.h
+++ b/nrf_802154/driver/src/nrf_802154_trx_ppi_api.h
@@ -111,6 +111,16 @@ void nrf_802154_trx_ppi_for_ramp_up_set(nrf_radio_task_t                      ra
                                         bool                                  start_timer);
 
 /**
+ * @brief Set (D)PPIs to connect trigger event with tasks needed to ramp up for a transmission of a frame.
+ *
+ * @param[in] cca         Transmission with preceding CCA operation.
+ * @param[in] trigg_mode  Trigger mode the connections must conform to.
+ */
+void nrf_802154_trx_ppi_for_txframe_ramp_up_set(
+    bool                                  cca,
+    nrf_802154_trx_ramp_up_trigger_mode_t trigg_mode);
+
+/**
  * @brief Set (D)PPIs to perform CCA procedures back-to-back.
  */
 void nrf_802154_trx_ppi_for_extra_cca_attempts_set(void);
@@ -133,6 +143,15 @@ void nrf_802154_trx_ppi_for_ramp_up_reconfigure(void);
  * @param[in]  start_timer   If timer start on RADIO DISABLED event is to be deconfigured as well. See @ref nrf_802154_trx_ppi_for_ramp_up_set.
  */
 void nrf_802154_trx_ppi_for_ramp_up_clear(nrf_radio_task_t ramp_up_task, bool start_timer);
+
+/**
+ * @brief Clear (D)PPIs that are configured for ramp up procedure for a transmission of a frame.
+ *
+ * @note Complementary to @ref nrf_802154_trx_ppi_for_txframe_ramp_up_set.
+ *
+ * @param cca   Transmission with preceding CCA operation.
+ */
+void nrf_802154_trx_ppi_for_txframe_ramp_up_clear(bool cca);
 
 /**
  * @brief Clear (D)PPIs to perform CCA procedures back-to-back.

--- a/nrf_802154/zephyr/Kconfig.nrfxlib
+++ b/nrf_802154/zephyr/Kconfig.nrfxlib
@@ -58,4 +58,17 @@ endif # NRF_802154_SL
 
 endif # NRF_802154_RADIO_DRIVER
 
+if NRF_802154_RADIO_DRIVER || NRF_802154_SERIALIZATION
+
+config NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US
+	int "Additional delay between triggering the TXEN task after the CCAIDLE event."
+	default 5 if SOC_COMPATIBLE_NRF54LX && MPSL_FEM_NRF2220
+	default 0
+	help
+	  Value of this option is passed to the `NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US`
+	  configuration macro of the nRF 802.15.4 Radio Driver.
+	  Please refer to the documentation of that macro.
+
+endif # NRF_802154_RADIO_DRIVER || NRF_802154_SERIALIZATION
+
 orsource "../internal/Kconfig.nrfxlib"


### PR DESCRIPTION
The Kconfig NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is introduced. Default value set to 5us for nRF2220 FEM.