### PR TITLE
[Backport v3.0-branch] nrf_802154: remove extraneous parentheses as those are not needed

### DIFF
--- a/nrf_802154/driver/src/mac_features/nrf_802154_delayed_trx.c
+++ b/nrf_802154/driver/src/mac_features/nrf_802154_delayed_trx.c
@@ -184,7 +184,7 @@ static dly_op_data_t * dly_rx_data_by_id_search(rsch_dly_ts_id_t id)
         if (m_dly_rx_data[i].id == id)
         {
             // Slot with a matching identifier found
-            if ((p_dly_op_data == NULL))
+            if (p_dly_op_data == NULL)
             {
                 // It's the first matching slot found
                 p_dly_op_data = &m_dly_rx_data[i];


### PR DESCRIPTION
Backport 864943e7301aa90eb684829f10905e910e844f18 from #1715.