### PR TITLE
softperipheral: include: add nRF54LM20B symbol

### DIFF
--- a/softperipheral/include/softperipheral_regif.h
+++ b/softperipheral/include/softperipheral_regif.h
@@ -10,7 +10,7 @@
 /* Shared between Host and Service, varies between platforms. */
 #if defined (NRF54L05_XXAA) || defined (NRF54L09_ENGA_XXAA) || defined (NRF54L10_XXAA) || \
     defined (NRF54L15_XXAA) || defined (NRF54LM20A_ENGA_XXAA) ||                          \
-    defined (NRF54LV10A_XXAA) || defined (NRF54LM20A_XXAA)
+    defined (NRF54LV10A_XXAA) || defined (NRF54LM20A_XXAA) || defined (NRF54LM20B_XXAA)
 #define SP_VPR_EVENT_IDX       20
 #define NRF_VPR                NRF_VPR00
 #define SP_VPR_TASK_DPPI_0_IDX 16 // Channel 0


### PR DESCRIPTION
Use dedicated nRF54LM20B symbol for the preprocessor guard.