### PR TITLE
nrf_rpc: allow more verbose error info

### DIFF
--- a/nrf_rpc/Kconfig
+++ b/nrf_rpc/Kconfig
@@ -77,4 +77,10 @@ config NRF_RPC_COMMAND_TIME_MEASURE
 	  and log the value. Time measured includes the transmission and reception
 	  time. Log level for the time measurement is CONFIG_NRF_RPC_LOG_LEVEL_INF.
 
+config NRF_RPC_DETAILED_ERROR_REPORTING
+	bool "Detailed error reporting"
+	help
+	  When enabled, nRF RPC will provide more detailed error information
+	  for debugging purposes.
+
 endif # NRF_RPC

--- a/nrf_rpc/include/nrf_rpc.h
+++ b/nrf_rpc/include/nrf_rpc.h
@@ -169,6 +169,15 @@ struct nrf_rpc_err_report {
 	 * if packet is malformed.
 	 */
 	enum nrf_rpc_packet_type packet_type;
+
+	/** @brief File where the error was reported. */
+	const char *file;
+
+	/** @brief Line number where the error was reported. */
+	int line;
+
+	/** @brief Function where the error was reported. */
+	const char *func;
 };
 
 /** @brief Cleanup procedure list element.
@@ -613,6 +622,29 @@ void nrf_rpc_decoding_done(const struct nrf_rpc_group *group, const uint8_t *pac
 void nrf_rpc_err(int code, enum nrf_rpc_err_src src,
 		 const struct nrf_rpc_group *group, uint8_t id,
 		 uint8_t packet_type);
+
+/** @brief Report an error to nRF RPC error handler.
+ *
+ * This function includes additional debug data.
+ *
+ * @param code        Negative error code.
+ * @param src         Source of error.
+ * @param group       Group where error happens or NULL if unknown.
+ * @param id          Command or event id which caused the error or
+ *                    @ref NRF_RPC_ID_UNKNOWN if unknown.
+ * @param packet_type Type of packet related to this error.
+ * @param file        File where error happens.
+ * @param line        Line number where error happens.
+ * @param func        Function where error happens.
+ */
+void nrf_rpc_err_impl(int code, enum nrf_rpc_err_src src,
+	const struct nrf_rpc_group *group, uint8_t id,
+	uint8_t packet_type, const char *file, int line, const char *func);
+
+#ifdef CONFIG_NRF_RPC_DETAILED_ERROR_REPORTING
+#define nrf_rpc_err(_code, _src, _group, _id, _packet_type) \
+	nrf_rpc_err_impl(_code, _src, _group, _id, _packet_type, __FILE__, __LINE__, __func__)
+#endif
 
 /** @brief Allocates buffer for a packet.
  *

--- a/nrf_rpc/include/nrf_rpc_cbor.h
+++ b/nrf_rpc/include/nrf_rpc_cbor.h
@@ -192,6 +192,16 @@ void nrf_rpc_cbor_cmd_no_err(const struct nrf_rpc_group *group, uint8_t cmd,
 			     nrf_rpc_cbor_handler_t handler,
 			     void *handler_data);
 
+void nrf_rpc_cbor_cmd_no_err_impl(const struct nrf_rpc_group *group, uint8_t cmd,
+			     struct nrf_rpc_cbor_ctx *ctx,
+			     nrf_rpc_cbor_handler_t handler,
+			     void *handler_data, const char *file, int line, const char *func);
+
+#ifdef CONFIG_NRF_RPC_DETAILED_ERROR_REPORTING
+#define nrf_rpc_cbor_cmd_no_err(_group, _cmd, _ctx, _handler, _handler_data) \
+	nrf_rpc_cbor_cmd_no_err_impl(_group, _cmd, _ctx, _handler, _handler_data, __FILE__, __LINE__, __func__)
+#endif
+
 /** @brief Send a command, get response as an output parameter and pass any
  * error to an error handler.
  *
@@ -204,6 +214,15 @@ void nrf_rpc_cbor_cmd_no_err(const struct nrf_rpc_group *group, uint8_t cmd,
  */
 void nrf_rpc_cbor_cmd_rsp_no_err(const struct nrf_rpc_group *group,
 				 uint8_t cmd, struct nrf_rpc_cbor_ctx *ctx);
