### PR TITLE
nrf_modem: `NRF_MODEM_SHMEM_CTRL_SIZE` dependency

### DIFF
--- a/nrf_modem/Kconfig
+++ b/nrf_modem/Kconfig
@@ -45,13 +45,13 @@ config NRF_MODEM_LOG
 	  Links the application with the library version capable of emitting logs.
 	  This increases the final size of the application.
 
-endif # NRF_MODEM
-
 config NRF_MODEM_SHMEM_CTRL_SIZE
 	hex
 	default 0x1000 if (SOC_SERIES_NRF92 && NRF_MODEM_LINK_BINARY_CELLULAR)
 	default 0x728 if (SOC_SERIES_NRF91 && \
 			  (NRF_MODEM_LINK_BINARY_DECT_PHY || NRF_MODEM_LINK_BINARY_DECT))
 	default 0x4e8
+
+endif # NRF_MODEM
 
 endmenu # nrf_modem


### PR DESCRIPTION
Add the `NRF_MODEM` dependency to the `NRF_MODEM_SHMEM_CTRL_SIZE` to ensure the latter is not present in builds unless `NRF_MODEM` is enabled.