### PR TITLE
cmake: Do path calculation in CMake as opposed to Kconfig

### DIFF
--- a/mpsl/CMakeLists.txt
+++ b/mpsl/CMakeLists.txt
@@ -4,15 +4,57 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (CONFIG_MPSL_BUILD_TYPE_LIB)
-  add_subdirectory(fem)
-  set(MPSL_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CONFIG_MPSL_LIB_DIR}/${CONFIG_MPSL_LIB_FLOAT_ABI_DIR}")
+if(CONFIG_MPSL_BUILD_TYPE_LIB)
+  if(CONFIG_SOC_SERIES_BSIM_NRFXX OR CONFIG_SOC_SERIES_NRF52 OR CONFIG_SOC_NRF5340_CPUNET OR
+    CONFIG_SOC_NRF54H20_CPURAD OR CONFIG_SOC_SERIES_NRF54L OR CONFIG_SOC_SERIES_NRF71
+  )
+    add_subdirectory(fem)
 
-  if(NOT EXISTS "${MPSL_LIB_DIR}/libmpsl.a")
-    message(FATAL_ERROR "This combination of SoC and floating point ABI is not supported by the MPSL lib.")
+    set(lib_dir_path "${CMAKE_CURRENT_SOURCE_DIR}/lib/")
+
+    if(CONFIG_SOC_SERIES_NRF52)
+      set(lib_dir_path ${lib_dir_path}nrf52)
+    elseif(CONFIG_SOC_NRF5340_CPUNET)
+      set(lib_dir_path ${lib_dir_path}nrf53)
+    elseif(CONFIG_SOC_NRF54H20_CPURAD)
+      set(lib_dir_path ${lib_dir_path}nrf54h)
+    elseif(CONFIG_SOC_NRF54LS05B OR CONFIG_SOC_NRF54LS05A)
+      set(lib_dir_path ${lib_dir_path}nrf54ls)
+    elseif(CONFIG_SOC_NRF54LM20A OR CONFIG_SOC_NRF54LM20B)
+      set(lib_dir_path ${lib_dir_path}nrf54lm)
+    elseif(CONFIG_SOC_NRF54LV10A OR CONFIG_SOC_NRF54LC10A)
+      set(lib_dir_path ${lib_dir_path}nrf54lv)
+    elseif(CONFIG_SOC_SERIES_NRF54L)
+      set(lib_dir_path ${lib_dir_path}nrf54l)
+    elseif(CONFIG_SOC_SERIES_NRF71)
+      set(lib_dir_path ${lib_dir_path}nrf71)
+    elseif(CONFIG_SOC_SERIES_BSIM_NRF52X)
+      set(lib_dir_path ${lib_dir_path}nrf52_bsim)
+    elseif(CONFIG_SOC_SERIES_BSIM_NRF53X)
+      set(lib_dir_path ${lib_dir_path}nrf53_bsim)
+    elseif(CONFIG_SOC_SERIES_BSIM_NRF54LX)
+      set(lib_dir_path ${lib_dir_path}nrf54l_bsim)
+    endif()
+
+    if(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+      set(lib_dir_path ${lib_dir_path}_ns)
+    endif()
+
+    if(CONFIG_FPU AND CONFIG_FP_HARDABI)
+      set(lib_dir_path ${lib_dir_path}/hard-float)
+    elseif(CONFIG_FPU AND CONFIG_FP_SOFTABI)
+      set(lib_dir_path ${lib_dir_path}/softfp-float)
+    else()
+      set(lib_dir_path ${lib_dir_path}/soft-float)
+    endif()
+
+    if(NOT EXISTS "${lib_dir_path}/libmpsl.a")
+      message(FATAL_ERROR "This combination of SoC and floating point ABI is not supported by the MPSL lib.")
+    endif()
+
+    zephyr_link_libraries(${lib_dir_path}/libmpsl.a)
   endif()
 
   zephyr_include_directories(include)
   zephyr_include_directories(include/protocol)
-  zephyr_link_libraries(${MPSL_LIB_DIR}/libmpsl.a)
 endif()

--- a/mpsl/Kconfig
+++ b/mpsl/Kconfig
@@ -4,6 +4,11 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+config HAS_MPSL_SUPPORT
+	bool
+	default y if SOC_SERIES_BSIM_NRFXX || SOC_SERIES_NRF52 || SOC_NRF5340_CPUNET || \
+		SOC_NRF54H20_CPURAD || SOC_SERIES_NRF54L || SOC_SERIES_NRF71
+
 config MPSL
 	bool "Nordic Multi Protocol Service Layer (MPSL)"
 	select ZERO_LATENCY_IRQS if !SOC_SERIES_BSIM_NRFXX
@@ -11,8 +16,7 @@ config MPSL
 	select NRF_802154_MULTIPROTOCOL_SUPPORT if NRF_802154_RADIO_DRIVER
 	select MULTITHREADING_LOCK
 	select NRF_GRTC_TIMER_AUTO_KEEP_ALIVE if NRF_GRTC_TIMER
-	depends on (SOC_SERIES_BSIM_NRFXX || SOC_SERIES_NRF52 || SOC_NRF5340_CPUNET ||\
-			SOC_NRF54H20_CPURAD || SOC_SERIES_NRF54L || SOC_SERIES_NRF71)
+	depends on HAS_MPSL_SUPPORT
 	help
 	  Use Nordic Multi Protocol Service Layer (MPSL) implementation,
 	  providing services for single and multi-protocol implementations.
@@ -28,34 +32,4 @@ config MPSL_BUILD_TYPE_LIB
 
 endchoice
 
-if MPSL_BUILD_TYPE_LIB
-config MPSL_LIB_DIR
-	string
-	default "nrf52" if SOC_SERIES_NRF52
-	default "nrf53" if SOC_NRF5340_CPUNET
-	default "nrf54h" if SOC_NRF54H20_CPURAD
-	default "nrf54ls" if SOC_NRF54LS05B || SOC_NRF54LS05A
-	default "nrf54lm_ns" if (SOC_NRF54LM20A || SOC_NRF54LM20B) && TRUSTED_EXECUTION_NONSECURE
-	default "nrf54lm" if (SOC_NRF54LM20A || SOC_NRF54LM20B) && !TRUSTED_EXECUTION_NONSECURE
-	default "nrf54lv_ns" if (SOC_NRF54LV10A || SOC_NRF54LC10A) && TRUSTED_EXECUTION_NONSECURE
-	default "nrf54lv" if (SOC_NRF54LV10A || SOC_NRF54LC10A) && !TRUSTED_EXECUTION_NONSECURE
-	default "nrf54l_ns" if SOC_SERIES_NRF54L && TRUSTED_EXECUTION_NONSECURE
-	default "nrf54l" if SOC_SERIES_NRF54L && !TRUSTED_EXECUTION_NONSECURE
-	default "nrf71_ns" if SOC_SERIES_NRF71 && TRUSTED_EXECUTION_NONSECURE
-	default "nrf71" if SOC_SERIES_NRF71 && !TRUSTED_EXECUTION_NONSECURE
-	default "nrf52_bsim" if SOC_SERIES_BSIM_NRF52X
-	default "nrf53_bsim" if SOC_SERIES_BSIM_NRF53X
-	default "nrf54l_bsim" if SOC_SERIES_BSIM_NRF54LX
-	help
-	  Hidden helper option to calculate the library path
-
-config MPSL_LIB_FLOAT_ABI_DIR
-	string
-	default "hard-float" if FPU && FP_HARDABI
-	default "softfp-float" if FPU && FP_SOFTABI
-	default "soft-float"
-	help
-	  Hidden helper option to calculate the library path
-
-endif # MPSL_BUILD_TYPE_LIB
 endif # MPSL

--- a/mpsl/fem/CMakeLists.txt
+++ b/mpsl/fem/CMakeLists.txt
@@ -3,23 +3,63 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-function(mpsl_fem_append_lib fem_lib_name)
-    set(LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${fem_lib_name}/lib/${CONFIG_MPSL_LIB_DIR}/${CONFIG_MPSL_LIB_FLOAT_ABI_DIR}")
+function(mpsl_fem_append_lib fem_lib_name fem_folder_name)
+  set(lib_dir_path "${CMAKE_CURRENT_SOURCE_DIR}/${fem_lib_name}/lib/${fem_folder_name}")
 
-    if(LIB_DIR)
-      zephyr_include_directories(${fem_lib_name}/include)
-      zephyr_link_libraries(${LIB_DIR}/libmpsl_fem_${fem_lib_name}.a)
-    endif()
+  if(EXISTS ${lib_dir_path})
+    zephyr_include_directories(${fem_lib_name}/include)
+    zephyr_link_libraries(${lib_dir_path}/libmpsl_fem_${fem_lib_name}.a)
+  endif()
 endfunction()
 
-FILE(GLOB subdirlist RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(CONFIG_SOC_SERIES_BSIM_NRFXX OR CONFIG_SOC_SERIES_NRF52 OR CONFIG_SOC_NRF5340_CPUNET OR
+  CONFIG_SOC_NRF54H20_CPURAD OR CONFIG_SOC_SERIES_NRF54L OR CONFIG_SOC_SERIES_NRF71
+)
+  if(CONFIG_SOC_SERIES_NRF52)
+    set(lib_dir_path nrf52)
+  elseif(CONFIG_SOC_NRF5340_CPUNET)
+    set(lib_dir_path nrf53)
+  elseif(CONFIG_SOC_NRF54H20_CPURAD)
+    set(lib_dir_path nrf54h)
+  elseif(CONFIG_SOC_NRF54LS05B OR CONFIG_SOC_NRF54LS05A)
+    set(lib_dir_path nrf54ls)
+  elseif(CONFIG_SOC_NRF54LM20A OR CONFIG_SOC_NRF54LM20B)
+    set(lib_dir_path nrf54lm)
+  elseif(CONFIG_SOC_NRF54LV10A OR CONFIG_SOC_NRF54LC10A)
+    set(lib_dir_path nrf54lv)
+  elseif(CONFIG_SOC_SERIES_NRF54L)
+    set(lib_dir_path nrf54l)
+  elseif(CONFIG_SOC_SERIES_NRF71)
+    set(lib_dir_path nrf71)
+  elseif(CONFIG_SOC_SERIES_BSIM_NRF52X)
+    set(lib_dir_path nrf52_bsim)
+  elseif(CONFIG_SOC_SERIES_BSIM_NRF53X)
+    set(lib_dir_path nrf53_bsim)
+  elseif(CONFIG_SOC_SERIES_BSIM_NRF54LX)
+    set(lib_dir_path nrf54l_bsim)
+  endif()
 
-# call mpsl_fem_append_lib for each subdirectory
-FOREACH(subdir ${subdirlist})
-  IF((IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}) AND NOT (${subdir} STREQUAL "include"))
-    mpsl_fem_append_lib(${subdir})
-  ENDIF()
-ENDFOREACH()
+  if(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+    set(lib_dir_path ${lib_dir_path}_ns)
+  endif()
+
+  if(CONFIG_FPU AND CONFIG_FP_HARDABI)
+    set(lib_dir_path ${lib_dir_path}/hard-float)
+  elseif(CONFIG_FPU AND CONFIG_FP_SOFTABI)
+    set(lib_dir_path ${lib_dir_path}/softfp-float)
+  else()
+    set(lib_dir_path ${lib_dir_path}/soft-float)
+  endif()
+
+  # Call mpsl_fem_append_lib for each subdirectory
+  file(GLOB subdirlist RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+
+  foreach(subdir ${subdirlist})
+    if((IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}) AND NOT (${subdir} STREQUAL "include"))
+      mpsl_fem_append_lib(${subdir} ${lib_dir_path})
+    endif()
+  endforeach()
+endif()
 
 zephyr_include_directories(include)
 zephyr_include_directories(include/protocol)

--- a/softdevice_controller/CMakeLists.txt
+++ b/softdevice_controller/CMakeLists.txt
@@ -4,30 +4,71 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
-if (CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE AND NOT CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE_PATH_OVERRIDE)
+if(CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE AND NOT CONFIG_BT_LL_SOFTDEVICE_HEADERS_INCLUDE_PATH_OVERRIDE)
   zephyr_include_directories(include)
 endif()
 
 if(CONFIG_BT_LL_SOFTDEVICE AND CONFIG_BT_LL_SOFTDEVICE_BUILD_TYPE_LIB)
-  set(SOFTDEVICE_CONTROLLER_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CONFIG_MPSL_LIB_DIR}/${CONFIG_MPSL_LIB_FLOAT_ABI_DIR}")
+  if(CONFIG_SOC_SERIES_BSIM_NRFXX OR CONFIG_SOC_SERIES_NRF52 OR
+    CONFIG_SOC_COMPATIBLE_NRF5340_CPUNET OR CONFIG_SOC_NRF54H20_CPURAD OR
+    CONFIG_SOC_SERIES_NRF54L OR CONFIG_SOC_SERIES_NRF71
+  )
+    set(lib_dir_path "${CMAKE_CURRENT_SOURCE_DIR}/lib/")
 
-  if(CONFIG_BT_LL_SOFTDEVICE_PERIPHERAL)
-    set(softdevice_controller_variant peripheral)
-  elseif(CONFIG_BT_LL_SOFTDEVICE_CENTRAL)
-    set(softdevice_controller_variant central)
-  elseif(CONFIG_BT_LL_SOFTDEVICE_MULTIROLE)
-    set(softdevice_controller_variant multirole)
-  else()
-    message(WARNING "No SoftDevice Controller variant selected")
+    if(CONFIG_SOC_SERIES_NRF52)
+      set(lib_dir_path ${lib_dir_path}nrf52)
+    elseif(CONFIG_SOC_NRF5340_CPUNET)
+      set(lib_dir_path ${lib_dir_path}nrf53)
+    elseif(CONFIG_SOC_NRF54H20_CPURAD)
+      set(lib_dir_path ${lib_dir_path}nrf54h)
+    elseif(CONFIG_SOC_NRF54LS05B OR CONFIG_SOC_NRF54LS05A)
+      set(lib_dir_path ${lib_dir_path}nrf54ls)
+    elseif(CONFIG_SOC_NRF54LM20A OR CONFIG_SOC_NRF54LM20B)
+      set(lib_dir_path ${lib_dir_path}nrf54lm)
+    elseif(CONFIG_SOC_NRF54LV10A OR CONFIG_SOC_NRF54LC10A)
+      set(lib_dir_path ${lib_dir_path}nrf54lv)
+    elseif(CONFIG_SOC_SERIES_NRF54L)
+      set(lib_dir_path ${lib_dir_path}nrf54l)
+    elseif(CONFIG_SOC_SERIES_NRF71)
+      set(lib_dir_path ${lib_dir_path}nrf71)
+    elseif(CONFIG_SOC_SERIES_BSIM_NRF52X)
+      set(lib_dir_path ${lib_dir_path}nrf52_bsim)
+    elseif(CONFIG_SOC_SERIES_BSIM_NRF53X)
+      set(lib_dir_path ${lib_dir_path}nrf53_bsim)
+    elseif(CONFIG_SOC_SERIES_BSIM_NRF54LX)
+      set(lib_dir_path ${lib_dir_path}nrf54l_bsim)
+    endif()
+
+    if(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+      set(lib_dir_path ${lib_dir_path}_ns)
+    endif()
+
+    if(CONFIG_FPU AND CONFIG_FP_HARDABI)
+      set(lib_dir_path ${lib_dir_path}/hard-float)
+    elseif(CONFIG_FPU AND CONFIG_FP_SOFTABI)
+      set(lib_dir_path ${lib_dir_path}/softfp-float)
+    else()
+      set(lib_dir_path ${lib_dir_path}/soft-float)
+    endif()
+
+    set(lib_dir_path ${lib_dir_path}/libsoftdevice_controller_)
+
+    if(CONFIG_BT_LL_SOFTDEVICE_PERIPHERAL)
+      set(lib_dir_path ${lib_dir_path}peripheral.a)
+    elseif(CONFIG_BT_LL_SOFTDEVICE_CENTRAL)
+      set(lib_dir_path ${lib_dir_path}central.a)
+    elseif(CONFIG_BT_LL_SOFTDEVICE_MULTIROLE)
+      set(lib_dir_path ${lib_dir_path}multirole.a)
+    else()
+      message(WARNING "No SoftDevice Controller variant selected")
+    endif()
+
+    if(NOT EXISTS ${lib_dir_path})
+      message(FATAL_ERROR "This combination of SoC and floating point ABI is not "
+        "supported by the SoftDevice Controller lib."
+      )
+    endif()
+
+    zephyr_link_libraries(${lib_dir_path})
   endif()
-
-  set(SOFTDEVICE_CONTROLLER_LIB
-    ${SOFTDEVICE_CONTROLLER_LIB_DIR}/libsoftdevice_controller_${softdevice_controller_variant}.a)
-
-  if(NOT EXISTS ${SOFTDEVICE_CONTROLLER_LIB})
-    message(FATAL_ERROR "This combination of SoC and floating point ABI is not"
-      "supported by the SoftDevice Controller lib.")
-  endif()
-
-  zephyr_link_libraries(${SOFTDEVICE_CONTROLLER_LIB})
 endif()


### PR DESCRIPTION
These Kconfigs should not have been added to begin with. This is not optimal and can be improved by making a common function in a future task

manifest-pr-skip