### PR TITLE
nrf_rpc: remove decoding_done_required

### DIFF
--- a/nrf_rpc/include/nrf_rpc_cbor.h
+++ b/nrf_rpc/include/nrf_rpc_cbor.h
@@ -49,7 +49,6 @@ typedef void (*nrf_rpc_cbor_handler_t)(const struct nrf_rpc_group *group,
 struct _nrf_rpc_cbor_decoder {
 	nrf_rpc_cbor_handler_t handler;
 	void *handler_data;
-	bool decoding_done_required;
 };
 
 /** @brief Context for encoding and sending commands, events and responses.
@@ -79,7 +78,6 @@ struct nrf_rpc_cbor_ctx {
 	struct _nrf_rpc_cbor_decoder NRF_RPC_CONCAT(_name, _cbor_data) = {     \
 		.handler = _handler,					       \
 		.handler_data = _data,					       \
-		.decoding_done_required = true,				       \
 	};								       \
 	NRF_RPC_CMD_DECODER(_group, _name, _cmd, _nrf_rpc_cbor_proxy_handler,  \
 			    (void *)&NRF_RPC_CONCAT(_name, _cbor_data))
@@ -98,7 +96,6 @@ struct nrf_rpc_cbor_ctx {
 	struct _nrf_rpc_cbor_decoder NRF_RPC_CONCAT(_name, _cbor_data) = {     \
 		.handler = _handler,					       \
 		.handler_data = _data,					       \
-		.decoding_done_required = true,				       \
 	};								       \
 	NRF_RPC_EVT_DECODER(_group, _name, _evt, _nrf_rpc_cbor_proxy_handler,  \
 			    (void *)&NRF_RPC_CONCAT(_name, _cbor_data))

--- a/nrf_rpc/nrf_rpc_cbor.c
+++ b/nrf_rpc/nrf_rpc_cbor.c
@@ -34,7 +34,6 @@ int nrf_rpc_cbor_cmd(const struct nrf_rpc_group *group, uint8_t cmd,
 	const struct _nrf_rpc_cbor_decoder cbor_handler = {
 		.handler = handler,
 		.handler_data = handler_data,
-		.decoding_done_required = false,
 	};
 
 	if (!zcbor_nil_put(ctx->zs, NULL)) {


### PR DESCRIPTION
Optimize _nrf_rpc_cbor_decoder structure size by removing unused decoding_done_required member. This saves 4B of flash per command decoder.