### PR TITLE
nrf_rpc: add protocols serialization team as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,7 +42,7 @@ doc/*                                     @b-gent
 /nrf_security/                            @frkv @tejlmand
 /openthread/                              @lmaciejonczyk @edmont @canisLupus1313
 /zephyr/                                  @carlescufi
-/nrf_rpc/                                 @doki-nordic @KAGA164
+/nrf_rpc/                                 @doki-nordic @KAGA164 @nrfconnect/ncs-protocols-serialization
 /nrf_dm/                                  @Tschet1 @eriksandgren
 /lc3/                                     @koffes @alexsven
 /nrf_fuel_gauge/                          @nordic-auko


### PR DESCRIPTION
Add protocols serialization team as nRF RPC code owner.