### PR TITLE
CODEOWNERS: Update nrf_modem codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,7 +33,7 @@ doc/*                                     @b-gent
 /.github/                                 @thst-nordic
 /.github/test-spec.yml                    @nrfconnect/ncs-test-leads
 /softdevice_controller/                   @nrfconnect/ncs-dragoon
-/nrf_modem/                               @rlubos @lemrey
+/nrf_modem/                               @nrfconnect/ncs-co-networking @nrfconnect/ncs-modem
 /crypto/                                  @frkv @tejlmand
 /gzll/                                    @leewkb4567
 /mpsl/                                    @nrfconnect/ncs-dragoon


### PR DESCRIPTION
Replace the single user lemrey with a team (ncs-modem).
See https://github.com/orgs/nrfconnect/teams/ncs-modem.

Replace the single user rlubos with a team (ncs-co-networking).
See https://github.com/orgs/nrfconnect/teams/ncs-co-networking.

Signed-off-by: Håvard Vermeer <havard.vermeer@nordicsemi.no>