### PR TITLE
zephyr: Move files from sdk-nrf

### DIFF
--- a/nrf_802154/sl/platform/zephyr/nrf_802154_hp_timer.c
+++ b/nrf_802154/sl/platform/zephyr/nrf_802154_hp_timer.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018 - 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/**
+ * @file
+ *   This file contains implementation of the nRF 802.15.4 high precision timer abstraction.
+ *
+ * This implementation is built on top of the TIMER peripheral.
+ * If SoftDevice RAAL is in use the TIMER peripheral is shared between RAAL and this module.
+ *
+ */
+
+#include "platform/nrf_802154_hp_timer.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "nrfx.h"
+#include "hal/nrf_timer.h"
+
+#include "nrf_802154_sl_periphs.h"
+
+/**@brief Timer instance. */
+#define TIMER                 NRF_802154_HIGH_PRECISION_TIMER_INSTANCE
+
+/**@brief Timer compare channel definitions. */
+#define TIMER_CC_CAPTURE      NRF_TIMER_CC_CHANNEL1
+#define TIMER_CC_CAPTURE_TASK NRF_TIMER_TASK_CAPTURE1
+
+#define TIMER_CC_SYNC         NRF_TIMER_CC_CHANNEL2
+#define TIMER_CC_SYNC_TASK    NRF_TIMER_TASK_CAPTURE2
+#define TIMER_CC_SYNC_EVENT   NRF_TIMER_EVENT_COMPARE2
+#define TIMER_CC_SYNC_INT     NRF_TIMER_INT_COMPARE2_MASK
+
+#define TIMER_CC_EVT          NRF_TIMER_CC_CHANNEL3
+#define TIMER_CC_EVT_TASK     NRF_TIMER_TASK_CAPTURE3
+#define TIMER_CC_EVT_INT      NRF_TIMER_INT_COMPARE3_MASK
+
+/**@brief Unexpected value in the sync compare channel. */
+static uint32_t m_unexpected_sync;
+
+/**@brief Get current time on the Timer. */
+static inline uint32_t timer_time_get(void)
+{
+	nrf_timer_task_trigger(TIMER, TIMER_CC_CAPTURE_TASK);
+	return nrf_timer_cc_get(TIMER, TIMER_CC_CAPTURE);
+}
+
+void nrf_802154_hp_timer_init(void)
+{
+	nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
+	nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_1MHz);
+	nrf_timer_mode_set(TIMER, NRF_TIMER_MODE_TIMER);
+}
+
+void nrf_802154_hp_timer_deinit(void)
+{
+	nrf_timer_task_trigger(TIMER, NRF_TIMER_TASK_SHUTDOWN);
+}
+
+void nrf_802154_hp_timer_start(void)
+{
+	nrf_timer_task_trigger(TIMER, NRF_TIMER_TASK_START);
+}
+
+void nrf_802154_hp_timer_stop(void)
+{
+	nrf_timer_task_trigger(TIMER, NRF_TIMER_TASK_SHUTDOWN);
+}
+
+uint32_t nrf_802154_hp_timer_sync_task_get(void)
+{
+	return nrf_timer_task_address_get(TIMER, TIMER_CC_SYNC_TASK);
+}
+
+void nrf_802154_hp_timer_sync_prepare(void)
+{
+	uint32_t past_time = timer_time_get() - 1;
+
+	m_unexpected_sync = past_time;
+	nrf_timer_cc_set(TIMER, TIMER_CC_SYNC, past_time);
+}
+
+bool nrf_802154_hp_timer_sync_time_get(uint32_t *p_timestamp)
+{
+	bool result = false;
+	uint32_t sync_time = nrf_timer_cc_get(TIMER, TIMER_CC_SYNC);
+
+	assert(p_timestamp != NULL);
+
+	if (sync_time != m_unexpected_sync) {
+		*p_timestamp = sync_time;
+		result = true;
+	}
+
+	return result;
+}
+
+uint32_t nrf_802154_hp_timer_timestamp_task_get(void)
+{
+	return nrf_timer_task_address_get(TIMER, TIMER_CC_EVT_TASK);
+}
+
+uint32_t nrf_802154_hp_timer_timestamp_get(void)
+{
+	return nrf_timer_cc_get(TIMER, TIMER_CC_EVT);
+}
+
+uint32_t nrf_802154_hp_timer_current_time_get(void)
+{
+	return timer_time_get();
+}