+
+void nrf_rpc_cbor_cmd_rsp_no_err_impl(const struct nrf_rpc_group *group,
+				 uint8_t cmd, struct nrf_rpc_cbor_ctx *ctx,
+				 const char *file, int line, const char *func);
+
+#ifdef CONFIG_NRF_RPC_DETAILED_ERROR_REPORTING
+#define nrf_rpc_cbor_cmd_rsp_no_err(_group, _cmd, _ctx) \
+	nrf_rpc_cbor_cmd_rsp_no_err_impl(_group, _cmd, _ctx, __FILE__, __LINE__, __func__)
+#endif
 
 /** @brief Send an event.
  *
@@ -230,6 +249,15 @@ int nrf_rpc_cbor_evt(const struct nrf_rpc_group *group, uint8_t evt,
 void nrf_rpc_cbor_evt_no_err(const struct nrf_rpc_group *group, uint8_t evt,
 			     struct nrf_rpc_cbor_ctx *ctx);
 
+void nrf_rpc_cbor_evt_no_err_impl(const struct nrf_rpc_group *group, uint8_t evt,
+			     struct nrf_rpc_cbor_ctx *ctx,
+			     const char *file, int line, const char *func);
+
+#ifdef CONFIG_NRF_RPC_DETAILED_ERROR_REPORTING
+#define nrf_rpc_cbor_evt_no_err(_group, _evt, _ctx) \
+	nrf_rpc_cbor_evt_no_err_impl(_group, _evt, _ctx, __FILE__, __LINE__, __func__)
+#endif
+
 /** @brief Send a response.
  *
  * @param group  Group that response belongs to.
@@ -250,6 +278,14 @@ int nrf_rpc_cbor_rsp(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx 
  * @param ctx    Context allocated by @ref NRF_RPC_CBOR_ALLOC.
  */
 void nrf_rpc_cbor_rsp_no_err(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx);
