### PR TITLE
doc: openthread: add nRF54L Thread CID links

### DIFF
--- a/doc/links.txt
+++ b/doc/links.txt
@@ -34,6 +34,11 @@
 
 .. _`nRF21540`: https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF21540
 
+.. _`Thread CIDs for nRF54LM20B`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_thread_cids.html
+.. _`Thread CIDs for nRF54LM20A`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54lm20a/page/COMP/nrf54lm20a/nrf54lm20a_thread_cids.html
+.. _`Thread CIDs for nRF54L15`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l15/page/COMP/nrf54l15/nrf54l15_thread_cids.html
+.. _`Thread CIDs for nRF54L10`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l10/page/COMP/nrf54l10/nrf54l10_thread_cids.html
+.. _`Thread CIDs for nRF54L05`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf54l05/page/COMP/nrf54l05/nrf54l05_thread_cids.html
 .. _`Thread CIDs for nRF5340`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf5340/page/COMP/nrf5340/nrf5340_thread_cids.html
 .. _`Thread CIDs for nRF52840`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf52840/page/COMP/nrf52840/nrf52840_thread_cids.html
 .. _`Thread CIDs for nRF52833`: https://docs.nordicsemi.com/bundle/comp_matrix_nrf52833/page/COMP/nrf52833/nrf52833_thread_cids.html

--- a/openthread/README.rst
+++ b/openthread/README.rst
@@ -24,8 +24,14 @@ For the full list of configuration options that were used during compilation of 
 Certified libraries
 *******************
 
-Check the following compatibility matrices for information about which library variants and versions are certified for a specific device:
+Check the following compatibility matrices for information about which library variants and versions are certified for a specific device.
+Each matrix maps the parent Certification ID (CID) to the |NCS| releases that provide the certified OpenThread libraries.
 
+* `Thread CIDs for nRF54LM20B`_
+* `Thread CIDs for nRF54LM20A`_
+* `Thread CIDs for nRF54L15`_
+* `Thread CIDs for nRF54L10`_
+* `Thread CIDs for nRF54L05`_
 * `Thread CIDs for nRF5340`_
 * `Thread CIDs for nRF52840`_
 * `Thread CIDs for nRF52833`_


### PR DESCRIPTION
Add compatibility matrix links for nRF54L-family SoCs so parent CID to NCS release traceability matches the existing nRF52 and nRF53 docs.