--- a/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc.c
+++ b/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc.c
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "platform/nrf_802154_platform_sl_lptimer.h"
+#include "nrf_802154_platform_sl_lptimer_grtc_hw_task.h"
+
+#include <assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/drivers/timer/nrf_grtc_timer.h>
+
+#include <haly/nrfy_dppi.h>
+#include <haly/nrfy_grtc.h>
+
+#include "nrf_802154_sl_config.h"
+#include "nrf_802154_sl_atomics.h"
+#include "nrf_802154_sl_utils.h"
+#include "timer/nrf_802154_timer_coord.h"
+#include "nrf_802154_sl_periphs.h"
+
+static atomic_t m_enabled;
+static bool     m_compare_int_lock_key;
+static uint32_t m_critical_section_cnt;
+static int32_t  m_callbacks_cc_channel;
+static int32_t  m_hw_task_cc_channel;
+
+static inline bool is_lptimer_enabled(void)
+{
+	return atomic_test_bit(&m_enabled, 0);
+}
+
+static void timer_compare_handler(int32_t id, uint64_t expire_time, void *user_data)
+{
+	(void)user_data;
+	(void)expire_time;
+
+	assert(id == m_callbacks_cc_channel);
+
+	if (!is_lptimer_enabled()) {
+		/* The interrupt is late. Ignore it */
+		return;
+	}
+
+	uint64_t curr_ticks = z_nrf_grtc_timer_read();
+
+	nrf_802154_sl_timer_handler(curr_ticks);
+}
+
+void nrf_802154_platform_sl_lp_timer_init(void)
+{
+	m_critical_section_cnt = 0UL;
+
+	m_callbacks_cc_channel = z_nrf_grtc_timer_chan_alloc();
+	assert(m_callbacks_cc_channel >= 0);
+
+	m_hw_task_cc_channel = z_nrf_grtc_timer_chan_alloc();
+	assert(m_hw_task_cc_channel >= 0);
+
+	nrf_802154_platform_sl_lptimer_hw_task_cross_domain_connections_setup(m_hw_task_cc_channel);
+}
+
+void nrf_802154_platform_sl_lp_timer_deinit(void)
+{
+	(void)z_nrf_grtc_timer_compare_int_lock(m_callbacks_cc_channel);
+
+	z_nrf_grtc_timer_chan_free(m_callbacks_cc_channel);
+	z_nrf_grtc_timer_chan_free(m_hw_task_cc_channel);
+}
+
+uint64_t nrf_802154_platform_sl_lptimer_current_lpticks_get(void)
+{
+	return z_nrf_grtc_timer_read();
+}
+
+uint64_t nrf_802154_platform_sl_lptimer_us_to_lpticks_convert(uint64_t us, bool round_up)
+{
+	(void) round_up;
+
+	return us;
+}
+
+uint64_t nrf_802154_platform_sl_lptimer_lpticks_to_us_convert(uint64_t lpticks)
+{
+	return lpticks;
+}
+
+void nrf_802154_platform_sl_lptimer_schedule_at(uint64_t fire_lpticks)
+{
+	/* This function is not required to be reentrant, hence no critical section. */
+	atomic_set_bit(&m_enabled, 0);
+
+	z_nrf_grtc_timer_set(m_callbacks_cc_channel,
+			     fire_lpticks,
+			     timer_compare_handler,
+			     NULL);
+}
+
+void nrf_802154_platform_sl_lptimer_disable(void)
+{
+	atomic_clear_bit(&m_enabled, 0);
+
+	z_nrf_grtc_timer_abort(m_callbacks_cc_channel);
+}
+
+void nrf_802154_platform_sl_lptimer_critical_section_enter(void)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	m_critical_section_cnt++;
+
+	if (m_critical_section_cnt == 1UL) {
+		m_compare_int_lock_key = z_nrf_grtc_timer_compare_int_lock(m_callbacks_cc_channel);
+	}
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+void nrf_802154_platform_sl_lptimer_critical_section_exit(void)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	assert(m_critical_section_cnt > 0UL);
+
+	if (m_critical_section_cnt == 1UL) {
+		z_nrf_grtc_timer_compare_int_unlock(m_callbacks_cc_channel, m_compare_int_lock_key);
+	}
+
+	m_critical_section_cnt--;
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+typedef uint8_t hw_task_state_t;
+#define HW_TASK_STATE_IDLE       0u
+#define HW_TASK_STATE_SETTING_UP 1u
+#define HW_TASK_STATE_READY      2u
+#define HW_TASK_STATE_CLEANING   3u
+#define HW_TASK_STATE_UPDATING   4u
+
+static volatile hw_task_state_t m_hw_task_state = HW_TASK_STATE_IDLE;
+static uint64_t                 m_hw_task_fire_lpticks;
+
+static bool hw_task_state_set(hw_task_state_t expected_state, hw_task_state_t new_state)
+{
+	return nrf_802154_sl_atomic_cas_u8(
+		(uint8_t *)&m_hw_task_state, &expected_state, new_state);
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_prepare(
+	uint64_t fire_lpticks,
+	uint32_t ppi_channel)
+{
+	const uint64_t                     grtc_cc_minimum_margin = 1uLL;
+	uint64_t                           syscnt_now;
+	bool                               done_on_time = true;
+	nrf_802154_sl_mcu_critical_state_t mcu_cs_state;
+
+	if (!hw_task_state_set(HW_TASK_STATE_IDLE, HW_TASK_STATE_SETTING_UP)) {
+		/* the only one available set of peripherals is already used */
+		return NRF_802154_SL_LPTIMER_PLATFORM_NO_RESOURCES;
+	}
+
+	nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_setup(
+		ppi_channel, m_hw_task_cc_channel);
+
+	m_hw_task_fire_lpticks = fire_lpticks;
+
+	z_nrf_grtc_timer_set(m_hw_task_cc_channel, fire_lpticks, NULL, NULL);
+
+	nrf_802154_sl_mcu_critical_enter(mcu_cs_state);
+
+	/* @todo: can this read be done outside of critical section? */
+	syscnt_now = z_nrf_grtc_timer_read();
+
+	if (syscnt_now + grtc_cc_minimum_margin >= fire_lpticks) {
+		/* it is too late */
+		nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_clear();
+		z_nrf_grtc_timer_abort(m_hw_task_cc_channel);
+		done_on_time = false;
+	}
+
+	nrf_802154_sl_mcu_critical_exit(mcu_cs_state);
+
+	hw_task_state_set(HW_TASK_STATE_SETTING_UP,
+			  done_on_time ? HW_TASK_STATE_READY : HW_TASK_STATE_IDLE);
+
+	return done_on_time ? NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS :
+			      NRF_802154_SL_LPTIMER_PLATFORM_TOO_LATE;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_cleanup(void)
+{
+	if (!hw_task_state_set(HW_TASK_STATE_READY, HW_TASK_STATE_CLEANING)) {
+		return NRF_802154_SL_LPTIMER_PLATFORM_WRONG_STATE;
+	}
+
+	nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_clear();
+
+	z_nrf_grtc_timer_abort(m_hw_task_cc_channel);
+
+	hw_task_state_set(HW_TASK_STATE_CLEANING, HW_TASK_STATE_IDLE);
+
+	return NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_update_ppi(
+	uint32_t ppi_channel)
+{
+	bool cc_triggered;
+
+	if (!hw_task_state_set(HW_TASK_STATE_READY, HW_TASK_STATE_UPDATING)) {
+		return NRF_802154_SL_LPTIMER_PLATFORM_WRONG_STATE;
+	}
+
+	nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_setup(
+		ppi_channel, m_hw_task_cc_channel);
+
+	cc_triggered = z_nrf_grtc_timer_compare_evt_check(m_hw_task_cc_channel);
+	if (z_nrf_grtc_timer_read() >= m_hw_task_fire_lpticks) {
+		cc_triggered = true;
+	}
+
+	hw_task_state_set(HW_TASK_STATE_UPDATING, HW_TASK_STATE_READY);
+
+	return cc_triggered ? NRF_802154_SL_LPTIMER_PLATFORM_TOO_LATE :
+		NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
+}

--- a/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc_hw_task.c
+++ b/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc_hw_task.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "nrf_802154_platform_sl_lptimer_grtc_hw_task.h"
+
+#include <haly/nrfy_dppi.h>
+#include <haly/nrfy_grtc.h>
+#include <hal/nrf_ppib.h>
+
+#include <platform/nrf_802154_platform_sl_lptimer.h>
+#include <zephyr/drivers/timer/nrf_grtc_timer.h>
+
+#if defined(NRF54H_SERIES)
+
+#include <hal/nrf_ipct.h>
+
+/* To trigger RADIO.TASKS_{?} with GRTC.EVENT_COMPARE[#cc] the following connection chain must be
+ * created:
+ *    - starting from LOCAL (RADIO core) domain:
+ *        {a} RADIO.TASKS_{?}  <-- DPPIC_020
+ *        {b} DPPIC_020        <-- IPCT_radio
+ *    - entering the GLOBAL "Main power" domain (G1):
+ *        {c} IPCT_radio       <-- IPCT_130
+ *        {d} IPCT_130         <-- DPPIC_130
+ *        {e} DPPIC_130        <-- PPIB_130
+ *        {f} PPIB_130         <-- PPIB_133
+ *    - ending in the GLOBAL "Active power" domain (G2):
+ *        {g} PPIB_133         <-- DPPIC_132
+ *        {h} DPPIC_132        <-- GRTC.CC
+ */
+
+/* Peripherals used for hardware tasks - located in local domain (_L_) */
+/*   - DPPIC_L : DPPIC020 (RADIOCORE.DPPIC020) */
+/*   - IPCT_L : NRF_IPCT (RADIOCORE.IPCT) */
+#define IPCT_L_HT_CHANNEL            2
+#if defined(NRF54H20_ENGA_XXAA)
+#define IPCT_L_SHORTS                IPCT_SHORTS_RECEIVE2_ACK2_Msk
+#else
+#define IPCT_L_SHORTS                IPCT_SHORTS_RECEIVE2_FLUSH2_Msk
+#endif
+#define IPCT_L_EVENT_RECEIVE         NRFX_CONCAT_2(NRF_IPCT_EVENT_RECEIVE_, IPCT_L_HT_CHANNEL)
+
+/* Peripherals used for timestamping - located in global "Main power domain" (_G1_) */
+/*   - IPCT_G1 : IPCT130_S */
+#define IPCT_G1_INST                 NRF_IPCT130_S
+#define IPCT_G1_HT_CHANNEL           2
+#define IPCT_G1_TASK_SEND            NRFX_CONCAT_2(NRF_IPCT_TASK_SEND_, IPCT_G1_HT_CHANNEL)
+
+/*   - DPPIC_G1 : DPPIC130_S */
+/* The channel must be in the [0..7] range to satisfy the requirements for the dependent macros */
+#define DPPIC_G1_INST                NRF_DPPIC130_S
+#define DPPIC_G1_HT_CHANNEL          2
+
+/*  - PPIB_G1 : PPIB130_S */
+#define PPIB_G1_HT_CHANNEL           (DPPIC_G1_HT_CHANNEL + 8) /* hw-fixed dependency */
+
+/* Peripherals used for timestamping - located in global "Active power domain" (_G2_) */
+/*   - PPIB_G2 : PPIB133_S */
+#define DPPIC_G2_INST                NRF_DPPIC132_S
+#define PPIB_G2_HT_CHANNEL           (PPIB_G1_HT_CHANNEL - 8) /* hw-fixed dependency */
+
+/*   - DPPIC_G2 : DPPIC132_S */
+#define DPPIC_G2_HT_CHANNEL          (PPIB_G2_HT_CHANNEL + 0) /* hw-fixed dependency */
+
+#if (PPIB_G1_HT_CHANNEL < 8) || (PPIB_G1_HT_CHANNEL > 15)
+/* Only this range of channels can be connected to PPIB133 */
+#error PPIB_G1_HT_CHANNEL is required to be in the [8..15] range
+#endif
+
+/* Ensure something similar to this is present in the DT:
+ * &dppic130 {
+ *	owned-channels = <2>;
+ *	sink-channels = <2>;
+ * };
+ * where 2 corresponds to DPPIC_G1_HT_CHANNEL.
+ */
+#define _HT_DT_CHECK_DPPIC_CHANNEL(node_id, prop, idx) \
+	(DT_PROP_BY_IDX(node_id, prop, idx) == DPPIC_G1_HT_CHANNEL) ||
+
+#define HT_DT_HAS_RESERVED_DPPIC_CHANNEL		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(dppic130), sink_channels), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(dppic130), \
+					  sink_channels, \
+					  _HT_DT_CHECK_DPPIC_CHANNEL) false), \
+		    (false))
+
+BUILD_ASSERT(HT_DT_HAS_RESERVED_DPPIC_CHANNEL,
+	     "The required DPPIC_G1 channel is not reserved");
+
+
+/* Ensure something similar to this is present in the DT:
+ * &dppic132 {
+ *	owned-channels = <2>;
+ *	source-channels = <2>;
+ * where 2 corresponds to DPPIC_G2_HT_CHANNEL.
+ * };
+ */
+#define _HT_DT_CHECK_DPPIC_G2_CHANNEL(node_id, prop, idx) \
+	(DT_PROP_BY_IDX(node_id, prop, idx) == DPPIC_G2_HT_CHANNEL) ||
+
+#define HT_DT_HAS_RESERVED_DPPIC_G2_CHANNEL		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(dppic132), source_channels), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(dppic132), \
+					  source_channels, \
+					  _HT_DT_CHECK_DPPIC_G2_CHANNEL) false), \
+		    (false))
+
+BUILD_ASSERT(HT_DT_HAS_RESERVED_DPPIC_G2_CHANNEL,
+	     "The required DPPIC_G2 channel is not reserved");
+
+/* Ensure something similar to this is present in the DT:
+ * &cpurad_ipct {
+ *	sink-channel-links = <2 13 2>;
+ * };
+ * where first 2 corresponds to IPCT_L_HT_CHANNEL.
+ */
+#define _HT_DT_CHECK_IPCT_L_LINK(node_id, prop, idx) \
+	((DT_PROP_BY_IDX(node_id, prop, idx) == IPCT_L_HT_CHANNEL) && ((idx) % 3 == 0)) ||
+
+#define HT_DT_HAS_RESERVED_IPCT_L_LINK		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(cpurad_ipct), sink_channel_links), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(cpurad_ipct), \
+					  sink_channel_links, \
+					  _HT_DT_CHECK_IPCT_L_LINK) false), \
+		    (false))
+
+/* NOTE: this not verifying the allocation as the device tree property is an
+ * array of triplets that is difficult to separate using macros.
+ */
+BUILD_ASSERT(HT_DT_HAS_RESERVED_IPCT_L_LINK,
+	     "The required IPCT_L link is not reserved");
+
+/* Ensure something similar to this is present in the DT:
+ * &ipct130 {
+ *	source-channel-links = <2 3 2>;
+ * };
+ * where first 2 corresponds to IPCT_G1_HT_CHANNEL.
+ */
+#define _HT_DT_CHECK_IPCT_G1_LINK(node_id, prop, idx) \
+	((DT_PROP_BY_IDX(node_id, prop, idx) == IPCT_G1_HT_CHANNEL) && ((idx) % 3 == 0)) ||
+
+
+#define TS_DT_HAS_RESERVED_IPCT_G1_LINK		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(ipct130), source_channel_links), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(ipct130), \
+					  source_channel_links, \
+					  _HT_DT_CHECK_IPCT_G1_LINK) false), \
+		    (false))
+
+/* NOTE: this not verifying the allocation as the device tree property is an
+ * array of triplets that is difficult to separate using macros.
+ */
+BUILD_ASSERT(TS_DT_HAS_RESERVED_IPCT_G1_LINK,
+	     "The required IPCT_G1 link is not reserved");
+
+void nrf_802154_platform_sl_lptimer_hw_task_cross_domain_connections_setup(uint32_t cc_channel)
+{
+	/* {c} IPCT_radio <-- IPCT_130
+	 * It is assumed that this connection has already been made by SECURE-core as a result of
+	 * configuring of the UICR->IPCMAP[] registers.
+	 *
+	 * Only enable auto confirmations on destination - IPCT_radio.
+	 */
+	nrf_ipct_shorts_enable(NRF_IPCT, IPCT_L_SHORTS);
+
+	/* {d} IPCT_130 <-- DPPIC_130 */
+	nrf_ipct_subscribe_set(IPCT_G1_INST, IPCT_G1_TASK_SEND, DPPIC_G1_HT_CHANNEL);
+
+	/* {e} DPPIC_130 <-- PPIB_130
+	 * It is assumed that this connection has already been made by SECURE-core as a result of
+	 * configuring the UICR->DPPI.GLOBAL[].CH.LINK.SOURCE registers.
+	 *
+	 * Only enable relevant DPPIC_G1_INST channel.
+	 */
+	nrfy_dppi_channels_enable(DPPIC_G1_INST, 1UL << DPPIC_G1_HT_CHANNEL);
+
+	/* {f} PPIB_130 <-- PPIB_133
+	 * One of HW-fixed connections (channels [8..15] --> [0..7]), so nothing to do.
+	 */
+
+	/* {g} PPIB_133 <-- DPPIC_132
+	 * It is assumed that this connection has already been made by SECURE-core as a result of
+	 * configuring of the UICR->DPPI.GLOBAL[].CH.LINK.SINK registers.
+	 */
+
+	/* {h} DPPIC_132 <-- GRTC.CC */
+	NRF_DPPI_ENDPOINT_SETUP(
+		z_nrf_grtc_timer_compare_evt_address_get(cc_channel), DPPIC_G2_HT_CHANNEL);
+}
+
+void nrf_802154_platform_sl_lptimer_hw_task_cross_domain_connections_clear(void)
+{
+	/* @todo: implement */
+}
+
+void nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_setup(uint32_t dppi_ch,
+									   uint32_t cc_channel)
+{
+	if (dppi_ch == NRF_802154_SL_HW_TASK_PPI_INVALID) {
+		return;
+	}
+
+	nrf_ipct_event_clear(NRF_IPCT, IPCT_L_EVENT_RECEIVE);
+
+	/* {a} RADIO.TASKS_{?} <-- DPPIC_020[dppi_ch]
+	 * It is the responsibility of the user of this platform to make the {a} connection
+	 * and pass the DPPI channel number as a parameter here.
+	 */
+
+	/* {b} DPPIC_020[dppi_ch] <-- IPCT_radio */
+	nrf_ipct_publish_set(NRF_IPCT, IPCT_L_EVENT_RECEIVE, dppi_ch);
+
+	/* {h} Enable relevant DPPIC_G2_INST channel. */
+	nrfy_dppi_channels_enable(DPPIC_G2_INST, 1UL << DPPIC_G2_HT_CHANNEL);
+}
+
+void nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_clear(void)
+{
+	nrf_ipct_publish_clear(NRF_IPCT, IPCT_L_EVENT_RECEIVE);
+	nrfy_dppi_channels_disable(DPPIC_G2_INST, 1UL << DPPIC_G2_HT_CHANNEL);
+	nrf_ipct_event_clear(NRF_IPCT, IPCT_L_EVENT_RECEIVE);
+}
+
+#elif defined(NRF54L_SERIES)
+
+#include <helpers/nrfx_gppi.h>
+#include <soc/interconnect/nrfx_gppi_d2ppi.h>
+
+/* To trigger RADIO.TASKS_x with GRTC.EVENT_CAPTURE{?}, the following connection chain must be
+ * created:
+ *    - starting with the PERI domain (_P_):
+ *        {a} DPPIC_20         <-- GRTC.CC
+ *        {b} PPIB_21          <-- DPPIC_20
+ *    - crossing domain boundaries
+ *        {c} PPIB_11          <-- PPIB_21
+ *    - ending with RADIO domain (_R_):
+ *        {d} DPPIC_10         <-- PPIB_11
+ *        {e} RADIO.TASK_{?}   <-- DPPIC_10
+ */
+
+#define INVALID_CHANNEL UINT8_MAX
+
+static nrfx_gppi_handle_t peri_rad_handle;
+static uint32_t ppib_chan;
+
+void nrf_802154_platform_sl_lptimer_hw_task_cross_domain_connections_setup(uint32_t cc_channel)
+{
+	nrfx_gppi_resource_t resource = {
+		.domain_id = NRFX_GPPI_DOMAIN_RAD,
+		.channel = 0
+	};
+	uint32_t eep = z_nrf_grtc_timer_compare_evt_address_get(cc_channel);
+	int err;
+
+	err = nrfx_gppi_ext_conn_alloc(NRFX_GPPI_DOMAIN_PERI, NRFX_GPPI_DOMAIN_RAD,
+				       &peri_rad_handle, &resource);
+	__ASSERT_NO_MSG(err == 0);
+
+	/* Add event endpoint (GRTC compare) to the previously configured connection. */
+	err = nrfx_gppi_ep_attach(eep, peri_rad_handle);
+	__ASSERT_NO_MSG(err == 0);
+
+	/* Get PPIB channel used in the connection. */
+	ppib_chan = nrfx_gppi_domain_channel_get(peri_rad_handle, NRFX_GPPI_NODE_PPIB11_21);
+	__ASSERT_NO_MSG(ppib_chan >= 0);
+
+	/* Disable PPIB for now until exact channel from RADIO domain is known. */
+	nrf_ppib_publish_clear(NRF_PPIB11, nrf_ppib_receive_event_get(ppib_chan));
+
+	nrfx_gppi_conn_enable(peri_rad_handle);
+}
+
+void nrf_802154_platform_sl_lptimer_hw_task_cross_domain_connections_clear(void)
+{
+	nrfx_gppi_conn_disable(peri_rad_handle);
+	nrfx_gppi_domain_conn_free(peri_rad_handle);
+}
+
+void nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_setup(uint32_t dppi_ch,
+									   uint32_t cc_channel)
+{
+	if (dppi_ch == NRF_802154_SL_HW_TASK_PPI_INVALID) {
+		return;
+	}
+
+	/* Configure PPIB to forward GRTC event to the DPPI channel from the Radio domain. */
+	nrf_ppib_publish_set(NRF_PPIB11, nrf_ppib_receive_event_get(ppib_chan), dppi_ch);
+}
+
+void nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_clear(void)
+{
+	nrf_ppib_publish_clear(NRF_PPIB11, nrf_ppib_receive_event_get(ppib_chan));
+}
+
+#endif

