### PR TITLE
nrf_802154: move NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US

### DIFF
--- a/nrf_802154/CMakeLists.txt
+++ b/nrf_802154/CMakeLists.txt
@@ -35,13 +35,6 @@
 add_library(nrf-802154-driver-interface INTERFACE)
 add_library(nrf-802154-serialization-interface INTERFACE)
 
-if (CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)
-  target_compile_definitions(zephyr-802154-interface
-    INTERFACE
-      NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US=${CONFIG_NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US}
-  )
-endif()
-
 add_subdirectory(common)
 
 add_subdirectory(driver)


### PR DESCRIPTION
The setting of NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US is moved to sdk-nrf, for consistency with other configuration options and to fix compile errors in upstream Zephyr.