### PR TITLE
ci: remove Sidewalk from test-spec

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -172,12 +172,6 @@
       - "!crypto/doc/**/*"
       - "!crypto/*.rst"
 
-"CI-sidewalk-test":
-  - any:
-      - "crypto/**/*"
-      - "!crypto/doc/**/*"
-      - "!crypto/*.rst"
-
 "CI-audio-test":
   - "lc3/**/*"
   - "softdevice_controller/CMakeLists.txt"


### PR DESCRIPTION
Sidewalk becomes NCS Add-on.
There is no need to trigger Sidewalk tests.