### PR TITLE
nrf_rpc: Reset decode_done_event so event_wait always works

### DIFF
--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -803,6 +803,10 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 			goto cleanup_and_exit;
 
 		} else {
+			if (auto_free_rx_buf(transport)) {
+				nrf_rpc_os_event_reset(&group->data->decode_done_event);
+			}
+
 			nrf_rpc_os_msg_set(&cmd_ctx->recv_msg, packet, len);
 			nrf_rpc_os_mutex_unlock(&cmd_ctx->mutex);
 
@@ -815,6 +819,10 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 
 	case NRF_RPC_PACKET_TYPE_EVT:
 		/* or NRF_RPC_PACKET_TYPE_CMD with unknown destination. */
+		if (auto_free_rx_buf(transport)) {
+			nrf_rpc_os_event_reset(&group->data->decode_done_event);
+		}
+
 		nrf_rpc_os_thread_pool_send(packet, len);
 
 		if (auto_free_rx_buf(transport)) {

--- a/nrf_rpc/template/nrf_rpc_os_tmpl.h
+++ b/nrf_rpc/template/nrf_rpc_os_tmpl.h
@@ -97,6 +97,12 @@ void nrf_rpc_os_event_set(struct nrf_rpc_os_event *event);
  */
 int nrf_rpc_os_event_wait(struct nrf_rpc_os_event *event, int32_t timeout);
 
+/** @brief Reset an event.
+ *
+ * @param event Event to set.
+ */
+void nrf_rpc_os_event_reset(struct nrf_rpc_os_event *event);
+
 /** @brief Initialize mutex structure.
  *
  * @param mutex Pointer to mutex structure.


### PR DESCRIPTION
If the transport is auto_free_rx_buf then the receive_handler must not return until after the packet has been decoded. Without this patch some code path sets the decode_done_event without a corresponding nrf_rpc_os_event_wait (not necessarily a bug) and then the event_wait stops working as intended.

Depends on nrfconnect/sdk-nrf/pull/29541