--- a/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc_hw_task.h
+++ b/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc_hw_task.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_802154_PLATFORM_SL_LPTIMER_GRTC_HW_TASK_H_
+#define NRF_802154_PLATFORM_SL_LPTIMER_GRTC_HW_TASK_H_
+
+#include <stdint.h>
+
+/**
+ * @brief Sets up cross-domain hardware connections necessary to trigger a RADIO task.
+ *
+ * This function configures cross-domain hardware connections necessary to trigger a RADIO task with
+ * an event from GRTC. These connections are identical for all RADIO tasks.
+ *
+ * @note Every call to this function must be paired with a call to @ref
+ * nrf_802154_platform_timestamper_cross_domain_connections_clear.
+ */
+void nrf_802154_platform_sl_lptimer_hw_task_cross_domain_connections_setup(uint32_t cc_channel);
+
+/**
+ * @brief Clears cross-domain hardware connections necessary to capture a timestamp.
+ */
+void nrf_802154_platform_sl_lptimer_hw_task_cross_domain_connections_clear(void);
+
+/**
+ * @brief Sets up local domain hardware connections necessary to trigger a RADIO task.
+ *
+ * This function configures local-domain hardware connections necessary to trigger a RADIO task with
+ * an event from GRTC. These connections must be setup separately for every RADIO task.
+ *
+ * @param  dppi_ch  Local domain DPPI channel that the RADIO task to be triggered subscribes to.
+ */
+void nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_setup(uint32_t dppi_ch,
+									   uint32_t cc_channel);
+
+/**
+ * @brief Clears local domain hardware connections necessary to trigger a RADIO task.
+ */
+void nrf_802154_platform_sl_lptimer_hw_task_local_domain_connections_clear(void);
+
+#endif /* NRF_802154_PLATFORM_SL_LPTIMER_GRTC_HW_TASK_H_ */

