### PR TITLE
nrf_802154: add ncs-radio-sw team as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,7 +38,7 @@ doc/*                                     @b-gent
 /gzll/                                    @leewkb4567
 /mpsl/                                    @nrfconnect/ncs-dragoon
 /nfc/                                     @anangl @grochu @KAGA164
-/nrf_802154/                              @ankuns @piotrkoziar
+/nrf_802154/                              @nrfconnect/ncs-radio-sw
 /nrf_security/                            @frkv @tejlmand
 /openthread/                              @lmaciejonczyk @edmont @canisLupus1313
 /zephyr/                                  @carlescufi


### PR DESCRIPTION
Adds ncs-radio-sw team as codeowner.

See https://github.com/orgs/nrfconnect/teams/ncs-radio-sw.