### PR TITLE
nrf_rpc: fix race condition in disable/enable functionality

### DIFF
--- a/nrf_rpc/Kconfig
+++ b/nrf_rpc/Kconfig
@@ -46,6 +46,13 @@ config NRF_RPC_GROUP_INIT_WAIT_TIME
 	  The number of milliseconds to wait for the remote cores to send group
 	  init packets with destination group IDs. Set to -1 to wait forever.
 
+config NRF_RPC_STOP_WAIT_TIME
+	int "RPC stop wait timeout in milliseconds"
+	default 1000
+	help
+	  The number of milliseconds to wait in nrf_rpc_stop() for all in-flight
+	  RPC processing to complete. Set to -1 to wait forever.
+
 config NRF_RPC_GROUP_DEFAULT_INITIATOR
 	bool "Initiate group binding by default"
 	default y

--- a/nrf_rpc/include/nrf_rpc.h
+++ b/nrf_rpc/include/nrf_rpc.h
@@ -447,20 +447,33 @@ void nrf_rpc_register_cleanup_handler(struct nrf_rpc_cleanup_handler *handler);
  * Calling this function automatically fails all communication until @ref nrf_rpc_resume is called.
  * It also causes all pending commands to fail immediately.
  *
+ * @warning This function is experimental and subject to change or removal without prior notice.
+ *
  * @param cleanup set to true to also invoke all the custom cleanup handlers.
  *
  * @note If the cleanup parameter is set to true it may be needed to reset the peer before invoking
  *       @ref nrf_rpc_resume.
  *
+ * @retval 0             on success.
+ * @retval -NRF_EALREADY when RPC is already stopped or stopping.
+ * @retval -NRF_ETIMEDOUT when waiting for in-flight RPC processing to complete times out
+ *                        and assertions are disabled.
+ *
  */
-void nrf_rpc_stop(bool cleanup);
+int nrf_rpc_stop(bool cleanup);
 
 /** @brief resumes RPC communication
  *
  * Calling this function reverts the effects of @ref nrf_rpc_stop.
  *
+ * @warning This function is experimental and subject to change or removal without prior notice.
+ *
+ * @retval 0             on success.
+ * @retval -NRF_EINPROGRESS when RPC is currently stopping.
+ * @retval -NRF_EALREADY when RPC is already running.
+ *
  */
-void nrf_rpc_resume(void);
+int nrf_rpc_resume(void);
 
 
 /** @brief Send a command and provide callback to handle response.

--- a/nrf_rpc/include/nrf_rpc.h
+++ b/nrf_rpc/include/nrf_rpc.h
@@ -452,15 +452,24 @@ void nrf_rpc_register_cleanup_handler(struct nrf_rpc_cleanup_handler *handler);
  * @note If the cleanup parameter is set to true it may be needed to reset the peer before invoking
  *       @ref nrf_rpc_resume.
  *
+ * @retval 0             on success.
+ * @retval -NRF_EALREADY when RPC is already stopped or stopping.
+ * @retval -NRF_ETIMEDOUT when waiting for in-flight RPC processing to complete times out
+ *                        and assertions are disabled.
+ *
  */
-void nrf_rpc_stop(bool cleanup);
+int nrf_rpc_stop(bool cleanup);
 
 /** @brief resumes RPC communication
  *
  * Calling this function reverts the effects of @ref nrf_rpc_stop.
  *
+ * @retval 0             on success.
+ * @retval -NRF_EINPROGRESS when RPC is currently stopping.
+ * @retval -NRF_EALREADY when RPC is already running.
+ *
  */
-void nrf_rpc_resume(void);
+int nrf_rpc_resume(void);
 
 
 /** @brief Send a command and provide callback to handle response.

--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <assert.h>
 
 #include "nrf_rpc.h"
 #include "nrf_rpc_tr.h"
@@ -129,7 +130,20 @@ static uint8_t initialized_group_count;
 
 /* nRF RPC initialization status. */
 static bool is_initialized;
-static bool is_stopped;
+enum nrf_rpc_runtime_state {
+	NRF_RPC_STATE_RUNNING,
+	NRF_RPC_STATE_STOPPING,
+	NRF_RPC_STATE_STOPPED,
+};
+static enum nrf_rpc_runtime_state rpc_runtime_state = NRF_RPC_STATE_RUNNING;
+
+static bool nrf_rpc_record_processing_start(void);
+static void nrf_rpc_record_processing_end(void);
+
+static bool nrf_rpc_state_is_stopped(void)
+{
+	return rpc_runtime_state != NRF_RPC_STATE_RUNNING;
+}
 
 /* Error handler provided to the init function. */
 static nrf_rpc_err_handler_t global_err_handler;
