### PR TITLE
nrf_802154: Fix incorrect RSSI conversion for antenna diversity

### DIFF
--- a/nrf_802154/driver/src/nrf_802154_core.c
+++ b/nrf_802154/driver/src/nrf_802154_core.c
@@ -3425,18 +3425,9 @@ int8_t nrf_802154_sl_ant_div_rssi_measure_get(void)
 
     if (nrf_802154_trx_rssi_measure_is_started())
     {
-        while (!nrf_802154_trx_rssi_sample_is_available())
-        {
-            /* Intentionally empty: This function is called from a critical section.
-             * WFE would not be waken up by a RADIO event.
-             */
-        }
+        rssi_measurement_wait();
 
-        uint8_t rssi_sample = nrf_802154_trx_rssi_last_sample_get();
-
-        rssi_sample = nrf_802154_rssi_sample_corrected_get(rssi_sample);
-
-        result = -((int8_t)rssi_sample);
+        result = rssi_last_measurement_get();
     }
 
     return result;

--- a/nrf_802154/driver/src/nrf_802154_trx.h
+++ b/nrf_802154/driver/src/nrf_802154_trx.h
@@ -267,7 +267,9 @@ bool nrf_802154_trx_rssi_sample_is_available(void);
 
 /**@brief Returns last measured RSSI sample.
  *
- * @return RSSI sample. Returned value must be scaled using API provided by nrf_802154_rssi.h.
+ * @note The returned value is signed, and should be cast to int8_t.
+ *
+ * @return RSSI sample with temperature and gain correction.
  */
 uint8_t nrf_802154_trx_rssi_last_sample_get(void);
 


### PR DESCRIPTION
The nrf_802154_trx_rssi_last_sample_get function was changed to perform RSSI sample corrections internally, but the antenna diversity RSSI callout was not updated. This caused the function to report an incorrect (and negated) RSSI value, which resulted in the antenna diversity algorithm consistently selecting the worse antenna.