+
+void nrf_rpc_cbor_rsp_no_err_impl(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
+			     const char *file, int line, const char *func);
+
+#ifdef CONFIG_NRF_RPC_DETAILED_ERROR_REPORTING
+#define nrf_rpc_cbor_rsp_no_err(_group, _ctx) \
+	nrf_rpc_cbor_rsp_no_err_impl(_group, _ctx, __FILE__, __LINE__, __func__)
+#endif
 
 /** @brief Indicate that decoding of the input packet is done.
  *

--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -14,6 +14,10 @@
 #include "nrf_rpc_tr.h"
 #include "nrf_rpc_os.h"
 
+#ifdef nrf_rpc_err
+#undef nrf_rpc_err
+#endif
+
 #if defined(__GNUC__)
 /* Content of "NRF_RPC_AUTO_ARR" arrays are added by the linker script,
  * so the compiler should ignore any out of bounds warnings.
@@ -1360,10 +1364,12 @@ void nrf_rpc_cmd_rsp_no_err(const struct nrf_rpc_group *group, uint8_t cmd,
 				  rsp_len);
 }
 
-/** Report an error that cannot be reported as a function return value */
-void nrf_rpc_err(int code, enum nrf_rpc_err_src src,
+/** Report an error that cannot be reported as a function return value
+ This function is used to report errors with debug information.
+*/
+void nrf_rpc_err_impl(int code, enum nrf_rpc_err_src src,
 		 const struct nrf_rpc_group *group, uint8_t id,
-		 uint8_t packet_type)
+		 uint8_t packet_type, const char *file, int line, const char *func)
 {
 	struct nrf_rpc_err_report report;
 	uint8_t src_group_id = (group != NULL) ? group->data->src_group_id :
@@ -1376,6 +1382,9 @@ void nrf_rpc_err(int code, enum nrf_rpc_err_src src,
 		    (src == NRF_RPC_ERR_SRC_SEND) ? "on send" : "from remote",
 		    code, (group != NULL) ? group->strid : "unknown", id,
 		    packet_type);
+	if (file != NULL) {
+		NRF_RPC_ERR("at %s:%d (%s)", file, line, func);
+	}
 
 	if ((src == NRF_RPC_ERR_SRC_RECV) && group) {
 		simple_send(group, packet_type, NRF_RPC_PACKET_TYPE_ERR, id, src_group_id,
@@ -1387,6 +1396,9 @@ void nrf_rpc_err(int code, enum nrf_rpc_err_src src,
 	report.group = group;
 	report.id = id;
 	report.packet_type = packet_type;
+	report.file = file;
+	report.line = line;
+	report.func = func;
 
 	if (group != NULL && group->err_handler != NULL) {
 		group->err_handler(&report);
@@ -1395,6 +1407,14 @@ void nrf_rpc_err(int code, enum nrf_rpc_err_src src,
 	if (global_err_handler != NULL) {
 		global_err_handler(&report);
 	}
+}
+
+/** Report an error that cannot be reported as a function return value */
+void nrf_rpc_err(int code, enum nrf_rpc_err_src src,
+		 const struct nrf_rpc_group *group, uint8_t id,
+		 uint8_t packet_type)
+{
+	nrf_rpc_err_impl(code, src, group, id, packet_type, NULL, 0, NULL);
 }
 
 void nrf_rpc_alloc_tx_buf(const struct nrf_rpc_group *group, uint8_t **buf, size_t len)

--- a/nrf_rpc/nrf_rpc_cbor.c
+++ b/nrf_rpc/nrf_rpc_cbor.c
@@ -13,6 +13,11 @@
 #include <nrf_rpc_cbor.h>
 #include <nrf_rpc_common.h>
 
+#undef nrf_rpc_cbor_cmd_no_err
+#undef nrf_rpc_cbor_cmd_rsp_no_err
+#undef nrf_rpc_cbor_evt_no_err
+#undef nrf_rpc_cbor_rsp_no_err
+
 /* Maximum RPC parameters that can be passed */
 #define NRF_RPC_MAX_PARAMETERS 255
 
@@ -75,32 +80,44 @@ int nrf_rpc_cbor_cmd_rsp(const struct nrf_rpc_group *group, uint8_t cmd,
 	return err;
 }
 
+static void check_send_err(int err, const struct nrf_rpc_group *group, uint8_t id, uint8_t packet_type, const char *file, int line, const char *func)
+{
+	if (err < 0) {
+		NRF_RPC_ERR("Unhandled command send error %d", err);
+		nrf_rpc_err_impl(err, NRF_RPC_ERR_SRC_SEND, group, id, packet_type, file, line, func);
+	}
+}
+
+void nrf_rpc_cbor_cmd_no_err_impl(const struct nrf_rpc_group *group, uint8_t cmd,
+			     struct nrf_rpc_cbor_ctx *ctx,
+			     nrf_rpc_cbor_handler_t handler,
+			     void *handler_data,
+			     const char *file, int line, const char *func)
+{
+	check_send_err(nrf_rpc_cbor_cmd(group, cmd, ctx, handler, handler_data),
+		       group, cmd, NRF_RPC_PACKET_TYPE_CMD, file, line, func);
+}
+
 void nrf_rpc_cbor_cmd_no_err(const struct nrf_rpc_group *group, uint8_t cmd,
 			     struct nrf_rpc_cbor_ctx *ctx,
 			     nrf_rpc_cbor_handler_t handler,
 			     void *handler_data)
 {
-	int err;
+	nrf_rpc_cbor_cmd_no_err_impl(group, cmd, ctx, handler, handler_data, NULL, 0, NULL);
+}
 
-	err = nrf_rpc_cbor_cmd(group, cmd, ctx, handler, handler_data);
-	if (err < 0) {
-		NRF_RPC_ERR("Unhandled command send error %d", err);
-		nrf_rpc_err(err, NRF_RPC_ERR_SRC_SEND, group, cmd,
-			    NRF_RPC_PACKET_TYPE_CMD);
-	}
+void nrf_rpc_cbor_cmd_rsp_no_err_impl(const struct nrf_rpc_group *group, uint8_t cmd,
+				 struct nrf_rpc_cbor_ctx *ctx,
+				 const char *file, int line, const char *func)
+{
+	check_send_err(nrf_rpc_cbor_cmd_rsp(group, cmd, ctx),
+		       group, cmd, NRF_RPC_PACKET_TYPE_CMD, file, line, func);
 }
 
 void nrf_rpc_cbor_cmd_rsp_no_err(const struct nrf_rpc_group *group, uint8_t cmd,
 				 struct nrf_rpc_cbor_ctx *ctx)
 {
-	int err;
-
-	err = nrf_rpc_cbor_cmd_rsp(group, cmd, ctx);
-	if (err < 0) {
-		NRF_RPC_ERR("Unhandled command send error %d", err);
-		nrf_rpc_err(err, NRF_RPC_ERR_SRC_SEND, group, cmd,
-			    NRF_RPC_PACKET_TYPE_CMD);
-	}
+	nrf_rpc_cbor_cmd_rsp_no_err_impl(group, cmd, ctx, NULL, 0, NULL);
 }
 
 int nrf_rpc_cbor_evt(const struct nrf_rpc_group *group, uint8_t evt,
@@ -119,18 +136,18 @@ int nrf_rpc_cbor_evt(const struct nrf_rpc_group *group, uint8_t evt,
 	return nrf_rpc_evt(group, evt, ctx->out_packet, len);
 }
 
+void nrf_rpc_cbor_evt_no_err_impl(const struct nrf_rpc_group *group, uint8_t evt,
+			     struct nrf_rpc_cbor_ctx *ctx,
+			     const char *file, int line, const char *func)
+{
+	check_send_err(nrf_rpc_cbor_evt(group, evt, ctx),
+		       group, evt, NRF_RPC_PACKET_TYPE_EVT, file, line, func);
+}
+
 void nrf_rpc_cbor_evt_no_err(const struct nrf_rpc_group *group, uint8_t evt,
 			     struct nrf_rpc_cbor_ctx *ctx)
 {
-	int err;
-
-	err = nrf_rpc_cbor_evt(group, evt, ctx);
-	if (err < 0) {
-		NRF_RPC_ERR("Unhandled command send error %d", err);
-		nrf_rpc_err(err, NRF_RPC_ERR_SRC_SEND, group, evt,
-			    NRF_RPC_PACKET_TYPE_EVT);
-	}
-
+	nrf_rpc_cbor_evt_no_err_impl(group, evt, ctx, NULL, 0, NULL);
 }
 
 int nrf_rpc_cbor_rsp(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx)
@@ -148,17 +165,16 @@ int nrf_rpc_cbor_rsp(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx 
 	return nrf_rpc_rsp(group, ctx->out_packet, len);
 }
 
+void nrf_rpc_cbor_rsp_no_err_impl(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx,
+			     const char *file, int line, const char *func)
+{
+	check_send_err(nrf_rpc_cbor_rsp(group, ctx),
+		       group, NRF_RPC_ID_UNKNOWN, NRF_RPC_PACKET_TYPE_RSP, file, line, func);
+}
+
 void nrf_rpc_cbor_rsp_no_err(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx)
 {
-	int err;
-
-	err = nrf_rpc_cbor_rsp(group, ctx);
-	if (err < 0) {
-		NRF_RPC_ERR("Unhandled command send error %d", err);
-		nrf_rpc_err(err, NRF_RPC_ERR_SRC_SEND, group, NRF_RPC_ID_UNKNOWN,
-			    NRF_RPC_PACKET_TYPE_RSP);
-	}
-
+	nrf_rpc_cbor_rsp_no_err_impl(group, ctx, NULL, 0, NULL);
 }
 
 void nrf_rpc_cbor_decoding_done(const struct nrf_rpc_group *group, struct nrf_rpc_cbor_ctx *ctx)


### PR DESCRIPTION
Modified the nrf_rpc error repoting api to provide more detailed error information. This will help in debugging RPC communication related issues. Additional file/function/line number were added to the error description.