@@ -140,7 +154,9 @@ static nrf_rpc_group_bound_handler_t global_bound_handler;
 static struct internal_task internal_task;
 static struct nrf_rpc_os_event internal_task_consumed;
 
-static struct nrf_rpc_os_mutex cleanup_mutex;
+static struct nrf_rpc_os_event processing_complete_event;
+static uint8_t processing_in_progress_count;
+static struct nrf_rpc_os_mutex rpc_state_mutex;
 static struct nrf_rpc_cleanup_handler *cleanup_handlers;
 
 /* Array with all defiend groups */
@@ -714,6 +730,7 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 	struct header hdr;
 	struct nrf_rpc_cmd_ctx *cmd_ctx = NULL;
 	const struct nrf_rpc_group *group = NULL;
+	bool is_stopped_local = nrf_rpc_record_processing_start();
 
 	err = header_decode(packet, len, &hdr);
 	if (err < 0) {
@@ -721,7 +738,7 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 		goto cleanup_and_exit;
 	}
 
-	if (is_stopped &&
+	if (is_stopped_local &&
 	    (hdr.type == NRF_RPC_PACKET_TYPE_CMD ||
 	     hdr.type == NRF_RPC_PACKET_TYPE_EVT ||
 	     hdr.type == NRF_RPC_PACKET_TYPE_ACK ||
@@ -815,6 +832,8 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 						      NRF_RPC_OS_WAIT_FOREVER);
 			}
 		}
+
+		nrf_rpc_record_processing_end();
 		return;
 
 	case NRF_RPC_PACKET_TYPE_EVT:
@@ -830,6 +849,7 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 					      NRF_RPC_OS_WAIT_FOREVER);
 		}
 
+		nrf_rpc_record_processing_end();
 		return;
 
 	case NRF_RPC_PACKET_TYPE_ACK:
@@ -861,6 +881,8 @@ cleanup_and_exit:
 	if (!auto_free_rx_buf(transport)) {
 		transport->api->rx_buf_free(transport, (void *)packet);
 	}