--- a/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_zephyr.c
+++ b/nrf_802154/sl/platform/zephyr/nrf_802154_platform_sl_lptimer_zephyr.c
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "platform/nrf_802154_platform_sl_lptimer.h"
+
+#include <assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/kernel.h>
+
+#include <zephyr/drivers/timer/nrf_rtc_timer.h>
+#include <zephyr/sys/barrier.h>
+#include <hal/nrf_rtc.h>
+#include <helpers/nrfx_gppi.h>
+
+#include "platform/nrf_802154_clock.h"
+#include "nrf_802154_sl_utils.h"
+
+#define RTC_CHAN_INVALID (-1)
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+
+BUILD_ASSERT(CONFIG_MPSL);
+
+#define HW_TASK_RTC	     NRF_RTC0
+#define HW_TASK_RTC_CHAN (3)
+
+#define RTC_COUNTER_BIT_WIDTH 24U
+#define RTC_COUNTER_SPAN      BIT(RTC_COUNTER_BIT_WIDTH)
+#define RTC_COUNTER_MAX       (RTC_COUNTER_SPAN - 1U)
+#define RTC_COUNTER_HALF_SPAN (RTC_COUNTER_SPAN / 2U)
+
+#define RTC_MIN_CYCLES_FROM_NOW 3
+#endif
+
+struct timer_desc {
+	z_nrf_rtc_timer_compare_handler_t handler;
+	uint64_t target_time;
+	int32_t chan;
+	int32_t int_lock_key;
+};
+
+enum hw_task_state_type {
+	HW_TASK_STATE_IDLE,
+	HW_TASK_STATE_SETTING_UP,
+	HW_TASK_STATE_READY,
+	HW_TASK_STATE_UPDATING,
+	HW_TASK_STATE_CLEANING
+};
+
+struct hw_task_desc {
+	atomic_t state;
+	int32_t chan;
+	int32_t ppi;
+	uint64_t fire_lpticks;
+};
+
+static struct timer_desc m_timer;
+static struct timer_desc m_sync_timer;
+static struct hw_task_desc m_hw_task;
+static bool m_in_critical_section;
+
+void timer_handler(int32_t id, uint64_t expire_time, void *user_data)
+{
+	(void)user_data;
+	(void)expire_time;
+
+	assert(id == m_timer.chan);
+
+	uint64_t curr_time = z_nrf_rtc_timer_read();
+
+	nrf_802154_sl_timer_handler(curr_time);
+}
+
+/**
+ * @brief RTC IRQ handler for synchronization timer channel.
+ */
+void sync_timer_handler(int32_t id, uint64_t expire_time, void *user_data)
+{
+	(void)user_data;
+
+	assert(id == m_sync_timer.chan);
+
+	/**
+	 * Expire time might have been different than the desired target
+	 * time. Update it so that a more accurate value can be returned
+	 * by nrf_802154_lp_timer_sync_time_get.
+	 */
+	m_sync_timer.target_time = expire_time;
+
+	nrf_802154_sl_timestamper_synchronized();
+}
+
+/**
+ * @brief Start one-shot timer that expires at specified time on desired channel.
+ *
+ * Start one-shot timer that will expire when @p target_time is reached on channel @p channel.
+ *
+ * @param[inout] timer        Pointer to descriptor of timer to set.
+ * @param[in]    target_time  Absolute target time in microseconds.
+ */
+static void timer_start_at(struct timer_desc *timer, uint64_t target_time)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	z_nrf_rtc_timer_set(timer->chan, target_time, timer->handler, NULL);
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	timer->target_time = target_time;
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+static inline uint32_t rtc_counter_diff(uint32_t a, uint32_t b)
+{
+	return (a - b) & RTC_COUNTER_MAX;
+}
+#endif
+
+static bool hw_task_state_set(enum hw_task_state_type expected_state,
+			      enum hw_task_state_type new_state)
+{
+	return atomic_cas(&m_hw_task.state, expected_state, new_state);
+}
+
+static inline uint32_t hw_task_rtc_get_compare_evt_address(int32_t cc_num)
+{
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+	return nrf_rtc_event_address_get(HW_TASK_RTC, nrf_rtc_compare_event_get(cc_num));
+#else
+	return z_nrf_rtc_timer_compare_evt_address_get(cc_num);
+#endif
+}
+
+static void hw_task_rtc_cc_bind_to_ppi(int32_t cc_num, uint32_t ppi_num)
+{
+	uint32_t event_address = hw_task_rtc_get_compare_evt_address(cc_num);
+
+	nrfx_gppi_ep_to_ch_attach(event_address, ppi_num);
+}
+
+static void hw_task_rtc_cc_unbind(int32_t cc_num, uint32_t ppi_num)
+{
+	if (ppi_num != NRF_802154_SL_HW_TASK_PPI_INVALID) {
+		uint32_t event_address = hw_task_rtc_get_compare_evt_address(cc_num);
+
+		nrfx_gppi_ep_ch_clear(event_address, ppi_num);
+	}
+}
+
+static bool hw_task_rtc_cc_event_check(int32_t cc_num)
+{
+	uint32_t event_address = hw_task_rtc_get_compare_evt_address(cc_num);
+
+	return *(volatile uint32_t *)event_address;
+}
+
+static void hw_task_rtc_timer_abort(void)
+{
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+	/* No interrupt disabling/clearing is needed, as HW task does not use interrupts*/
+	nrf_rtc_event_disable(HW_TASK_RTC, NRF_RTC_CHANNEL_INT_MASK(m_hw_task.chan));
+	nrf_rtc_event_clear(HW_TASK_RTC, NRF_RTC_CHANNEL_EVENT_ADDR(m_hw_task.chan));
+#else
+	z_nrf_rtc_timer_abort(m_hw_task.chan);
+#endif
+}
+
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+static uint32_t zephyr_rtc_ticks_to_hw_task_rtc_counter(uint64_t ticks)
+{
+	uint64_t zephyr_rtc_counter_now = 0;
+	uint32_t hw_task_rtc_counter_now = 0;
+	uint32_t hw_task_rtc_counter_now_2 = 0;
+
+	/**
+	 * The RTC0 counter is read twice - once before and once after reading RTC1.
+	 * If the two reads are different, the procedure is repeated.
+	 * This is to make sure that no RTC tick occurred between reading RTC0 and
+	 * RTC1 and so the calculated difference between the timers is correct.
+	 */
+	do {
+		hw_task_rtc_counter_now = nrf_rtc_counter_get(HW_TASK_RTC);
+		zephyr_rtc_counter_now = z_nrf_rtc_timer_read();
+		barrier_dmem_fence_full();
+		hw_task_rtc_counter_now_2 = nrf_rtc_counter_get(HW_TASK_RTC);
+
+	} while (hw_task_rtc_counter_now != hw_task_rtc_counter_now_2);
+
+	/* This function can only be called in close proximity of ticks */
+	assert(ticks >= zephyr_rtc_counter_now
+		|| zephyr_rtc_counter_now - ticks < RTC_COUNTER_HALF_SPAN);
+	assert(ticks <= zephyr_rtc_counter_now
+		|| ticks - zephyr_rtc_counter_now < RTC_COUNTER_HALF_SPAN);
+
+	uint32_t diff = rtc_counter_diff(hw_task_rtc_counter_now,
+		(uint32_t) zephyr_rtc_counter_now % RTC_COUNTER_SPAN);
+
+	return (uint32_t) ((ticks + diff) % RTC_COUNTER_SPAN);
+}
+
+static int hw_task_rtc_counter_compare_set(uint32_t cc_value)
+{
+	uint32_t current_counter_value = nrf_rtc_counter_get(HW_TASK_RTC);
+
+	/* As the HW tasks are setup only shortly before they are triggered,
+	 * it is certain that the required fire time is not further away
+	 * than one half of the RTC counter span.
+	 * If it is it means that the trigger time is already in the past.
+	 */
+	if (rtc_counter_diff(cc_value, current_counter_value) > RTC_COUNTER_HALF_SPAN) {
+		return -EINVAL;
+	}
+
+	nrf_rtc_event_disable(HW_TASK_RTC, NRF_RTC_CHANNEL_INT_MASK(m_hw_task.chan));
+	nrf_rtc_event_clear(HW_TASK_RTC, NRF_RTC_CHANNEL_EVENT_ADDR(m_hw_task.chan));
+
+	nrf_rtc_cc_set(HW_TASK_RTC, m_hw_task.chan, cc_value);
+
+	nrf_rtc_event_enable(HW_TASK_RTC, NRF_RTC_CHANNEL_INT_MASK(m_hw_task.chan));
+
+	current_counter_value = nrf_rtc_counter_get(HW_TASK_RTC);
+
+	if (rtc_counter_diff(cc_value, current_counter_value + RTC_MIN_CYCLES_FROM_NOW)
+		> (RTC_COUNTER_HALF_SPAN - RTC_MIN_CYCLES_FROM_NOW)) {
+		nrf_rtc_event_disable(HW_TASK_RTC, NRF_RTC_CHANNEL_INT_MASK(m_hw_task.chan));
+		nrf_rtc_event_clear(HW_TASK_RTC, NRF_RTC_CHANNEL_EVENT_ADDR(m_hw_task.chan));
+		return -EINVAL;
+	}
+
+	return 0;
+}
+#endif
+
+static int hw_task_rtc_timer_set(uint64_t fire_lpticks)
+{
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+	uint32_t hw_task_rtc_counter_ticks = zephyr_rtc_ticks_to_hw_task_rtc_counter(fire_lpticks);
+
+	return hw_task_rtc_counter_compare_set(hw_task_rtc_counter_ticks);
+#else
+	return z_nrf_rtc_timer_exact_set(m_hw_task.chan, fire_lpticks, NULL, NULL);
+#endif
+}
+
+void nrf_802154_platform_sl_lp_timer_init(void)
+{
+	m_in_critical_section = false;
+	m_hw_task.state = HW_TASK_STATE_IDLE;
+#if defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+	m_hw_task.chan = HW_TASK_RTC_CHAN;
+#else
+	m_hw_task.chan = z_nrf_rtc_timer_chan_alloc();
+	if (m_hw_task.chan < 0) {
+		assert(false);
+		return;
+	}
+#endif
+	m_hw_task.ppi = NRF_802154_SL_HW_TASK_PPI_INVALID;
+	m_timer.handler = timer_handler;
+	m_sync_timer.handler = sync_timer_handler;
+
+	m_timer.chan = z_nrf_rtc_timer_chan_alloc();
+	if (m_timer.chan < 0) {
+		assert(false);
+		return;
+	}
+
+	m_sync_timer.chan = z_nrf_rtc_timer_chan_alloc();
+	if (m_sync_timer.chan < 0) {
+		assert(false);
+		return;
+	}
+}
+
+void nrf_802154_platform_sl_lp_timer_deinit(void)
+{
+	(void)z_nrf_rtc_timer_compare_int_lock(m_timer.chan);
+
+	nrf_802154_platform_sl_lptimer_sync_abort();
+
+	z_nrf_rtc_timer_chan_free(m_timer.chan);
+	z_nrf_rtc_timer_chan_free(m_sync_timer.chan);
+
+	if (m_hw_task.chan != RTC_CHAN_INVALID) {
+#if !defined(CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET)
+		z_nrf_rtc_timer_chan_free(m_hw_task.chan);
+#endif
+		m_hw_task.chan = RTC_CHAN_INVALID;
+	}
+}
+
+uint64_t nrf_802154_platform_sl_lptimer_current_lpticks_get(void)
+{
+	return z_nrf_rtc_timer_read();
+}
+
+uint64_t nrf_802154_platform_sl_lptimer_us_to_lpticks_convert(uint64_t us, bool round_up)
+{
+	return NRF_802154_SL_US_TO_RTC_TICKS(us, round_up);
+}
+
+uint64_t nrf_802154_platform_sl_lptimer_lpticks_to_us_convert(uint64_t lpticks)
+{
+	/* Calculations are performed on uint64_t as it is safe to assume
+	 * overflow will not occur in any foreseeable future.
+	 */
+	return NRF_802154_SL_RTC_TICKS_TO_US(lpticks);
+}
+
+void nrf_802154_platform_sl_lptimer_schedule_at(uint64_t fire_lpticks)
+{
+	/* This function is not required to be reentrant, hence no critical section. */
+	timer_start_at(&m_timer, fire_lpticks);
+}
+
+void nrf_802154_platform_sl_lptimer_disable(void)
+{
+	z_nrf_rtc_timer_abort(m_timer.chan);
+}
+
+void nrf_802154_platform_sl_lptimer_critical_section_enter(void)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	if (!m_in_critical_section) {
+		m_timer.int_lock_key = z_nrf_rtc_timer_compare_int_lock(m_timer.chan);
+		m_sync_timer.int_lock_key = z_nrf_rtc_timer_compare_int_lock(m_sync_timer.chan);
+		m_in_critical_section = true;
+	}
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+void nrf_802154_platform_sl_lptimer_critical_section_exit(void)
+{
+	nrf_802154_sl_mcu_critical_state_t state;
+
+	nrf_802154_sl_mcu_critical_enter(state);
+
+	m_in_critical_section = false;
+
+	z_nrf_rtc_timer_compare_int_unlock(m_timer.chan, m_timer.int_lock_key);
+	z_nrf_rtc_timer_compare_int_unlock(m_sync_timer.chan, m_sync_timer.int_lock_key);
+
+	nrf_802154_sl_mcu_critical_exit(state);
+}
+
+uint32_t nrf_802154_platform_sl_lptimer_granularity_get(void)
+{
+	return NRF_802154_SL_US_PER_TICK;
+}
+
+void nrf_802154_platform_sl_lptimer_sync_schedule_now(void)
+{
+	uint64_t now = z_nrf_rtc_timer_read();
+
+	/**
+	 * Despite this function's name, synchronization is not expected to be
+	 * scheduled for the current tick. Add a safe 3-tick margin
+	 */
+	timer_start_at(&m_sync_timer, now + 3);
+}
+
+void nrf_802154_platform_sl_lptimer_sync_schedule_at(uint64_t fire_lpticks)
+{
+	timer_start_at(&m_sync_timer, fire_lpticks);
+}
+
+void nrf_802154_platform_sl_lptimer_sync_abort(void)
+{
+	z_nrf_rtc_timer_abort(m_sync_timer.chan);
+}
+
+uint32_t nrf_802154_platform_sl_lptimer_sync_event_get(void)
+{
+	return z_nrf_rtc_timer_compare_evt_address_get(m_sync_timer.chan);
+}
+
+uint64_t nrf_802154_platform_sl_lptimer_sync_lpticks_get(void)
+{
+	return m_sync_timer.target_time;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_prepare(
+	uint64_t fire_lpticks,
+	uint32_t ppi_channel)
+{
+	uint32_t evt_address;
+	nrf_802154_sl_mcu_critical_state_t mcu_cs_state;
+
+	if (!hw_task_state_set(HW_TASK_STATE_IDLE, HW_TASK_STATE_SETTING_UP)) {
+		/* The only one available set of peripherals is already used. */
+		return NRF_802154_SL_LPTIMER_PLATFORM_NO_RESOURCES;
+	}
+
+	if (hw_task_rtc_timer_set(fire_lpticks) != 0) {
+		hw_task_state_set(HW_TASK_STATE_SETTING_UP, HW_TASK_STATE_IDLE);
+		uint64_t now = z_nrf_rtc_timer_read();
+
+		if ((fire_lpticks > now) &&
+		    (fire_lpticks - now > NRF_RTC_TIMER_MAX_SCHEDULE_SPAN/2)) {
+			return NRF_802154_SL_LPTIMER_PLATFORM_TOO_DISTANT;
+		}
+		return NRF_802154_SL_LPTIMER_PLATFORM_TOO_LATE;
+	}
+
+	evt_address = hw_task_rtc_get_compare_evt_address(m_hw_task.chan);
+
+	nrf_802154_sl_mcu_critical_enter(mcu_cs_state);
+
+	/* For triggering to take place a safe margin is 2 lpticks from `now`. */
+	if ((z_nrf_rtc_timer_read() + 2) > fire_lpticks) {
+		/* it is too late */
+		nrf_802154_sl_mcu_critical_exit(mcu_cs_state);
+		hw_task_rtc_cc_unbind(m_hw_task.chan, ppi_channel);
+		m_hw_task.ppi = NRF_802154_SL_HW_TASK_PPI_INVALID;
+		hw_task_rtc_timer_abort();
+		hw_task_state_set(HW_TASK_STATE_SETTING_UP, HW_TASK_STATE_IDLE);
+		return NRF_802154_SL_LPTIMER_PLATFORM_TOO_LATE;
+	}
+
+	if (ppi_channel != NRF_802154_SL_HW_TASK_PPI_INVALID) {
+		nrfx_gppi_ep_to_ch_attach(evt_address, ppi_channel);
+	}
+	m_hw_task.ppi = ppi_channel;
+	m_hw_task.fire_lpticks = fire_lpticks;
+	nrf_802154_sl_mcu_critical_exit(mcu_cs_state);
+	hw_task_state_set(HW_TASK_STATE_SETTING_UP, HW_TASK_STATE_READY);
+	return NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_cleanup(void)
+{
+	if (!hw_task_state_set(HW_TASK_STATE_READY, HW_TASK_STATE_CLEANING)) {
+		return NRF_802154_SL_LPTIMER_PLATFORM_WRONG_STATE;
+	}
+
+	hw_task_rtc_timer_abort();
+
+	hw_task_rtc_cc_unbind(m_hw_task.chan, m_hw_task.ppi);
+	m_hw_task.ppi = NRF_802154_SL_HW_TASK_PPI_INVALID;
+
+	hw_task_state_set(HW_TASK_STATE_CLEANING, HW_TASK_STATE_IDLE);
+
+	return NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
+}
+
+nrf_802154_sl_lptimer_platform_result_t nrf_802154_platform_sl_lptimer_hw_task_update_ppi(
+	uint32_t ppi_channel)
+{
+	bool cc_triggered;
+
+	if (!hw_task_state_set(HW_TASK_STATE_READY, HW_TASK_STATE_UPDATING)) {
+		return NRF_802154_SL_LPTIMER_PLATFORM_WRONG_STATE;
+	}
+
+	nrf_802154_sl_mcu_critical_state_t mcu_cs_state;
+
+	nrf_802154_sl_mcu_critical_enter(mcu_cs_state);
+
+	hw_task_rtc_cc_bind_to_ppi(m_hw_task.chan, ppi_channel);
+	m_hw_task.ppi = ppi_channel;
+
+	cc_triggered = hw_task_rtc_cc_event_check(m_hw_task.chan);
+	if (z_nrf_rtc_timer_read() >= m_hw_task.fire_lpticks) {
+		cc_triggered = true;
+	}
+	nrf_802154_sl_mcu_critical_exit(mcu_cs_state);
+
+	hw_task_state_set(HW_TASK_STATE_UPDATING, HW_TASK_STATE_READY);
+
+	return cc_triggered ? NRF_802154_SL_LPTIMER_PLATFORM_TOO_LATE :
+	       NRF_802154_SL_LPTIMER_PLATFORM_SUCCESS;
+}

--- a/nrf_802154/sl/platform/zephyr/nrf_802154_platform_timestamper.c
+++ b/nrf_802154/sl/platform/zephyr/nrf_802154_platform_timestamper.c
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#include "platform/nrf_802154_platform_timestamper.h"
+
+#include <haly/nrfy_dppi.h>
+#include <haly/nrfy_grtc.h>
+#include <hal/nrf_dppi.h>
+#include <hal/nrf_ppib.h>
+#if defined(NRF54H_SERIES)
+#include <hal/nrf_ipct.h>
+#endif
+
+#include <assert.h>
+#include <zephyr/drivers/timer/nrf_grtc_timer.h>
+
+static int32_t m_timestamp_cc_channel;
+
+#if defined(NRF54H_SERIES)
+/* To trigger GRTC.TASKS_CAPTURE[#cc] with RADIO.EVENT_{?}, the following connection chain must be
+ * created:
+ *    - starting from LOCAL (RADIO core) domain:
+ *        {a} RADIO.EVENT_{?}  --> DPPIC_020
+ *        {b} DPPIC_020        --> IPCT_radio
+ *    - entering the GLOBAL "Main power" domain (G1):
+ *        {c} IPCT_radio       --> IPCT_130
+ *        {d} IPCT_130         --> DPPIC_130
+ *        {e} DPPIC_130        --> PPIB_130
+ *        {f} PPIB_130         --> PPIB_133
+ *    - ending in the GLOBAL "Active power" domain (G2):
+ *        {g} PPIB_133         --> DPPIC_132
+ *        {h} DPPIC_132        --> GRTC.CC
+ */
+
+/* Peripherals used for timestamping - located in local domain (_L_) */
+/*   - DPPIC_L : DPPIC020 (RADIOCORE.DPPIC020) */
+#define DPPIC_L_INST                 NRF_DPPIC020
+
+/*   - IPCT_L : NRF_IPCT (RADIOCORE.IPCT) */
+#define IPCT_L_TS_CHANNEL            2
+#define IPCT_L_TASK_SEND             NRFX_CONCAT_2(NRF_IPCT_TASK_SEND_, IPCT_L_TS_CHANNEL)
+
+/* Peripherals used for timestamping - located in global "Main power domain" (_G1_) */
+/*   - IPCT_G1 : IPCT130_S */
+#define IPCT_G1_INST                 NRF_IPCT130_S
+#define IPCT_G1_TS_CHANNEL           2
+#if defined(NRF54H20_ENGA_XXAA)
+#define IPCT_G1_SHORTS               IPCT_SHORTS_RECEIVE2_ACK2_Msk
+#else
+#define IPCT_G1_SHORTS               IPCT_SHORTS_RECEIVE2_FLUSH2_Msk
+#endif
+#define IPCT_G1_EVENT_RECEIVE        NRFX_CONCAT_2(NRF_IPCT_EVENT_RECEIVE_, IPCT_G1_TS_CHANNEL)
+
+/*   - DPPIC_G1 : DPPIC130_S */
+/* The channel must be in the [0..7] range to satisfy the requirements for the dependent macros */
+#define DPPIC_G1_INST                NRF_DPPIC130_S
+#define DPPIC_G1_TS_CHANNEL          3
+
+/*   - PPIB_G1 : PPIB130_S */
+#define PPIB_G1_TS_CHANNEL           (DPPIC_G1_TS_CHANNEL + 8) /* hw-fixed dependency */
+
+/* Peripherals used for timestamping - located in global "Active power domain" (_G2_) */
+/*   - PPIB_G2 : PPIB133_S */
+#define PPIB_G2_TS_CHANNEL           (PPIB_G1_TS_CHANNEL - 8) /* hw-fixed dependency */
+
+/*   - DPPIC_G2 : DPPIC132_S */
+#define DPPIC_G2_INST                NRF_DPPIC132_S
+#define DPPIC_G2_TS_CHANNEL          (PPIB_G2_TS_CHANNEL + 0) /* hw-fixed dependency */
+
+#if (PPIB_G1_TS_CHANNEL < 8) || (PPIB_G1_TS_CHANNEL > 15)
+/* Only this range of channels can be connected to PPIB133 */
+#error PPIB_G1_TS_CHANNEL is required to be in the [8..15] range
+#endif
+
+/* Ensure something similar to this is present in the DT:
+ * &dppic130 {
+ *	owned-channels = <3>;
+ *	source-channels = <3>;
+ * };
+ * where 3 corresponds to DPPIC_G1_TS_CHANNEL.
+ */
+#define _TS_DT_CHECK_DPPIC_G1_CHANNEL(node_id, prop, idx) \
+	(DT_PROP_BY_IDX(node_id, prop, idx) == DPPIC_G1_TS_CHANNEL) ||
+
+#define TS_DT_HAS_RESERVED_DPPIC_G1_CHANNEL		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(dppic130), source_channels), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(dppic130), \
+					  source_channels, \
+					  _TS_DT_CHECK_DPPIC_G1_CHANNEL) false), \
+		    (false))
+
+BUILD_ASSERT(TS_DT_HAS_RESERVED_DPPIC_G1_CHANNEL,
+	     "The required DPPIC_G1 channel is not reserved");
+
+/* Ensure something similar to this is present in the DT:
+ * &dppic132 {
+ *	owned-channels = <3>;
+ *	sink-channels = <3>;
+ * };
+ * where 3 corresponds to DPPIC_G2_TS_CHANNEL.
+ */
+#define _TS_DT_CHECK_DPPIC_G2_CHANNEL(node_id, prop, idx) \
+	(DT_PROP_BY_IDX(node_id, prop, idx) == DPPIC_G2_TS_CHANNEL) ||
+
+#define TS_DT_HAS_RESERVED_DPPIC_G2_CHANNEL		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(dppic132), sink_channels), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(dppic132), \
+					  sink_channels, \
+					  _TS_DT_CHECK_DPPIC_G2_CHANNEL) false), \
+		    (false))
+
+BUILD_ASSERT(TS_DT_HAS_RESERVED_DPPIC_G2_CHANNEL,
+	     "The required DPPIC_G2 channel is not reserved");
+
+/* Ensure something similar to this is present in the DT:
+ * &cpurad_ipct {
+ *	source-channel-links = <2 13 2>;
+ * };
+ * where first 2 corresponds to IPCT_L_TS_CHANNEL.
+ */
+#define _TS_DT_CHECK_IPCT_L_LINK(node_id, prop, idx) \
+	((DT_PROP_BY_IDX(node_id, prop, idx) == IPCT_L_TS_CHANNEL) && ((idx) % 3 == 0)) ||
+
+
+#define TS_DT_HAS_RESERVED_IPCT_L_LINK		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(cpurad_ipct), source_channel_links), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(cpurad_ipct), \
+					  source_channel_links, \
+					  _TS_DT_CHECK_IPCT_L_LINK) false), \
+		    (false))
+
+/* NOTE: this not verifying the allocation as the device tree property is an
+ * array of triplets that is difficult to separate using macros.
+ */
+BUILD_ASSERT(TS_DT_HAS_RESERVED_IPCT_L_LINK,
+	     "The required IPCT_radio link is not reserved");
+
+/* Ensure something similar to this is present in the DT:
+ * &ipct130 {
+ *	sink-channel-links = <2 3 2>;
+ * };
+ * where first 2 corresponds to IPCT_G1_TS_CHANNEL.
+ */
+#define _TS_DT_CHECK_IPCT_G1_LINK(node_id, prop, idx) \
+	((DT_PROP_BY_IDX(node_id, prop, idx) == IPCT_G1_TS_CHANNEL) && ((idx) % 3 == 0)) ||
+
+
+#define TS_DT_HAS_RESERVED_IPCT_G1_LINK		\
+	COND_CODE_1(DT_NODE_HAS_PROP(DT_NODELABEL(ipct130), sink_channel_links), \
+		    (DT_FOREACH_PROP_ELEM(DT_NODELABEL(ipct130), \
+					  sink_channel_links, \
+					  _TS_DT_CHECK_IPCT_G1_LINK) false), \
+		    (false))
+
+/* NOTE: this not verifying the allocation as the device tree property is an
+ * array of triplets that is difficult to separate using macros.
+ */
+BUILD_ASSERT(TS_DT_HAS_RESERVED_IPCT_G1_LINK,
+	     "The required IPCT_G1 link is not reserved");
+
+
+void nrf_802154_platform_timestamper_cross_domain_connections_setup(void)
+{
+	/* {c} IPCT_radio --> IPCT_130
+	 * It is assumed that this connection has already been made by SECURE-core as a result of
+	 * configuring the UICR->IPCMAP[] registers.
+	 *
+	 * Only enable auto confirmations on destination - IPCT_130.
+	 */
+	nrf_ipct_shorts_enable(IPCT_G1_INST, IPCT_G1_SHORTS);
+
+	/* {d} IPCT_130 --> DPPIC_130 */
+	nrf_ipct_publish_set(IPCT_G1_INST, IPCT_G1_EVENT_RECEIVE, DPPIC_G1_TS_CHANNEL);
+
+	/* {e} DPPIC_130 --> PPIB_130
+	 * It is assumed that this connection has already been made by SECURE-core as a result of
+	 * configuring the UICR->DPPI.GLOBAL[].CH.LINK.SOURCE registers.
+	 *
+	 * Only enable relevant DPPIC_G1_INST channel.
+	 */
+	nrfy_dppi_channels_enable(DPPIC_G1_INST, 1UL << DPPIC_G1_TS_CHANNEL);
+
+	/* {f} PPIB_130 --> PPIB_133
+	 * One of HW-fixed connections (channels [8..15] --> [0..7]), so nothing to do.
+	 */
+
+	/* {g} PPIB_133 --> DPPIC_132
+	 * It is assumed that this connection has already been made by SECURE-core as a result of
+	 * configuring of the UICR->DPPI.GLOBAL[].CH.LINK.SINK registers.
+	 */
+
+	/* {h} DPPIC_132 --> GRTC.CC */
+	nrf_grtc_task_t capture_task =
+		nrfy_grtc_sys_counter_capture_task_get(m_timestamp_cc_channel);
+	NRF_DPPI_ENDPOINT_SETUP(
+		nrfy_grtc_task_address_get(NRF_GRTC, capture_task), DPPIC_G2_TS_CHANNEL);
+
+	/* Enable relevant DPPIC_G2_INST channel. */
+	nrfy_dppi_channels_enable(DPPIC_G2_INST, 1UL << DPPIC_G2_TS_CHANNEL);
+}
+
+void nrf_802154_platform_timestamper_local_domain_connections_setup(uint32_t dppi_ch)
+{
+	/* {a} RADIO.EVENT_{?} --> DPPIC_020[dppi_ch]
+	 * It is the responsibility of the user of this platform to make the {a} connection
+	 * and pass the DPPI channel number as a parameter here.
+	 */
+
+	/* {b} DPPIC_020[dppi_ch] to IPCT_radio. */
+	nrf_ipct_subscribe_set(NRF_IPCT, IPCT_L_TASK_SEND, dppi_ch);
+}
+
+#elif defined(NRF54L_SERIES)
+
+/* To trigger GRTC.TASKS_CAPTURE[#cc] with RADIO.EVENT_{?}, the following connection chain must be
+ * created:
+ *    - starting from RADIO domain (_R_):
+ *        {a} RADIO.EVENT_{?}  --> DPPIC_10
+ *        {b} DPPIC_10         --> PPIB_11
+ *    - crossing domain boundaries
+ *        {c} PPIB_11          --> PPIB_21
+ *    - ending in the PERI domain (_P_):
+ *        {d} PPIB_21          --> DPPIC_20
+ *        {e} DPPIC_20         --> GRTC.CC
+ */
+
+#include <helpers/nrfx_gppi.h>
+#include <soc/interconnect/nrfx_gppi_d2ppi.h>
+
+static nrfx_gppi_handle_t rad_peri_handle;
+static uint32_t ppib_chan;
+
+void nrf_802154_platform_timestamper_cross_domain_connections_setup(void)
+{
+	nrfx_gppi_resource_t resource = {
+		.domain_id = NRFX_GPPI_DOMAIN_RAD,
+		.channel = 0
+	};
+	nrf_grtc_task_t capture_task =
+		nrfy_grtc_sys_counter_capture_task_get(m_timestamp_cc_channel);
+	uint32_t tep = nrfy_grtc_task_address_get(NRF_GRTC, capture_task);
+	int err;
+
+	err = nrfx_gppi_ext_conn_alloc(NRFX_GPPI_DOMAIN_RAD, NRFX_GPPI_DOMAIN_PERI,
+				       &rad_peri_handle, &resource);
+	__ASSERT_NO_MSG(err == 0);
+
+	/* Add task endpoint (GRTC capture) to the previously configured connection. */
+	err = nrfx_gppi_ep_attach(tep, rad_peri_handle);
+	__ASSERT_NO_MSG(err == 0);
+
+	/* Get PPIB channel used in the connection. */
+	ppib_chan = nrfx_gppi_domain_channel_get(rad_peri_handle, NRFX_GPPI_NODE_PPIB11_21);
+	__ASSERT_NO_MSG(ppib_chan >= 0);
+
+	/* Disable PPIB for now until exact channel from RADIO domain is known. */
+	nrf_ppib_subscribe_clear(NRF_PPIB11, nrf_ppib_send_task_get(ppib_chan));
+
+	nrfx_gppi_conn_enable(rad_peri_handle);
+}
+
+void nrf_802154_platform_timestamper_local_domain_connections_setup(uint32_t dppi_ch)
+{
+	z_nrf_grtc_timer_capture_prepare(m_timestamp_cc_channel);
+	/* Configure PPIB to forward provided DPPI channel from Radio domain and enable
+	 * the connection.
+	 */
+	nrf_ppib_subscribe_set(NRF_PPIB11, nrf_ppib_send_task_get(ppib_chan), dppi_ch);
+}
+
+#endif
+
+void nrf_802154_platform_timestamper_init(void)
+{
+	m_timestamp_cc_channel = z_nrf_grtc_timer_chan_alloc();
+	assert(m_timestamp_cc_channel >= 0);
+}
+
+void nrf_802154_platform_timestamper_cross_domain_connections_clear(void)
+{
+	nrf_grtc_task_t capture_task =
+		nrfy_grtc_sys_counter_capture_task_get(m_timestamp_cc_channel);
+
+	NRF_DPPI_ENDPOINT_CLEAR(nrfy_grtc_task_address_get(NRF_GRTC, capture_task));
+}
+
+void nrf_802154_platform_timestamper_local_domain_connections_clear(uint32_t dppi_ch)
+{
+	/* Intentionally empty. */
+}
+
+bool nrf_802154_platform_timestamper_captured_timestamp_read(uint64_t *p_captured)
+{
+	/* @todo: check if this can be replaced with:
+	 *
+	 * z_nrf_grtc_timer_capture_read(m_timestamp_cc_channel, p_captured);
+	 */
+	if (nrf_grtc_sys_counter_cc_enable_check(NRF_GRTC, m_timestamp_cc_channel)) {
+		return false;
+	}
+
+	*p_captured = nrfy_grtc_sys_counter_cc_get(NRF_GRTC, m_timestamp_cc_channel);
+	return true;
+}

