### PR TITLE
[Backport v3.4-branch] doc: doc fixes to nrf_modem

### DIFF
--- a/mpsl/doc/radio_notification.rst
+++ b/mpsl/doc/radio_notification.rst
@@ -3,6 +3,10 @@
 Radio notifications
 ###################
 
+.. contents::
+   :local:
+   :depth: 2
+
 The radio notification is a configurable feature that enables ACTIVE and INACTIVE (nACTIVE) signals from the MPSL to indicate when the radio is in use.
 
 Radio notification signals

--- a/nrf_modem/doc/architecture.rst
+++ b/nrf_modem/doc/architecture.rst
@@ -36,7 +36,7 @@ The application can adjust the size of these regions based on its requirements, 
 The base address of all regions must be 4-bytes aligned.
 The library accepts the layout of these regions as parameters to the :c:func:`nrf_modem_init` function through the :c:struct:`nrf_modem_init_params` structure.
 
-For |NCS| users, the Partition Manager will automatically reserve some RAM for each region during linking, according to the size of each region as specified in the glue.
+For |NCS| users, the location and size of these regions can be set and modified using devicetree.
 
 Control area
 ============

--- a/nrf_modem/doc/ug_nrf_modem_porting_os.rst
+++ b/nrf_modem/doc/ug_nrf_modem_porting_os.rst
@@ -90,11 +90,11 @@ The following RAM overview diagram shows the placement of Modem library in the s
 
 Following are the minimum sizes of the regions of the Modem Library:
 
-*  The minimum size of the control region is given in the :file:`nrf_modem_platform.h` file.
-*  The RX/TX sizes are set using the  :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_TX_SIZE` and :kconfig:option:`CONFIG_NRF_MODEM_LIB_SHMEM_RX_SIZE` Kconfig options.
-   The RX/TX must fit the data for the largest command or socket operation executed.
-*  The trace area size can remain zero if traces are not used.
-   If traces are used, refer to :ref:`nrf_modem_trace` for more information on the trace area size.
+* The minimum size of the control region is given in the :file:`nrf_modem_platform.h` file.
+* The locations and sizes of the control, RX, TX, and trace regions are passed on to the modem library inside the ``init_params`` when calling :c:func:`nrf_modem_init`.
+  The RX/TX must fit the data for the largest command or socket operation executed.
+* The trace area size can remain zero if traces are not used.
+  If traces are used, refer to :ref:`nrf_modem_trace` for more information on the trace area size.
 
 Faults and traces
 *****************


### PR DESCRIPTION
Backport f54ad122c6d50739435040b84198d8757d72a82c from #2170.