### PR TITLE
cmake: add option to build NFC Library from sources

### DIFF
--- a/nfc/CMakeLists.txt
+++ b/nfc/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+if(CONFIG_NFC_LIBRARY_SOURCE_NRFXLIB)
+
 nrfxlib_calculate_lib_path(lib_path)
 
 nrfxlib_calculate_lib_path(NFC_LIB_DIR
@@ -33,4 +35,6 @@ endif()
 
 if (NOT CONFIG_NFC_T2T_NRFXLIB AND NOT CONFIG_NFC_T4T_NRFXLIB)
 	message(WARNING "One of CONFIG_NFC_T2T_NRFXLIB or CONFIG_NFC_T4T_NRFXLIB must be specified.")
+endif()
+
 endif()

--- a/nfc/Kconfig
+++ b/nfc/Kconfig
@@ -4,6 +4,18 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+choice NFC_LIBRARY_SOURCE
+	prompt "Source of the NFC Type 2 / Type 4 tag libraries"
+	default NFC_LIBRARY_SOURCE_NRFXLIB
+	help
+	  Prebuilt archives come from sdk-nrfxlib. Internal builds compile the same
+	  API from the nfc-library repository (Zephyr integration).
+
+config NFC_LIBRARY_SOURCE_NRFXLIB
+	bool "Prebuilt (sdk-nrfxlib)"
+
+endchoice
+
 config NFC_T2T_NRFXLIB
 	bool "NFC Type 2 Tag library"
 


### PR DESCRIPTION
Modifies CMake file to handle CONFIG_NFC_LIBRARY_SOURCE_INTERNAL.

See https://projecttools.nordicsemi.no/bitbucket/projects/NRFFOSDK/repos/nfc-library/pull-requests/130/overview for reference.