### PR TITLE
ci: fix compliance by updating actions/cache

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-doc-pip


### PR DESCRIPTION
The actions/cache@v1 is deprecated. Update to actions/cache@v4.