### PR TITLE
nrf_rpc: implement timeout for response

### DIFF
--- a/nrf_rpc/CHANGELOG.rst
+++ b/nrf_rpc/CHANGELOG.rst
@@ -9,6 +9,18 @@ Changelog
 
 All the notable changes to this project are documented on this page.
 
+nRF Connect SDK v3.0.99
+***********************
+
+Added
+=====
+
+* Added a timeout feature for awaiting command responses.
+  This change required making the following changes to the nRF RPC OS abstraction layer:
+
+  * Introduced the :c:struct:`nrf_rpc_os_mutex` structure to protect the nRF RPC thread-local context.
+  * Updated the :c:func:`nrf_rpc_os_msg_get` function to unlock the thread-local context mutex and to allow returning no data from the function if a timeout occurs.
+
 nRF Connect SDK v2.8.0
 **********************
 


### PR DESCRIPTION
Introduce necessary changes to support timing out waiting for a command response:
1. Handle nrf_rpc_os_msg_get() returning null data pointer, indicating that the response has not arrived within the required maximum time.
2. Introduce context mutex to protect all context members. This is necessary because now the response may arrive after the initiating thread has already released the context.

Note that 2 may not sufficient solution to address another scenario where the context is freed by the initiator but is then reused before a delayed response arrives - to solve this, we likely need to introduce the concept of session ID or conversation ID to detect outdated packets.

manifest-pr-skip