### PR TITLE
[Backport v3.4-branch] nrf_modem: Fix copyright notice in DECT header

### DIFF
--- a/nrf_modem/include/nrf_modem_dect.h
+++ b/nrf_modem/include/nrf_modem_dect.h
@@ -1,9 +1,7 @@
 /*
- * Copyright (c) 2026 Nordic Semiconductor ASA. All Rights Reserved.
+ * Copyright (c) 2026 Nordic Semiconductor ASA
  *
- * The information contained herein is confidential property of Nordic Semiconductor ASA.
- * The use, copying, transfer or disclosure of such information is prohibited except by
- * express written agreement with Nordic Semiconductor ASA.
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 /**


### PR DESCRIPTION
Backport e4635cd2f1ebccebb05c9a278d171b87d8c1d64d from #2140.