### PR TITLE
softperipheral_regif: Add NRF54LM20B_XXAA

### DIFF
--- a/softperipheral/include/softperipheral_regif.h
+++ b/softperipheral/include/softperipheral_regif.h
@@ -10,7 +10,7 @@
 /* Shared between Host and Service, varies between platforms. */
 #if defined (NRF54L05_XXAA) || defined (NRF54L09_ENGA_XXAA) || defined (NRF54L10_XXAA) || \
     defined (NRF54L15_XXAA) || defined (NRF54LM20A_ENGA_XXAA) ||                          \
-    defined (NRF54LV10A_XXAA) || defined (NRF54LM20A_XXAA)
+    defined (NRF54LV10A_XXAA) || defined (NRF54LM20A_XXAA) || defined (NRF54LM20B_XXAA)
 #define SP_VPR_EVENT_IDX       20
 #define NRF_VPR                NRF_VPR00
 #define SP_VPR_TASK_DPPI_0_IDX 16 // Channel 0


### PR DESCRIPTION
Add the NRF54LM20B_XXAA to the list of platforms for which register interface is defined. The commit:

remove nRF54LM20A compatibility symbol from nRF54LM20B

from zephyr PR #: 111155 removed the SOC_COMPATIBLE_NRF54LM20A define so NRF54LM20A_XXAA is no longer defined if the target is nRF54LM20B. This results in no register interface being defined and thus build failing.