### PR TITLE
mpsl: Update default location for bsim libraries

### DIFF
--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -36,9 +36,9 @@ config MPSL_LIB_DIR
 	default "nrf54l_ns" if SOC_SERIES_NRF54LX && TRUSTED_EXECUTION_NONSECURE
 	default "nrf54l" if SOC_SERIES_NRF54LX && !TRUSTED_EXECUTION_NONSECURE
 	default "nrf71" if SOC_SERIES_NRF71X
-	default "bsim_nrf52" if SOC_SERIES_BSIM_NRF52X
-	default "bsim_nrf53" if SOC_SERIES_BSIM_NRF53X
-	default "bsim_nrf54l" if SOC_SERIES_BSIM_NRF54LX
+	default "nrf52_bsim" if SOC_SERIES_BSIM_NRF52X
+	default "nrf53_bsim" if SOC_SERIES_BSIM_NRF53X
+	default "nrf54l_bsim" if SOC_SERIES_BSIM_NRF54LX
 	help
 	  Hidden helper option to calculate the library path
 


### PR DESCRIPTION
The folder name has changed.
Jira-ref: DRGN-21945.

manifest-pr-skip