### PR TITLE
cmake: update nrfxlib_calculate_lib_path case for nrf54lm20a and nrf54lv10a

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -48,9 +48,9 @@ function(nrfxlib_calculate_lib_path lib_path)
       set(arch_soc_dir ${arch_soc_dir}_cpuapp)
     elseif(DEFINED CONFIG_SOC_NRF5340_CPUNET)
       set(arch_soc_dir ${arch_soc_dir}_cpunet)
-    elseif(DEFINED CONFIG_SOC_NRF54L15_CPUAPP OR DEFINED CONFIG_SOC_NRF54L20_ENGA_CPUAPP
+    elseif(DEFINED CONFIG_SOC_NRF54L15_CPUAPP OR DEFINED CONFIG_SOC_NRF54LM20A_ENGA_CPUAPP
           OR DEFINED CONFIG_SOC_NRF54L10_CPUAPP OR DEFINED CONFIG_SOC_NRF54L05_CPUAPP
-          OR DEFINED CONFIG_SOC_NRF54L09_ENGA_CPUAPP)
+          OR DEFINED CONFIG_SOC_NRF54LV10A_ENGA_CPUAPP)
       set(arch_soc_dir ${arch_soc_dir}_cpuapp)
       if(DEFINED CONFIG_TRUSTED_EXECUTION_NONSECURE AND ${CALC_LIB_PATH_NS_PROVIDED})
         set(arch_soc_dir ${arch_soc_dir}_ns)


### PR DESCRIPTION
Updates the cmake defines used to calculate the path with the naming change.