+
+	nrf_rpc_record_processing_end();
 
 	if (err < 0) {
 		internal_task.type = NRF_RPC_TASK_RECV_ERROR;
@@ -910,7 +932,10 @@ static int wait_for_response(const struct nrf_rpc_group *group, struct nrf_rpc_c
 	NRF_RPC_DBG("Waiting for a response");
 
 	do {
+
+		nrf_rpc_record_processing_end();
 		nrf_rpc_os_msg_get(&cmd_ctx->recv_msg, &cmd_ctx->mutex, &packet, &len);
+		nrf_rpc_record_processing_start();
 
 		if (packet == NULL) {
 			return -NRF_ETIMEDOUT;
@@ -974,14 +999,13 @@ int nrf_rpc_cmd_common(const struct nrf_rpc_group *group, uint32_t cmd,
 		handler_data = ptr2;
 	}
 
-	nrf_rpc_os_mutex_lock(&cleanup_mutex);
-	if (is_stopped) {
+	bool cmd_stopped = nrf_rpc_record_processing_start();
+
+	if (cmd_stopped) {
 		err = -NRF_EPERM;
-		nrf_rpc_os_mutex_unlock(&cleanup_mutex);
 	} else {
 
 		cmd_ctx = cmd_ctx_reserve();
-		nrf_rpc_os_mutex_unlock(&cleanup_mutex); /* release the mutex as the context specific one has been acquired */
 
 		hdr.dst = cmd_ctx->remote_id;
 		hdr.src = cmd_ctx->id;
@@ -1022,6 +1046,7 @@ int nrf_rpc_cmd_common(const struct nrf_rpc_group *group, uint32_t cmd,
 		cmd_ctx_release(cmd_ctx);
 	}
 
+	nrf_rpc_record_processing_end();
 	return err;
 }
 
@@ -1140,7 +1165,9 @@ int nrf_rpc_setup(nrf_rpc_err_handler_t err_handler, nrf_rpc_group_bound_handler
 		return 0;
 	}
 
-	nrf_rpc_os_mutex_init(&cleanup_mutex);
+	nrf_rpc_os_mutex_init(&rpc_state_mutex);
+	nrf_rpc_os_event_init(&processing_complete_event);
+	nrf_rpc_os_event_set(&processing_complete_event); /* initially set to 1 to avoid waiting for the event in nrf_rpc_stop */
 
 	global_err_handler = err_handler;
 	global_bound_handler = bound_handler;
@@ -1285,7 +1312,12 @@ int nrf_rpc_init(nrf_rpc_err_handler_t err_handler)
 
 void nrf_rpc_register_cleanup_handler(struct nrf_rpc_cleanup_handler *handler)
 {
-	nrf_rpc_os_mutex_lock(&cleanup_mutex);
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+
+	if (nrf_rpc_state_is_stopped()) {
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+		return;
+	}
 
 	struct nrf_rpc_cleanup_handler *current;
 
@@ -1301,14 +1333,54 @@ void nrf_rpc_register_cleanup_handler(struct nrf_rpc_cleanup_handler *handler)
 		cleanup_handlers = handler;
 	}
 
-	nrf_rpc_os_mutex_unlock(&cleanup_mutex);
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
 }
 
-void nrf_rpc_stop(bool cleanup)
+static bool nrf_rpc_record_processing_start(void)
 {
-	nrf_rpc_os_mutex_lock(&cleanup_mutex);
+	bool stopped;
 
-	is_stopped = true;
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	assert(processing_in_progress_count < UINT8_MAX);
+
+	nrf_rpc_os_event_wait(&processing_complete_event,
+			      NRF_RPC_OS_NO_WAIT); /* take if available */
+
+	processing_in_progress_count++;
+	stopped = nrf_rpc_state_is_stopped(); /* snapshot under the same lock as the count increment */
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+
+	return stopped;
+}
+
+static void nrf_rpc_record_processing_end(void)
+{
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	assert(processing_in_progress_count > 0);
+
+	processing_in_progress_count--;
+	if (processing_in_progress_count == 0) {
+		nrf_rpc_os_event_set(&processing_complete_event);
+	}
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+}
+
+static bool nrf_rpc_request_completion(void)
+{
+	bool request_done;
+
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	request_done = (rpc_runtime_state == NRF_RPC_STATE_RUNNING);
+	if (request_done) {
+		rpc_runtime_state = NRF_RPC_STATE_STOPPING;
+	}
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+
+	return request_done;
+}
+
+static void nrf_rpc_finalize_stop(bool cleanup)
+{
 	abort_all_ops();
 	if (cleanup) {
 		struct nrf_rpc_cleanup_handler *current;
@@ -1318,13 +1390,52 @@ void nrf_rpc_stop(bool cleanup)
 			}
 		}
 	}
-
-	nrf_rpc_os_mutex_unlock(&cleanup_mutex);
 }
 
-void nrf_rpc_resume(void)
+int nrf_rpc_stop(bool cleanup)
 {
-	is_stopped = false;
+	int err;
+	bool requested = nrf_rpc_request_completion();
+	if (requested) {
+		err = nrf_rpc_os_event_wait(&processing_complete_event, CONFIG_NRF_RPC_STOP_WAIT_TIME);
+		if (err) {
+			assert(err != -NRF_ETIMEDOUT);
+			nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+			rpc_runtime_state = NRF_RPC_STATE_RUNNING;
+			nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+			return err;
+		}
+		nrf_rpc_finalize_stop(cleanup);
+		nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+		rpc_runtime_state = NRF_RPC_STATE_STOPPED;
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+		return 0;
+	}
+
+	return -NRF_EALREADY;
+}
+
+int nrf_rpc_resume(void)
+{
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex); /* just in case, for future use */
+
+	if (rpc_runtime_state == NRF_RPC_STATE_STOPPING) {
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+		return -NRF_EINPROGRESS;
+	}
+
+	if (rpc_runtime_state == NRF_RPC_STATE_RUNNING) {
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+		return -NRF_EALREADY;
+	}
+
+	rpc_runtime_state = NRF_RPC_STATE_RUNNING;
+	if (processing_in_progress_count == 0) { /* restore event if was claimed by nrf_rpc_stop */
+		nrf_rpc_os_event_set(&processing_complete_event);
+	}
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+
+	return 0;
 }
 
 int nrf_rpc_cmd(const struct nrf_rpc_group *group, uint8_t cmd, uint8_t *packet,

--- a/nrf_rpc/nrf_rpc.c
+++ b/nrf_rpc/nrf_rpc.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <assert.h>
 
 #include "nrf_rpc.h"
 #include "nrf_rpc_tr.h"
@@ -129,7 +130,16 @@ static uint8_t initialized_group_count;
 
 /* nRF RPC initialization status. */
 static bool is_initialized;
-static bool is_stopped;
+enum nrf_rpc_runtime_state {
+	NRF_RPC_STATE_RUNNING,
+	NRF_RPC_STATE_BINDING,
+	NRF_RPC_STATE_STOPPING,
+	NRF_RPC_STATE_STOPPED,
+};
+static enum nrf_rpc_runtime_state rpc_runtime_state = NRF_RPC_STATE_RUNNING;
+
+static enum nrf_rpc_runtime_state nrf_rpc_record_processing_start(void);
+static void nrf_rpc_record_processing_end(void);
 
 /* Error handler provided to the init function. */
 static nrf_rpc_err_handler_t global_err_handler;
@@ -140,7 +150,9 @@ static nrf_rpc_group_bound_handler_t global_bound_handler;
 static struct internal_task internal_task;
 static struct nrf_rpc_os_event internal_task_consumed;
 
-static struct nrf_rpc_os_mutex cleanup_mutex;
+static struct nrf_rpc_os_event processing_complete_event;
+static uint8_t processing_in_progress_count;
+static struct nrf_rpc_os_mutex rpc_state_mutex;
 static struct nrf_rpc_cleanup_handler *cleanup_handlers;
 
 /* Array with all defiend groups */
@@ -201,6 +213,8 @@ static struct nrf_rpc_cmd_ctx *cmd_ctx_alloc(void)
 	ctx->handler = NULL;
 	ctx->remote_id = NRF_RPC_ID_UNKNOWN;
 	ctx->use_count = 1;
+	ctx->recv_msg.data = NULL;
+	ctx->recv_msg.len = 0;
 
 	nrf_rpc_os_tls_set(ctx);
 
@@ -542,11 +556,18 @@ static uint8_t parse_incoming_packet(struct nrf_rpc_cmd_ctx *cmd_ctx,
 /* Thread pool callback */
 static void execute_packet(const uint8_t *packet, size_t len)
 {
+	/* The dispatcher signals decode_done_event / internal_task_consumed long before the
+	 * work is finished, so account for the remainder here.
+	 */
+	(void)nrf_rpc_record_processing_start();
+
 	if (packet == (const uint8_t *)&internal_task) {
 		internal_tx_handler();
 	} else {
 		parse_incoming_packet(NULL, packet, len);
 	}
+
+	nrf_rpc_record_processing_end();
 }
 
 static bool protocol_version_check(const struct init_packet_data *init_data)
@@ -698,10 +719,26 @@ static void abort_all_ops(void)
 	for (int i = 0; i < CONFIG_NRF_RPC_CMD_CTX_POOL_SIZE; i++) {
 		struct nrf_rpc_cmd_ctx *ctx = &cmd_ctx_pool[i];
 		nrf_rpc_os_mutex_lock(&ctx->mutex);
-		if (ctx->use_count > 0) {
+		if (ctx->use_count > 0 && ctx->recv_msg.data == NULL) {
 			nrf_rpc_os_msg_set(&ctx->recv_msg, NULL, 0);
 		}
 		nrf_rpc_os_mutex_unlock(&ctx->mutex);
+	}
+}
+
+static bool packet_type_accepted(enum nrf_rpc_runtime_state state, uint8_t packet_type)
+{
+	switch (state) {
+	case NRF_RPC_STATE_RUNNING:
+		return true;
+	case NRF_RPC_STATE_BINDING:
+		return (packet_type == NRF_RPC_PACKET_TYPE_INIT ||
+			packet_type == NRF_RPC_PACKET_TYPE_ERR);
+	case NRF_RPC_STATE_STOPPING:
+	case NRF_RPC_STATE_STOPPED:
+		return (packet_type == NRF_RPC_PACKET_TYPE_ERR);
+	default:
+		return false;
 	}
 }
 
@@ -714,6 +751,7 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 	struct header hdr;
 	struct nrf_rpc_cmd_ctx *cmd_ctx = NULL;
 	const struct nrf_rpc_group *group = NULL;
+	enum nrf_rpc_runtime_state local_state = nrf_rpc_record_processing_start();
 
 	err = header_decode(packet, len, &hdr);
 	if (err < 0) {
@@ -721,14 +759,7 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 		goto cleanup_and_exit;
 	}
 
-	if (is_stopped &&
-	    (hdr.type == NRF_RPC_PACKET_TYPE_CMD ||
-	     hdr.type == NRF_RPC_PACKET_TYPE_EVT ||
-	     hdr.type == NRF_RPC_PACKET_TYPE_ACK ||
-	     hdr.type == NRF_RPC_PACKET_TYPE_RSP)) {
-		// drop only selected types of packets
-		// do not drop INITs and ERRORS
-
+	if (!packet_type_accepted(local_state, hdr.type)) {
 		NRF_RPC_WRN("Dropping the packet.");
 		goto cleanup_and_exit;
 	}
@@ -815,6 +846,8 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 						      NRF_RPC_OS_WAIT_FOREVER);
 			}
 		}
+
+		nrf_rpc_record_processing_end();
 		return;
 
 	case NRF_RPC_PACKET_TYPE_EVT:
@@ -830,6 +863,7 @@ static void receive_handler(const struct nrf_rpc_tr *transport, const uint8_t *p
 					      NRF_RPC_OS_WAIT_FOREVER);
 		}
 
