### PR TITLE
nrf_rpc: Declare packet_validate as unused

### DIFF
--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -363,7 +363,7 @@ static int group_init_send(const struct nrf_rpc_group *group)
 	return send(group, tx_buf, NRF_RPC_HEADER_SIZE + len);
 }
 
-static inline bool packet_validate(const uint8_t *packet)
+static inline __attribute__((unused)) bool packet_validate(const uint8_t *packet)
 {
 	uintptr_t addr = (uintptr_t)packet;
 	/* Checking NULL may be sometimes not enough, because pointer can be


### PR DESCRIPTION
Since the NRF_RPC_ASSERT macro is not enabled, clang complains about the function being unused.