--- a/nrf_802154/zephyr/CMakeLists.txt
+++ b/nrf_802154/zephyr/CMakeLists.txt
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if(CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)
+  if(CONFIG_NRF_802154_SL)
+    if(CONFIG_SOC_COMPATIBLE_NRF52X OR CONFIG_SOC_COMPATIBLE_NRF53X)
+      target_sources(nrf-802154-platform
+        PRIVATE
+          ${CMAKE_CURRENT_SOURCE_DIR}/../sl/platform/zephyr/nrf_802154_hp_timer.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/../sl/platform/zephyr/nrf_802154_platform_sl_lptimer_zephyr.c
+      )
+    elseif(CONFIG_SOC_SERIES_NRF54H OR CONFIG_SOC_SERIES_NRF54L)
+      target_sources(nrf-802154-platform
+        PRIVATE
+          ${CMAKE_CURRENT_SOURCE_DIR}/../sl/platform/zephyr/nrf_802154_platform_timestamper.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/../sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/../sl/platform/zephyr/nrf_802154_platform_sl_lptimer_grtc_hw_task.c
+      )
+    endif()
+  endif()
+
+  if(CONFIG_MPSL)
+    target_compile_definitions(nrf-802154-platform PUBLIC NRF_802154_VERIFY_PERIPHS_ALLOC_AGAINST_MPSL=1)
+  endif()
+
+  set(NRF53_SERIES  ${CONFIG_SOC_SERIES_NRF53})
+  set(SER_HOST      ${CONFIG_NRF_802154_SER_HOST})
+  set(SL_OPENSOURCE ${CONFIG_NRF_802154_SL_OPENSOURCE})
+
+  if(CONFIG_NRF_802154_SOURCE_NRFXLIB)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ nrf_802154)
+
+    target_link_libraries(nrf-802154-driver-interface INTERFACE zephyr-802154-interface)
+    target_link_libraries(nrf-802154-serialization-interface INTERFACE zephyr-802154-interface)
+  endif(CONFIG_NRF_802154_SOURCE_NRFXLIB)
+
+  target_compile_definitions(zephyr-802154-interface
+    INTERFACE
+      NRF_802154_ECB_PRIORITY=-1
+      NRF_802154_SWI_PRIORITY=1
+      NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US=${CONFIG_NRF_802154_CCAIDLE_TO_TXEN_EXTRA_TIME_US}
+      NRF_802154_CSMA_CA_MIN_BE_DEFAULT=${CONFIG_NRF_802154_CSMA_CA_MIN_BE_DEFAULT}
+      NRF_802154_CSMA_CA_MAX_BE_DEFAULT=${CONFIG_NRF_802154_CSMA_CA_MAX_BE_DEFAULT}
+      NRF_802154_CSMA_CA_MAX_CSMA_BACKOFFS_DEFAULT=${CONFIG_NRF_802154_CSMA_CA_MAX_CSMA_BACKOFFS_DEFAULT}
+  )
+
+  if(CONFIG_NRF_802154_TX_DIAGNOSTIC_MODE)
+    target_compile_definitions(zephyr-802154-interface
+      INTERFACE
+        NRF_802154_TX_DIAGNOSTIC_MODE=1
+    )
+  endif()
+
+  if(CONFIG_NRF_802154_ACK_TIMEOUT_CUSTOM_US)
+    target_compile_definitions(zephyr-802154-interface
+      INTERFACE
+        NRF_802154_PRECISE_ACK_TIMEOUT_DEFAULT_TIMEOUT=${CONFIG_NRF_802154_ACK_TIMEOUT_CUSTOM_US}
+    )
+  endif()
+
+  if(CONFIG_NRF_802154_DRV_REINIT_ENABLED)
+    target_compile_definitions(zephyr-802154-interface
+      INTERFACE
+        NRF_802154_DRV_REINIT_ENABLED=1
+    )
+  endif()
+endif(CONFIG_NRF_802154_RADIO_DRIVER OR CONFIG_NRF_802154_SERIALIZATION)

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(.. nrfxlib)
+add_subdirectory(../nrf_802154/zephyr nrf_802154_zephyr)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,5 +1,5 @@
 build:
-  cmake-ext: True
+  cmake: zephyr
   kconfig: Kconfig.nrfxlib
   depends:
   - hal_nordic


### PR DESCRIPTION
Moves files from sdk-nrf to here so this can be used as an actual zephyr module

manifest-pr-skip