### PR TITLE
nrf_modem: add invalid_sec_tag value

### DIFF
--- a/nrf_modem/include/nrf_socket.h
+++ b/nrf_modem/include/nrf_socket.h
@@ -780,6 +780,9 @@ struct nrf_ifaddrs {
  */
 typedef uint32_t nrf_sec_tag_t;
 
+/** Placeholder value for security tags. Needed for various checks in SDK code. */
+#define NRF_SEC_TAG_INVALID 0xFFFFFFFF
+
 /** @} */
 
 /**


### PR DESCRIPTION
Define a placeholder value for the sec tag type.