### PR TITLE
rpc: fix for running out of buffers in thread coap communication

### DIFF
--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -799,6 +799,11 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 			goto cleanup_and_exit;
 
 		} else {
+
+			if (auto_free_rx_buf(transport)) {
+				nrf_rpc_os_event_reset(&group->data->decode_done_event);
+			}
+
 			nrf_rpc_os_msg_set(&cmd_ctx->recv_msg, packet, len);
 			nrf_rpc_os_mutex_unlock(&cmd_ctx->mutex);
 
@@ -810,7 +815,15 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 		return;
 
 	case NRF_RPC_PACKET_TYPE_EVT:
-		/* or NRF_RPC_PACKET_TYPE_CMD with unknown destination. */
+		/*
+		 * Reset before dispatch so synchronous nrf_rpc_os_thread_pool_send()
+		 * implementations (e.g. unit tests) cannot signal decode_done_event
+		 * before we clear it, which would deadlock on the subsequent wait.
+		 */
+		if (auto_free_rx_buf(transport)) {
+			nrf_rpc_os_event_reset(&group->data->decode_done_event);
+		}
+
 		nrf_rpc_os_thread_pool_send(packet, len);
 
 		if (auto_free_rx_buf(transport)) {

--- a/nrf_rpc/template/nrf_rpc_os_tmpl.h
+++ b/nrf_rpc/template/nrf_rpc_os_tmpl.h
@@ -97,6 +97,12 @@ void nrf_rpc_os_event_set(struct nrf_rpc_os_event *event);
  */
 int nrf_rpc_os_event_wait(struct nrf_rpc_os_event *event, int32_t timeout);
 
+/** @brief Reset an event.
+ *
+ * @param event Event to set.
+ */
+void nrf_rpc_os_event_reset(struct nrf_rpc_os_event *event);
+
 /** @brief Initialize mutex structure.
  *
  * @param mutex Pointer to mutex structure.


### PR DESCRIPTION
Resetting an event in case it was already set.