+		nrf_rpc_record_processing_end();
 		return;
 
 	case NRF_RPC_PACKET_TYPE_ACK:
@@ -871,6 +905,11 @@ cleanup_and_exit:
 		nrf_rpc_os_thread_pool_send((const uint8_t *)&internal_task, sizeof(internal_task));
 		nrf_rpc_os_event_wait(&internal_task_consumed, NRF_RPC_OS_WAIT_FOREVER);
 	}
+
+	/* Released only once the task is consumed, so the count never drops to zero before
+	 * execute_packet() takes over.
+	 */
+	nrf_rpc_record_processing_end();
 }
 
 void nrf_rpc_decoding_done(const struct nrf_rpc_group *group, const uint8_t *packet)
@@ -887,6 +926,41 @@ void nrf_rpc_decoding_done(const struct nrf_rpc_group *group, const uint8_t *pac
 }
 
 /* ======================== Command sending ======================== */
+
+static void release_uncollected(struct nrf_rpc_cmd_ctx *cmd_ctx)
+{
+	struct header hdr;
+	const struct nrf_rpc_group *group;
+	const uint8_t *packet = cmd_ctx->recv_msg.data;
+	size_t len = cmd_ctx->recv_msg.len;
+
+	if (packet == NULL) {
+		return;
+	}
+
+	cmd_ctx->recv_msg.data = NULL;
+	cmd_ctx->recv_msg.len = 0;
+
+	/* The receive thread does not wait for decode_done after inline handling. */
+	if (packet == RESPONSE_HANDLED_PTR) {
+		return;
+	}
+
+	if (header_decode(packet, len, &hdr) < 0) {
+		NRF_RPC_ERR("Uncollected packet has an invalid header");
+		NRF_RPC_ASSERT(false);
+		return;
+	}
+
+	group = group_from_id(hdr.dst_group_id);
+	if (group == NULL) {
+		NRF_RPC_ERR("Uncollected packet has an unknown group");
+		NRF_RPC_ASSERT(false);
+		return;
+	}
+
+	nrf_rpc_decoding_done(group, &packet[NRF_RPC_HEADER_SIZE]);
+}
 
 /** Wait for response after sending a command.
  *
@@ -910,11 +984,19 @@ static int wait_for_response(const struct nrf_rpc_group *group, struct nrf_rpc_c
 	NRF_RPC_DBG("Waiting for a response");
 
 	do {
+
+		nrf_rpc_record_processing_end();
 		nrf_rpc_os_msg_get(&cmd_ctx->recv_msg, &cmd_ctx->mutex, &packet, &len);
+		nrf_rpc_record_processing_start();
 
 		if (packet == NULL) {
+			release_uncollected(cmd_ctx);
 			return -NRF_ETIMEDOUT;
 		}
+
+		/* recv_msg.data == NULL means no message is waiting to be collected. */
+		cmd_ctx->recv_msg.data = NULL;
+		cmd_ctx->recv_msg.len = 0;
 
 		if (packet == RESPONSE_HANDLED_PTR) {
 			return 0;
@@ -974,14 +1056,15 @@ int nrf_rpc_cmd_common(const struct nrf_rpc_group *group, uint32_t cmd,
 		handler_data = ptr2;
 	}
 
-	nrf_rpc_os_mutex_lock(&cleanup_mutex);
-	if (is_stopped) {
+	bool cmd_running = (nrf_rpc_record_processing_start() == NRF_RPC_STATE_RUNNING);
+
+	if (!cmd_running) {
+		/* send() is skipped, so free allocated tx buffer explicitly. */
+		nrf_rpc_free_tx_buf(group, packet);
 		err = -NRF_EPERM;
-		nrf_rpc_os_mutex_unlock(&cleanup_mutex);
 	} else {
 
 		cmd_ctx = cmd_ctx_reserve();
-		nrf_rpc_os_mutex_unlock(&cleanup_mutex); /* release the mutex as the context specific one has been acquired */
 
 		hdr.dst = cmd_ctx->remote_id;
 		hdr.src = cmd_ctx->id;
@@ -1022,6 +1105,7 @@ int nrf_rpc_cmd_common(const struct nrf_rpc_group *group, uint32_t cmd,
 		cmd_ctx_release(cmd_ctx);
 	}
 
+	nrf_rpc_record_processing_end();
 	return err;
 }
 
@@ -1059,10 +1143,19 @@ int nrf_rpc_evt(const struct nrf_rpc_group *group, uint8_t evt, uint8_t *packet,
 	hdr.dst_group_id = group->data->dst_group_id;
 	header_encode(full_packet, &hdr);
 
+	if (nrf_rpc_record_processing_start() != NRF_RPC_STATE_RUNNING) {
+		nrf_rpc_record_processing_end();
+		/* send() is skipped, so free allocated tx buffer explicitly. */
+		nrf_rpc_free_tx_buf(group, packet);
+		return -NRF_EPERM;
+	}
+
 	NRF_RPC_DBG("Sending event 0x%02X from group 0x%02X", evt,
 		    group->data->src_group_id);
 
 	err = send(group, full_packet, len + NRF_RPC_HEADER_SIZE);
+
+	nrf_rpc_record_processing_end();
 
 	return err;
 }
@@ -1140,7 +1233,9 @@ int nrf_rpc_setup(nrf_rpc_err_handler_t err_handler, nrf_rpc_group_bound_handler
 		return 0;
 	}
 
-	nrf_rpc_os_mutex_init(&cleanup_mutex);
+	nrf_rpc_os_mutex_init(&rpc_state_mutex);
+	nrf_rpc_os_event_init(&processing_complete_event);
+	nrf_rpc_os_event_set(&processing_complete_event); /* initially set to 1 to avoid waiting for the event in nrf_rpc_stop */
 
 	global_err_handler = err_handler;
 	global_bound_handler = bound_handler;
@@ -1213,8 +1308,16 @@ int nrf_rpc_setup(nrf_rpc_err_handler_t err_handler, nrf_rpc_group_bound_handler
 int nrf_rpc_bind(void)
 {
 	int err;
+	bool binding_mode = false;
 	void *iter;
 	const struct nrf_rpc_group *group;
+
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	if (rpc_runtime_state == NRF_RPC_STATE_STOPPED) {
+		rpc_runtime_state = NRF_RPC_STATE_BINDING;
+		binding_mode = true;
+	}
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
 
 	for (NRF_RPC_AUTO_ARR_FOR(iter, group, &nrf_rpc_groups_array, const struct nrf_rpc_group)) {
 		const struct nrf_rpc_tr *transport = group->transport;
@@ -1252,6 +1355,14 @@ int nrf_rpc_bind(void)
 		}
 	}
 
+	if (binding_mode && err != 0) {
+		nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+		if (rpc_runtime_state == NRF_RPC_STATE_BINDING) {
+			rpc_runtime_state = NRF_RPC_STATE_STOPPED;
+		}
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+	}
+
 	return err;
 }
 
@@ -1285,7 +1396,7 @@ int nrf_rpc_init(nrf_rpc_err_handler_t err_handler)
 
 void nrf_rpc_register_cleanup_handler(struct nrf_rpc_cleanup_handler *handler)
 {
-	nrf_rpc_os_mutex_lock(&cleanup_mutex);
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
 
 	struct nrf_rpc_cleanup_handler *current;
 
@@ -1301,30 +1412,122 @@ void nrf_rpc_register_cleanup_handler(struct nrf_rpc_cleanup_handler *handler)
 		cleanup_handlers = handler;
 	}
 
-	nrf_rpc_os_mutex_unlock(&cleanup_mutex);
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
 }
 
-void nrf_rpc_stop(bool cleanup)
+static enum nrf_rpc_runtime_state nrf_rpc_record_processing_start(void)
 {
-	nrf_rpc_os_mutex_lock(&cleanup_mutex);
+	enum nrf_rpc_runtime_state state;
 
-	is_stopped = true;
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	assert(processing_in_progress_count < UINT8_MAX);
+
+	nrf_rpc_os_event_wait(&processing_complete_event,
+			      NRF_RPC_OS_NO_WAIT); /* take if available */
+
+	processing_in_progress_count++;
+	state = rpc_runtime_state; /* snapshot under the same lock as the count increment */
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+
+	return state;
+}
+
+static void nrf_rpc_record_processing_end(void)
+{
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	assert(processing_in_progress_count > 0);
+
+	processing_in_progress_count--;
+	if (processing_in_progress_count == 0) {
+		nrf_rpc_os_event_set(&processing_complete_event);
+	}
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+}
+
+static bool nrf_rpc_request_completion(void)
+{
+	bool request_done;
+
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	request_done = (rpc_runtime_state == NRF_RPC_STATE_RUNNING ||
+			rpc_runtime_state == NRF_RPC_STATE_BINDING);
+	if (request_done) {
+		rpc_runtime_state = NRF_RPC_STATE_STOPPING;
+	}
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+
+	return request_done;
+}
+
+static void nrf_rpc_finalize_stop(bool cleanup)
+{
+	struct nrf_rpc_cleanup_handler *current;
+
 	abort_all_ops();
-	if (cleanup) {
-		struct nrf_rpc_cleanup_handler *current;
-		for (current = cleanup_handlers; current != NULL; current = current->next) {
-			if (current->handler != NULL) {
-				current->handler(current->context);
-			}
-		}
+
+	if (!cleanup) {
+		return;
 	}
 
-	nrf_rpc_os_mutex_unlock(&cleanup_mutex);
+	/* Prepend-only list of caller-owned nodes, so walking it unlocked is safe. The lock
+	 * cannot be held across the handlers - nrf_rpc_cbkproxy_in_set() registers while
+	 * holding the same mutex nrf_rpc_cbproxy_clear() takes, which would invert the order.
+	 */
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+	current = cleanup_handlers;
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+
+	for (; current != NULL; current = current->next) {
+		if (current->handler != NULL) {
+			current->handler(current->context);
+		}
+	}
 }
 
-void nrf_rpc_resume(void)
+int nrf_rpc_stop(bool cleanup)
 {
-	is_stopped = false;
+	int err;
+	bool requested = nrf_rpc_request_completion();
+	if (requested) {
+		err = nrf_rpc_os_event_wait(&processing_complete_event, CONFIG_NRF_RPC_STOP_WAIT_TIME);
+		if (err) {
+			assert(err != -NRF_ETIMEDOUT);
+			nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+			rpc_runtime_state = NRF_RPC_STATE_RUNNING;
+			nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+			return err;
+		}
+		nrf_rpc_finalize_stop(cleanup);
+		nrf_rpc_os_mutex_lock(&rpc_state_mutex);
+		rpc_runtime_state = NRF_RPC_STATE_STOPPED;
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+		return 0;
+	}
+
+	return -NRF_EALREADY;
+}
+
+int nrf_rpc_resume(void)
+{
+	nrf_rpc_os_mutex_lock(&rpc_state_mutex); /* just in case, for future use */
+
+	if (rpc_runtime_state == NRF_RPC_STATE_STOPPING) {
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+		return -NRF_EINPROGRESS;
+	}
+
+	if (rpc_runtime_state == NRF_RPC_STATE_RUNNING) {
+		nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+		return -NRF_EALREADY;
+	}
+
+	rpc_runtime_state = NRF_RPC_STATE_RUNNING;
+	if (processing_in_progress_count == 0) { /* restore event if was claimed by nrf_rpc_stop */
+		nrf_rpc_os_event_set(&processing_complete_event);
+	}
+	nrf_rpc_os_mutex_unlock(&rpc_state_mutex);
+
+	return 0;
 }
 
 int nrf_rpc_cmd(const struct nrf_rpc_group *group, uint8_t cmd, uint8_t *packet,


### PR DESCRIPTION
A solution was implemented, to complete all the handlers first, prevent registering handlers when disabled, avoid enabling during disabling, etc.