### PR TITLE
test-spec: Add CI-ble-host-test to test-spec.yml

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -36,6 +36,12 @@
   - "mpsl/include/**/*"
   - "mpsl/lib/**/*"
 
+"CI-ble-host-test":
+  - "softdevice_controller/include/**/*"
+  - "softdevice_controller/lib/**/*"
+  - "mpsl/include/**/*"
+  - "mpsl/lib/**/*"
+
 "CI-ble-samples-test":
   - "softdevice_controller/include/**/*"
   - "softdevice_controller/lib/**/*"


### PR DESCRIPTION
Adding triggered for NCS Ble Host tests.

Needed for https://github.com/nrfconnect/sdk-nrf/pull/27863