### PR TITLE
nfc: align the T2T and T4T Kconfig options with DTS node status

### DIFF
--- a/nfc/Kconfig
+++ b/nfc/Kconfig
@@ -1,11 +1,13 @@
 #
-# Copyright (c) 2018 Nordic Semiconductor
+# Copyright (c) 2018-2025 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 config NFC_T2T_NRFXLIB
 	bool "Enable NFC Type 2 Tag library"
+	depends on HAS_HW_NRF_NFCT
 
 config NFC_T4T_NRFXLIB
 	bool "Enable NFC Type 4 Tag library"
+	depends on HAS_HW_NRF_NFCT


### PR DESCRIPTION
Aligned the availability of the NFC_T2T_NRFXLIB and NFC_T4T_NRFXLIB Kconfig options with the status of the nfct DTS node.